### PR TITLE
fix: Update schema validation to V1.11 (Issue #36)

### DIFF
--- a/scripts/validate_schema_consistency.py
+++ b/scripts/validate_schema_consistency.py
@@ -198,7 +198,7 @@ def validate_table_existence() -> tuple[bool, list[str]]:
 
     # Get documented tables
     schema_file = (
-        Path(__file__).parent.parent / "docs" / "database" / "DATABASE_SCHEMA_SUMMARY_V1.7.md"
+        Path(__file__).parent.parent / "docs" / "database" / "DATABASE_SCHEMA_SUMMARY_V1.11.md"
     )
     if not schema_file.exists():
         errors.append(f"Schema documentation not found: {schema_file}")


### PR DESCRIPTION
## Summary

Updates `scripts/validate_schema_consistency.py` to reference current schema version, automatically validating all analytics tables added in PR #17.

## Changes

**scripts/validate_schema_consistency.py:**
- Changed `DATABASE_SCHEMA_SUMMARY_V1.7.md` → `DATABASE_SCHEMA_SUMMARY_V1.11.md` (line 201)

## Why This Works

The `parse_documented_tables()` function automatically discovers tables from schema doc headers (`#### table_name`), so updating the schema version reference automatically validates all new analytics tables:

- **performance_metrics** (Phase 1.5-2) - Core performance tracking
- **evaluation_runs** (Phase 1.5-2) - Model validation tracking  
- **predictions** (Phase 1.5-2, Phase 4+) - Unified individual + ensemble predictions

No manual table list updates needed - all 8 validation levels automatically apply to discovered tables.

## Issue Context

Issue #36 mentioned non-existent tables:
- ❌ `portfolio_snapshots` - NOT in schema
- ❌ `ensemble_metrics` - NOT in schema (replaced by unified `predictions` table)

Actual analytics tables from PR #17 are correctly documented in V1.11 Section 8.

## Testing

- ✅ Pre-commit hooks passed (Ruff, Mypy, security scan, documentation validation)
- ✅ Validation script updated to current schema version
- ✅ All documented tables will be validated by existing validation logic

## References

- Closes #36
- DATABASE_SCHEMA_SUMMARY_V1.11.md lines 1502-1928 (Section 8: Performance Tracking & Analytics)
- PR #17: Phases 6-9 analytics infrastructure documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)