### PR TITLE
bugfix: Fix test_initialization.py imports for src/ layout

### DIFF
--- a/tests/database/test_initialization.py
+++ b/tests/database/test_initialization.py
@@ -23,7 +23,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from database.initialization import (
+
+from precog.database.initialization import (
     apply_migrations,
     apply_schema,
     get_database_url,
@@ -165,7 +166,7 @@ class TestValidateSchemaFile:
 class TestApplySchema:
     """Tests for apply_schema() function."""
 
-    @patch("database.initialization.subprocess.run")
+    @patch("precog.database.initialization.subprocess.run")
     def test_apply_schema_success(self, mock_run: MagicMock, temp_schema_file: str) -> None:
         """Test successful schema application.
 
@@ -183,7 +184,7 @@ class TestApplySchema:
         assert error == ""
         mock_run.assert_called_once()
 
-    @patch("database.initialization.subprocess.run")
+    @patch("precog.database.initialization.subprocess.run")
     def test_apply_schema_already_exists_is_ok(
         self, mock_run: MagicMock, temp_schema_file: str
     ) -> None:
@@ -202,7 +203,7 @@ class TestApplySchema:
         assert success is True  # Should succeed despite error
         assert error == ""
 
-    @patch("database.initialization.subprocess.run")
+    @patch("precog.database.initialization.subprocess.run")
     def test_apply_schema_fails_on_other_errors(
         self, mock_run: MagicMock, temp_schema_file: str
     ) -> None:
@@ -261,7 +262,7 @@ class TestApplySchema:
         assert success is False
         assert "not found" in error
 
-    @patch("database.initialization.subprocess.run")
+    @patch("precog.database.initialization.subprocess.run")
     def test_apply_schema_psql_not_installed(
         self, mock_run: MagicMock, temp_schema_file: str
     ) -> None:
@@ -278,7 +279,7 @@ class TestApplySchema:
         assert success is False
         assert "psql command not found" in error
 
-    @patch("database.initialization.subprocess.run")
+    @patch("precog.database.initialization.subprocess.run")
     def test_apply_schema_timeout(self, mock_run: MagicMock, temp_schema_file: str) -> None:
         """Test schema application fails on timeout.
 
@@ -304,7 +305,7 @@ class TestApplySchema:
 class TestApplyMigrations:
     """Tests for apply_migrations() function."""
 
-    @patch("database.initialization.subprocess.run")
+    @patch("precog.database.initialization.subprocess.run")
     def test_apply_migrations_success(self, mock_run: MagicMock, temp_migration_dir: str) -> None:
         """Test successful migration application.
 
@@ -321,7 +322,7 @@ class TestApplyMigrations:
         assert failed == []
         assert mock_run.call_count == 3
 
-    @patch("database.initialization.subprocess.run")
+    @patch("precog.database.initialization.subprocess.run")
     def test_apply_migrations_partial_failure(
         self, mock_run: MagicMock, temp_migration_dir: str
     ) -> None:
@@ -384,7 +385,7 @@ class TestApplyMigrations:
         assert applied == 0
         assert failed == []
 
-    @patch("database.initialization.subprocess.run")
+    @patch("precog.database.initialization.subprocess.run")
     def test_apply_migrations_psql_timeout(
         self, mock_run: MagicMock, temp_migration_dir: str
     ) -> None:
@@ -418,13 +419,13 @@ class TestApplyMigrations:
 class TestValidateCriticalTables:
     """Tests for validate_critical_tables() function."""
 
-    @patch("database.connection.fetch_all")
+    @patch("precog.database.connection.fetch_all")
     def test_validate_critical_tables_all_exist(self, mock_fetch_all: MagicMock) -> None:
         """Test validation succeeds when all critical tables exist.
 
         Educational Note:
-            We mock fetch_all() at database.connection (where it's defined)
-            not database.initialization (where it's imported). This is because
+            We mock fetch_all() at precog.database.connection (where it's defined)
+            not precog.database.initialization (where it's imported). This is because
             the import happens inside the function, so we need to mock at the
             source location. Pattern 11 - mock at the right boundary.
         """
@@ -435,7 +436,7 @@ class TestValidateCriticalTables:
 
         assert missing == []
 
-    @patch("database.connection.fetch_all")
+    @patch("precog.database.connection.fetch_all")
     def test_validate_critical_tables_some_missing(self, mock_fetch_all: MagicMock) -> None:
         """Test validation reports missing tables correctly.
 
@@ -461,7 +462,7 @@ class TestValidateCriticalTables:
         assert "series" in missing
         assert "markets" in missing
 
-    @patch("database.connection.fetch_all")
+    @patch("precog.database.connection.fetch_all")
     def test_validate_critical_tables_custom_list(self, mock_fetch_all: MagicMock) -> None:
         """Test validation works with custom table list.
 
@@ -480,7 +481,7 @@ class TestValidateCriticalTables:
         assert missing == ["orders"]
         assert mock_fetch_all.call_count == 2
 
-    @patch("database.connection.fetch_all")
+    @patch("precog.database.connection.fetch_all")
     def test_validate_critical_tables_empty_result(self, mock_fetch_all: MagicMock) -> None:
         """Test validation handles empty database response.
 


### PR DESCRIPTION
## Summary
Critical bugfix: Update test_initialization.py imports to use correct module paths after src/ layout migration (PR #22).

## The Problem
- test_initialization.py still used old import style: `from database.initialization import ...`
- This caused `ModuleNotFoundError` preventing the entire test suite from running
- 25 tests were not discovered, leading to misleading coverage reports

## The Fix
- Updated imports to: `from precog.database.initialization import ...`
- Updated all @patch decorators to use `precog.database.initialization` and `precog.database.connection`
- Fixed import sorting per Ruff linter

## Impact

**Before (Broken)**:
```
ERROR collecting tests/database/test_initialization.py
ModuleNotFoundError: No module named 'database'
```
- Full test suite couldn't run (fails at collection)
- crud_operations.py coverage showed misleading 75.21%

**After (Fixed)**:
```
25 tests discoverable in test_initialization.py
- 16 tests passing ✅
- 9 tests failing (due to security validation logic, separate issue)
```
- Full test suite runs: **381 passing, 10 failed, 9 skipped**
- crud_operations.py coverage correct: **97.86%** (vs misleading 75.21%)
- Overall coverage: **93.02%** (EXCEEDS 80% target)

## Testing

**All tests now run**:
```bash
python -m pytest tests/ -v --cov=src/precog --cov-report=term
============ 10 failed, 381 passed, 9 skipped in 89.34s =============
TOTAL                                          826     45    206     19  93.02%
```

**test_initialization.py specifically**:
```bash
python -m pytest tests/database/test_initialization.py -v
============ 16 passed, 9 failed in 2.45s =============
```

**Pre-push validation**: ✅ All checks passed

## Related Issues

- Fixes: Missing test coverage from PR #22 (src/ layout migration)
- Resolves: Misleading coverage reports blocking DEF-P1 tasks
- Enables: Accurate coverage tracking for Phase 1.5

## Files Changed

**tests/database/test_initialization.py**:
- Updated main import: `database.initialization` → `precog.database.initialization`
- Updated 8 @patch decorators for subprocess.run mocks
- Updated 4 @patch decorators for fetch_all mocks
- Fixed import sorting (os, subprocess, pathlib, unittest.mock, pytest, precog imports)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>