### PR TITLE
Fix: Rename security check job to 'Security Scanning (Ruff & Safety)'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         run: pre-commit run --all-files
 
   security-scan:
-    name: Security Scanning (Bandit & Safety)
+    name: Security Scanning (Ruff & Safety)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
Completes the proper fix for CI job naming after PR #6.

## Changes
- Rename CI workflow job from 'Security Scanning (Bandit & Safety)' to 'Security Scanning (Ruff & Safety)'
- Job name now accurately reflects that it uses Ruff for security scanning (not Bandit)

## Context
PR #6 migrated from Bandit to Ruff for Python 3.14 compatibility. To unblock that PR merge, we temporarily kept the old job name to satisfy branch protection rules. Now that branch protection has been updated to accept the new name, we can properly rename the job.

## Steps Taken
1. ✅ Updated GitHub branch protection rules (via API) to accept 'Security Scanning (Ruff & Safety)'
2. ✅ Renamed CI workflow job to match (this PR)

## Related
- PR #6 (Python 3.14 compatibility - Bandit to Ruff migration)
- Removes technical debt introduced as temporary workaround

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>