### PR TITLE
fix: Resolve code quality issues in validation scripts from PR #96

### DIFF
--- a/scripts/validate_docs.py
+++ b/scripts/validate_docs.py
@@ -1036,7 +1036,6 @@ def validate_config_synchronization() -> ValidationResult:
 
                     # Validation already done in Check #9 (YAML syntax + Decimal safety)
                     # This check focuses on cross-layer consistency
-                    pass
 
         layers_checked += 1
 

--- a/scripts/validate_phase_completion.py
+++ b/scripts/validate_phase_completion.py
@@ -33,6 +33,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any, cast
 
 try:
     import yaml
@@ -64,7 +65,7 @@ def load_phase_deliverables(phase: str) -> dict:
         with open(validation_config_path, encoding="utf-8") as f:
             config = yaml.safe_load(f)
             phase_deliverables = config.get("phase_deliverables", {})
-            return phase_deliverables.get(phase, {})
+            return cast("dict[Any, Any]", phase_deliverables.get(phase, {}))
     except Exception:
         return {}
 

--- a/scripts/validate_phase_start.py
+++ b/scripts/validate_phase_start.py
@@ -36,6 +36,7 @@ Example usage:
 import re
 import sys
 from pathlib import Path
+from typing import Any, cast
 
 try:
     import yaml
@@ -67,7 +68,7 @@ def load_phase_deliverables(phase: str) -> dict:
         with open(validation_config_path, encoding="utf-8") as f:
             config = yaml.safe_load(f)
             phase_deliverables = config.get("phase_deliverables", {})
-            return phase_deliverables.get(phase, {})
+            return cast("dict[Any, Any]", phase_deliverables.get(phase, {}))
     except Exception:
         return {}
 
@@ -168,15 +169,13 @@ def check_phase_dependencies(phase: str, verbose: bool = False) -> tuple[bool, l
         # For Phase 1.5, check Phase 1
         # For Phase 2, check Phase 1 and 1.5
 
-        if phase_num >= 2:
-            # Check Phase 1 complete
-            if not re.search(r"Phase\s+1[^.0-9].*?✅", content, re.IGNORECASE):
-                violations.append("Phase 1 not complete (required for Phase >= 2)")
+        # Check Phase 1 complete (required for Phase >= 2)
+        if phase_num >= 2 and not re.search(r"Phase\s+1[^.0-9].*?✅", content, re.IGNORECASE):
+            violations.append("Phase 1 not complete (required for Phase >= 2)")
 
-        if phase_num >= 1.5:
-            # Check Phase 1 partial/complete
-            if not re.search(r"Phase\s+1[^.]", content):
-                violations.append("Phase 1 not found in DEVELOPMENT_PHASES")
+        # Check Phase 1 partial/complete (required for Phase >= 1.5)
+        if phase_num >= 1.5 and not re.search(r"Phase\s+1[^.]", content):
+            violations.append("Phase 1 not found in DEVELOPMENT_PHASES")
 
     except Exception as e:
         violations.append(f"Error reading DEVELOPMENT_PHASES: {e}")

--- a/scripts/validate_property_tests.py
+++ b/scripts/validate_property_tests.py
@@ -34,6 +34,7 @@ Example usage:
 import re
 import sys
 from pathlib import Path
+from typing import Any, cast
 
 try:
     import yaml
@@ -95,7 +96,9 @@ def load_property_test_requirements() -> dict:
     try:
         with open(validation_config_path, encoding="utf-8") as f:
             config = yaml.safe_load(f)
-            return config.get("property_test_requirements", default_requirements)
+            return cast(
+                "dict[Any, Any]", config.get("property_test_requirements", default_requirements)
+            )
     except Exception:
         return default_requirements
 

--- a/scripts/validate_test_fixtures.py
+++ b/scripts/validate_test_fixtures.py
@@ -33,6 +33,7 @@ Example usage:
 import re
 import sys
 from pathlib import Path
+from typing import Any, cast
 
 try:
     import yaml
@@ -84,7 +85,9 @@ def load_test_fixture_requirements() -> dict:
     try:
         with open(validation_config_path, encoding="utf-8") as f:
             config = yaml.safe_load(f)
-            return config.get("test_fixture_requirements", default_requirements)
+            return cast(
+                "dict[Any, Any]", config.get("test_fixture_requirements", default_requirements)
+            )
     except Exception:
         return default_requirements
 


### PR DESCRIPTION
## Summary

Fixes Ruff lint and Mypy type errors in validation scripts introduced in PR #96.

**Ruff fixes (3 errors):**
- PIE790: Remove unnecessary `pass` statement in validate_docs.py:1039
- SIM102: Combine nested `if` statements in validate_phase_start.py:171,176

**Mypy fixes (4 errors):**
- Add explicit type casts for `yaml.safe_load()` return values
- Affected files:
  - validate_phase_start.py:71
  - validate_phase_completion.py:68
  - validate_test_fixtures.py:89
  - validate_property_tests.py:100

## Why These Changes

PR #96 added workflow enforcement infrastructure but introduced code quality issues that block CI for other PRs (specifically PR #97).

## Testing

✅ `python -m ruff check scripts/` - All checks passed
✅ `python -m mypy scripts/` - Success (64 files)
✅ Pre-commit hooks - All 19 checks passed

## Blockers Resolved

- Unblocks PR #97 (trailing stop test coverage)
- Enables clean CI runs for future PRs

## Related

- Closes #N/A (code quality fix, no issue)
- Follows up: PR #96 (Workflow Enforcement Infrastructure)
- Unblocks: PR #97 (Trailing Stop Test Coverage)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>