### PR TITLE
fix: Update config path in property tests for src/ layout

### DIFF
--- a/tests/property/test_config_validation_properties.py
+++ b/tests/property/test_config_validation_properties.py
@@ -463,7 +463,7 @@ def test_config_loader_converts_money_to_decimal():
 
     Test verifies that loaded config values are Decimal, not float.
     """
-    loader = ConfigLoader(Path(__file__).parent.parent.parent / "config")
+    loader = ConfigLoader(Path(__file__).parent.parent.parent / "src/precog/config")
 
     # Load trading config
     trading_config = loader.load("trading")
@@ -504,7 +504,7 @@ def test_trading_config_has_required_fields():
     - execution.default_order_type
     - market_filters.min_volume_contracts
     """
-    loader = ConfigLoader(Path(__file__).parent.parent.parent / "config")
+    loader = ConfigLoader(Path(__file__).parent.parent.parent / "src/precog/config")
     trading_config = loader.load("trading")
 
     # Required top-level sections


### PR DESCRIPTION
## Summary

Fix hardcoded config path references in test_config_validation_properties.py after src/ layout migration (PR #22).

## Problem

After merging PR #22 (src/ layout migration), 2 property tests were failing because they used hardcoded paths to the old `config/` directory instead of the new `src/precog/config/` location.

## Solution

- Updated 2 ConfigLoader instantiations in test_config_validation_properties.py
- Changed `Path(__file__).parent.parent.parent / "config"` → `Path(__file__).parent.parent.parent / "src/precog/config"`

## Impact

- ✅ All 348 tests now passing (was 346/348)
- ✅ Coverage maintained at 85.48%
- ✅ No functional changes to source code

## Test Results

```
348 passed, 9 skipped in 87.48s
Coverage: 85.48%
```

## Related

- Fixes issue discovered post-merge of PR #22
- DEF-P1-010 (src/ layout migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)