### PR TITLE
fix: Correct Kalshi client tests to use accurate dual-format API mock data

### DIFF
--- a/tests/fixtures/api_responses.py
+++ b/tests/fixtures/api_responses.py
@@ -98,14 +98,21 @@ KALSHI_SINGLE_MARKET_RESPONSE = {
         "status": "open",
         "can_close_early": False,
         "result": None,
-        "yes_bid": "0.6200",
-        "yes_ask": "0.6250",
-        "no_bid": "0.3750",
-        "no_ask": "0.3800",
-        "last_price": "0.6225",
+        # Kalshi dual format: legacy integer cents + sub-penny string dollars
+        "yes_bid": 62,  # Legacy: integer cents
+        "yes_bid_dollars": "0.6200",  # Sub-penny: string dollars
+        "yes_ask": 63,
+        "yes_ask_dollars": "0.6250",
+        "no_bid": 37,
+        "no_bid_dollars": "0.3750",
+        "no_ask": 38,
+        "no_ask_dollars": "0.3800",
+        "last_price": 62,
+        "last_price_dollars": "0.6225",
         "volume": 15420,
         "open_interest": 8750,
         "liquidity": 125000,
+        "liquidity_dollars": "1250.0000",
     }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes failing Kalshi client decimal tests by correcting the test fixtures to accurately reflect the real Kalshi API response format.

**Root Cause Analysis:**
- The test fixture `KALSHI_SINGLE_MARKET_RESPONSE` was inaccurate - it used simple string format (`"yes_bid": "0.6200"`) instead of Kalshi's actual dual format
- The Kalshi API returns BOTH:
  - Legacy integer cent fields (`yes_bid: 62`)
  - Sub-penny string dollar fields (`yes_bid_dollars: "0.6200"`)
- The client's `_convert_prices_to_decimal()` method correctly converts only `*_dollars` and `*_fixed` fields to Decimal
- Tests were asserting on the wrong fields (expecting Decimal on legacy integer fields)

**Changes:**
1. **tests/fixtures/api_responses.py**: Updated `KALSHI_SINGLE_MARKET_RESPONSE` to use accurate dual format matching real Kalshi API and existing `KALSHI_MARKET_RESPONSE` fixture
2. **tests/unit/api_connectors/test_kalshi_client.py**: Fixed `test_get_single_market_decimal_prices` to assert on correct fields (`*_dollars` fields) and verify Decimal conversion

**Test Results:**
- All 45 Kalshi client tests passing
- 8 pre-existing test failures unrelated to this change (DB connection tests, CLI error handling)

## Test plan

- [x] Run Kalshi client unit tests: `pytest tests/unit/api_connectors/test_kalshi_client.py -v`
- [x] Verify all 45 tests pass
- [x] Verify no regressions in other tests

## Related

- Addresses test failures discovered in Kalshi client decimal handling
- Follows Pattern 1 (Decimal Precision) and Pattern 13 (Real Fixtures, Not Mocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)