### PR TITLE
feat: Phase 2B Database Migrations - venues, team_rankings, teams, game_states

### DIFF
--- a/docs/utility/ESPN_DATA_MODEL_IMPLEMENTATION_PLAN_V1.0.md
+++ b/docs/utility/ESPN_DATA_MODEL_IMPLEMENTATION_PLAN_V1.0.md
@@ -53,13 +53,13 @@ This document captures the implementation plan for Phase 2 ESPN data model enhan
 - [x] Added generic `get_scoreboard(league)` method for sport-agnostic pipelines
 - [x] All 44 tests passing
 
-### Phase B: Database Migrations (PENDING)
-**Status:** Pending
-**Duration:** 1-2 days
+### Phase B: Database Migrations (COMPLETE)
+**Status:** ✅ Complete (2025-11-29)
+**Duration:** 1 day
 **Dependencies:** Phase A complete
 
 **Deliverables:**
-- [ ] Migration 026: Create `venues` table
+- [x] Migration 026: Create `venues` table
   ```sql
   CREATE TABLE venues (
       venue_id SERIAL PRIMARY KEY,
@@ -74,7 +74,7 @@ This document captures the implementation plan for Phase 2 ESPN data model enhan
   );
   ```
 
-- [ ] Migration 027: Create `team_rankings` table
+- [x] Migration 027: Create `team_rankings` table
   ```sql
   CREATE TABLE team_rankings (
       ranking_id SERIAL PRIMARY KEY,
@@ -91,7 +91,7 @@ This document captures the implementation plan for Phase 2 ESPN data model enhan
   );
   ```
 
-- [ ] Migration 028: Enhance `teams` table
+- [x] Migration 028: Enhance `teams` table
   ```sql
   ALTER TABLE teams ADD COLUMN IF NOT EXISTS espn_team_id VARCHAR(50);
   ALTER TABLE teams ADD COLUMN IF NOT EXISTS display_name VARCHAR(100);
@@ -102,7 +102,7 @@ This document captures the implementation plan for Phase 2 ESPN data model enhan
   CREATE UNIQUE INDEX IF NOT EXISTS idx_teams_espn_id ON teams(espn_team_id);
   ```
 
-- [ ] Migration 029: Create `game_states` table (SCD Type 2)
+- [x] Migration 029: Create `game_states` table (SCD Type 2)
   ```sql
   CREATE TABLE game_states (
       game_state_id SERIAL PRIMARY KEY,

--- a/scripts/audit_test_type_coverage.py
+++ b/scripts/audit_test_type_coverage.py
@@ -200,8 +200,9 @@ def check_test_file_for_types(test_file: Path) -> list[str]:
                 if f"@pytest.mark.{marker}" in content or f"pytest.mark.{marker}" in content:
                     types_found.append(test_type)
                     break
-    except Exception:
-        pass
+    except (OSError, UnicodeDecodeError):
+        # Skip files that can't be read - return empty list
+        return []
     return types_found
 
 

--- a/src/precog/database/migrations/migration_026_create_venues_table.py
+++ b/src/precog/database/migrations/migration_026_create_venues_table.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""
+Migration 026: Create Venues Table
+
+**Purpose:**
+Create normalized venues table for ESPN venue/stadium data. Prevents data
+duplication across ~9,500 games/year that reference only ~150 unique venues.
+
+**Schema:**
+- venue_id: SERIAL PRIMARY KEY (surrogate key)
+- espn_venue_id: VARCHAR(50) UNIQUE NOT NULL (ESPN's stable external ID)
+- venue_name: VARCHAR(255) NOT NULL (e.g., "GEHA Field at Arrowhead Stadium")
+- city: VARCHAR(100) (nullable - some venues may not have city data)
+- state: VARCHAR(50) (nullable - international venues)
+- capacity: INTEGER (nullable - capacity data not always available)
+- indoor: BOOLEAN DEFAULT FALSE (important for weather-dependent analysis)
+- created_at: TIMESTAMP WITH TIME ZONE (audit trail)
+- updated_at: TIMESTAMP WITH TIME ZONE (tracks naming rights changes)
+
+**Indexes:**
+- idx_venues_espn_id: Fast ESPN ID lookups during data ingestion
+- idx_venues_name: Text search on venue names
+- idx_venues_state: Partial index for state-based queries
+- idx_venues_indoor: Boolean index for weather analysis
+
+**Constraints:**
+- venues_capacity_check: capacity must be positive or NULL
+- venues_espn_id_format_check: ESPN ID must be alphanumeric with dashes/underscores
+
+**Design Decision (No SCD Type 2):**
+Venues are mutable entities - when naming rights change (e.g., "Arrowhead Stadium"
+-> "GEHA Field at Arrowhead Stadium"), we UPDATE in place. No historical versioning
+needed because venue history doesn't affect trading decisions.
+
+**References:**
+- REQ-DATA-002: Venue Data Management
+- ADR-029: ESPN Data Model with Normalized Schema
+- docs/database/DATABASE_SCHEMA_SUMMARY_V1.13.md (planned)
+
+**Migration Safe:** YES
+- New table creation, no existing data affected
+- Rollback script included
+
+**Estimated Time:** <1 second
+
+Created: 2025-11-29
+Phase: 2 (Live Data Integration)
+"""
+
+import os
+
+import psycopg2
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+
+def apply_migration(connection_string: str | None = None) -> None:
+    """
+    Apply migration: Create venues table.
+
+    Args:
+        connection_string: PostgreSQL connection string (defaults to env vars)
+    """
+    if connection_string:
+        conn = psycopg2.connect(connection_string)
+    else:
+        # Build connection from individual env vars
+        host = os.getenv("DB_HOST", "localhost")
+        port = os.getenv("DB_PORT", "5432")
+        database = os.getenv("DB_NAME", "precog_dev")
+        user = os.getenv("DB_USER", "postgres")
+        password = os.getenv("DB_PASSWORD")
+
+        if not password:
+            raise ValueError("DB_PASSWORD environment variable not set")
+
+        conn = psycopg2.connect(
+            host=host, port=port, database=database, user=user, password=password
+        )
+    conn.autocommit = False  # Use transaction
+
+    try:
+        with conn.cursor() as cur:
+            print("Starting Migration 026: Create Venues Table")
+            print("=" * 70)
+
+            # =================================================================
+            # Step 1: Create venues table
+            # =================================================================
+            print("[1/4] Creating venues table...")
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS venues (
+                    venue_id SERIAL PRIMARY KEY,
+                    espn_venue_id VARCHAR(50) UNIQUE NOT NULL,
+                    venue_name VARCHAR(255) NOT NULL,
+                    city VARCHAR(100),
+                    state VARCHAR(50),
+                    capacity INTEGER,
+                    indoor BOOLEAN DEFAULT FALSE NOT NULL,
+                    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+                    updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL
+                );
+            """)
+            print("    [OK] venues table created")
+
+            # =================================================================
+            # Step 2: Create indexes
+            # =================================================================
+            print("[2/4] Creating indexes...")
+
+            # ESPN ID lookup index
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_venues_espn_id
+                ON venues(espn_venue_id);
+            """)
+            print("    [OK] idx_venues_espn_id created")
+
+            # Venue name index for text search
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_venues_name
+                ON venues(venue_name);
+            """)
+            print("    [OK] idx_venues_name created")
+
+            # Partial index for state-based queries (exclude NULLs)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_venues_state
+                ON venues(state)
+                WHERE state IS NOT NULL;
+            """)
+            print("    [OK] idx_venues_state (partial) created")
+
+            # Indoor flag index for weather analysis
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_venues_indoor
+                ON venues(indoor);
+            """)
+            print("    [OK] idx_venues_indoor created")
+
+            # =================================================================
+            # Step 3: Add CHECK constraints
+            # =================================================================
+            print("[3/4] Adding CHECK constraints...")
+
+            # Capacity must be positive or NULL
+            cur.execute("""
+                ALTER TABLE venues
+                ADD CONSTRAINT venues_capacity_check
+                CHECK (capacity IS NULL OR capacity > 0);
+            """)
+            print("    [OK] venues_capacity_check constraint added")
+
+            # ESPN ID format validation (alphanumeric with dashes/underscores)
+            cur.execute("""
+                ALTER TABLE venues
+                ADD CONSTRAINT venues_espn_id_format_check
+                CHECK (espn_venue_id ~ '^[0-9A-Za-z_-]+$');
+            """)
+            print("    [OK] venues_espn_id_format_check constraint added")
+
+            # =================================================================
+            # Step 4: Add trigger for updated_at
+            # =================================================================
+            print("[4/4] Creating updated_at trigger...")
+
+            # Create trigger function if not exists
+            cur.execute("""
+                CREATE OR REPLACE FUNCTION update_venues_updated_at()
+                RETURNS TRIGGER AS $$
+                BEGIN
+                    NEW.updated_at = NOW();
+                    RETURN NEW;
+                END;
+                $$ LANGUAGE plpgsql;
+            """)
+
+            # Create trigger
+            cur.execute("""
+                DROP TRIGGER IF EXISTS trigger_venues_updated_at ON venues;
+                CREATE TRIGGER trigger_venues_updated_at
+                    BEFORE UPDATE ON venues
+                    FOR EACH ROW
+                    EXECUTE FUNCTION update_venues_updated_at();
+            """)
+            print("    [OK] updated_at trigger created")
+
+            # =================================================================
+            # Commit transaction
+            # =================================================================
+            conn.commit()
+            print("=" * 70)
+            print("[OK] Migration 026 completed successfully!")
+            print("    - Table: venues")
+            print("    - Indexes: 4 (espn_id, name, state, indoor)")
+            print("    - Constraints: 2 (capacity_check, espn_id_format)")
+            print("    - Trigger: updated_at auto-update")
+
+    except Exception as e:
+        conn.rollback()
+        print(f"[FAIL] Migration 026 failed: {e}")
+        raise
+
+    finally:
+        conn.close()
+
+
+def rollback_migration(connection_string: str | None = None) -> None:
+    """
+    Rollback migration: Drop venues table and related objects.
+
+    Args:
+        connection_string: PostgreSQL connection string (defaults to env vars)
+    """
+    if connection_string:
+        conn = psycopg2.connect(connection_string)
+    else:
+        host = os.getenv("DB_HOST", "localhost")
+        port = os.getenv("DB_PORT", "5432")
+        database = os.getenv("DB_NAME", "precog_dev")
+        user = os.getenv("DB_USER", "postgres")
+        password = os.getenv("DB_PASSWORD")
+
+        if not password:
+            raise ValueError("DB_PASSWORD environment variable not set")
+
+        conn = psycopg2.connect(
+            host=host, port=port, database=database, user=user, password=password
+        )
+    conn.autocommit = False
+
+    try:
+        with conn.cursor() as cur:
+            print("Rolling back Migration 026: Drop Venues Table")
+            print("=" * 70)
+
+            # Drop table (cascades to indexes, constraints, triggers)
+            cur.execute("DROP TABLE IF EXISTS venues CASCADE;")
+            print("    [OK] venues table dropped")
+
+            # Drop trigger function
+            cur.execute("DROP FUNCTION IF EXISTS update_venues_updated_at() CASCADE;")
+            print("    [OK] update_venues_updated_at function dropped")
+
+            conn.commit()
+            print("=" * 70)
+            print("[OK] Migration 026 rollback completed!")
+
+    except Exception as e:
+        conn.rollback()
+        print(f"[FAIL] Rollback failed: {e}")
+        raise
+
+    finally:
+        conn.close()
+
+
+def verify_migration(connection_string: str | None = None) -> bool:
+    """
+    Verify migration was applied correctly.
+
+    Returns:
+        True if verification passes, False otherwise
+    """
+    if connection_string:
+        conn = psycopg2.connect(connection_string)
+    else:
+        host = os.getenv("DB_HOST", "localhost")
+        port = os.getenv("DB_PORT", "5432")
+        database = os.getenv("DB_NAME", "precog_dev")
+        user = os.getenv("DB_USER", "postgres")
+        password = os.getenv("DB_PASSWORD")
+
+        if not password:
+            raise ValueError("DB_PASSWORD environment variable not set")
+
+        conn = psycopg2.connect(
+            host=host, port=port, database=database, user=user, password=password
+        )
+
+    try:
+        with conn.cursor() as cur:
+            print("Verifying Migration 026...")
+
+            # Check table exists
+            cur.execute("""
+                SELECT EXISTS (
+                    SELECT FROM information_schema.tables
+                    WHERE table_name = 'venues'
+                );
+            """)
+            table_exists = cur.fetchone()[0]
+
+            # Check columns
+            cur.execute("""
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_name = 'venues'
+                ORDER BY ordinal_position;
+            """)
+            columns = [row[0] for row in cur.fetchall()]
+            expected_columns = [
+                "venue_id",
+                "espn_venue_id",
+                "venue_name",
+                "city",
+                "state",
+                "capacity",
+                "indoor",
+                "created_at",
+                "updated_at",
+            ]
+
+            # Check indexes
+            cur.execute("""
+                SELECT indexname FROM pg_indexes
+                WHERE tablename = 'venues';
+            """)
+            indexes = [row[0] for row in cur.fetchall()]
+
+            # Results
+            print(f"    Table exists: {table_exists}")
+            print(f"    Columns: {columns}")
+            print(f"    Indexes: {indexes}")
+
+            success = (
+                table_exists
+                and all(col in columns for col in expected_columns)
+                and len(indexes) >= 4  # Primary key + 4 custom indexes
+            )
+
+            if success:
+                print("[OK] Migration 026 verification passed!")
+            else:
+                print("[FAIL] Migration 026 verification failed!")
+
+            return success
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--rollback":
+        rollback_migration()
+    elif len(sys.argv) > 1 and sys.argv[1] == "--verify":
+        verify_migration()
+    else:
+        apply_migration()

--- a/src/precog/database/migrations/migration_027_create_team_rankings_table.py
+++ b/src/precog/database/migrations/migration_027_create_team_rankings_table.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""
+Migration 027: Create Team Rankings Table
+
+**Purpose:**
+Create team_rankings table for AP Poll, CFP, Coaches Poll, ESPN Power Index,
+and ESPN FPI rankings. Tracks temporal validity (rankings change weekly).
+
+**Schema:**
+- ranking_id: SERIAL PRIMARY KEY (surrogate key)
+- team_id: INTEGER REFERENCES teams(team_id) (FK to teams table)
+- ranking_type: VARCHAR(50) NOT NULL (ap_poll, cfp, coaches_poll, espn_power, espn_fpi)
+- rank: INTEGER NOT NULL (1-25 for polls, 1-130+ for power rankings)
+- season: INTEGER NOT NULL (e.g., 2024)
+- week: INTEGER (NULL for preseason/final, 1-18 for in-season)
+- ranking_date: DATE NOT NULL (date ranking was published)
+- points: INTEGER (AP/Coaches poll voting points)
+- first_place_votes: INTEGER (number of #1 votes)
+- previous_rank: INTEGER (last week's rank, for trend analysis)
+- created_at: TIMESTAMP WITH TIME ZONE (audit trail)
+
+**Indexes:**
+- idx_rankings_type_season_week: Composite for "get week N rankings"
+- idx_rankings_team: Team-based queries
+- idx_rankings_date: Date-based queries
+- idx_rankings_rank: Rank-based queries (top 10, etc.)
+
+**Unique Constraint:**
+- team_rankings_unique: (team_id, ranking_type, season, week)
+  Ensures one ranking per team per type per week
+
+**Use Cases:**
+- College football rankings affect line movement
+- "Ranked vs. ranked" matchups have different market dynamics
+- CFP rankings directly impact bowl game markets
+- Trend analysis (rising/falling teams)
+
+**References:**
+- REQ-DATA-004: Team Rankings Data
+- ADR-029: ESPN Data Model with Normalized Schema
+
+**Migration Safe:** YES
+- New table creation, no existing data affected
+- Rollback script included
+
+**Estimated Time:** <1 second
+
+Created: 2025-11-29
+Phase: 2 (Live Data Integration)
+"""
+
+import os
+
+import psycopg2
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+
+def apply_migration(connection_string: str | None = None) -> None:
+    """
+    Apply migration: Create team_rankings table.
+
+    Args:
+        connection_string: PostgreSQL connection string (defaults to env vars)
+    """
+    if connection_string:
+        conn = psycopg2.connect(connection_string)
+    else:
+        # Build connection from individual env vars
+        host = os.getenv("DB_HOST", "localhost")
+        port = os.getenv("DB_PORT", "5432")
+        database = os.getenv("DB_NAME", "precog_dev")
+        user = os.getenv("DB_USER", "postgres")
+        password = os.getenv("DB_PASSWORD")
+
+        if not password:
+            raise ValueError("DB_PASSWORD environment variable not set")
+
+        conn = psycopg2.connect(
+            host=host, port=port, database=database, user=user, password=password
+        )
+    conn.autocommit = False  # Use transaction
+
+    try:
+        with conn.cursor() as cur:
+            print("Starting Migration 027: Create Team Rankings Table")
+            print("=" * 70)
+
+            # =================================================================
+            # Step 1: Create team_rankings table
+            # =================================================================
+            print("[1/3] Creating team_rankings table...")
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS team_rankings (
+                    ranking_id SERIAL PRIMARY KEY,
+                    team_id INTEGER NOT NULL REFERENCES teams(team_id),
+                    ranking_type VARCHAR(50) NOT NULL,
+                    rank INTEGER NOT NULL,
+                    season INTEGER NOT NULL,
+                    week INTEGER,
+                    ranking_date DATE NOT NULL,
+                    points INTEGER,
+                    first_place_votes INTEGER,
+                    previous_rank INTEGER,
+                    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+
+                    CONSTRAINT team_rankings_unique
+                        UNIQUE (team_id, ranking_type, season, week)
+                );
+            """)
+            print("    [OK] team_rankings table created")
+
+            # =================================================================
+            # Step 2: Create indexes
+            # =================================================================
+            print("[2/3] Creating indexes...")
+
+            # Composite index for week N rankings queries
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_rankings_type_season_week
+                ON team_rankings(ranking_type, season, week);
+            """)
+            print("    [OK] idx_rankings_type_season_week created")
+
+            # Team-based queries
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_rankings_team
+                ON team_rankings(team_id);
+            """)
+            print("    [OK] idx_rankings_team created")
+
+            # Date-based queries
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_rankings_date
+                ON team_rankings(ranking_date);
+            """)
+            print("    [OK] idx_rankings_date created")
+
+            # Rank-based queries (top 10, etc.)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_rankings_rank
+                ON team_rankings(rank)
+                WHERE rank <= 25;
+            """)
+            print("    [OK] idx_rankings_rank (partial) created")
+
+            # =================================================================
+            # Step 3: Add CHECK constraints
+            # =================================================================
+            print("[3/3] Adding CHECK constraints...")
+
+            # Valid ranking types
+            cur.execute("""
+                ALTER TABLE team_rankings
+                ADD CONSTRAINT team_rankings_type_check
+                CHECK (ranking_type IN (
+                    'ap_poll',
+                    'cfp',
+                    'coaches_poll',
+                    'espn_power',
+                    'espn_fpi',
+                    'committee'
+                ));
+            """)
+            print("    [OK] team_rankings_type_check constraint added")
+
+            # Rank must be positive
+            cur.execute("""
+                ALTER TABLE team_rankings
+                ADD CONSTRAINT team_rankings_rank_check
+                CHECK (rank >= 1);
+            """)
+            print("    [OK] team_rankings_rank_check constraint added")
+
+            # Season must be reasonable (1900-2100)
+            cur.execute("""
+                ALTER TABLE team_rankings
+                ADD CONSTRAINT team_rankings_season_check
+                CHECK (season >= 1900 AND season <= 2100);
+            """)
+            print("    [OK] team_rankings_season_check constraint added")
+
+            # Week must be NULL (preseason/final) or valid week number
+            cur.execute("""
+                ALTER TABLE team_rankings
+                ADD CONSTRAINT team_rankings_week_check
+                CHECK (week IS NULL OR (week >= 0 AND week <= 20));
+            """)
+            print("    [OK] team_rankings_week_check constraint added")
+
+            # Points must be non-negative if provided
+            cur.execute("""
+                ALTER TABLE team_rankings
+                ADD CONSTRAINT team_rankings_points_check
+                CHECK (points IS NULL OR points >= 0);
+            """)
+            print("    [OK] team_rankings_points_check constraint added")
+
+            # First place votes must be non-negative if provided
+            cur.execute("""
+                ALTER TABLE team_rankings
+                ADD CONSTRAINT team_rankings_fpv_check
+                CHECK (first_place_votes IS NULL OR first_place_votes >= 0);
+            """)
+            print("    [OK] team_rankings_fpv_check constraint added")
+
+            # =================================================================
+            # Commit transaction
+            # =================================================================
+            conn.commit()
+            print("=" * 70)
+            print("[OK] Migration 027 completed successfully!")
+            print("    - Table: team_rankings")
+            print("    - Indexes: 4 (type_season_week, team, date, rank)")
+            print("    - Constraints: 7 (unique, type, rank, season, week, points, fpv)")
+            print("    - FK: team_id -> teams(team_id)")
+
+    except Exception as e:
+        conn.rollback()
+        print(f"[FAIL] Migration 027 failed: {e}")
+        raise
+
+    finally:
+        conn.close()
+
+
+def rollback_migration(connection_string: str | None = None) -> None:
+    """
+    Rollback migration: Drop team_rankings table.
+
+    Args:
+        connection_string: PostgreSQL connection string (defaults to env vars)
+    """
+    if connection_string:
+        conn = psycopg2.connect(connection_string)
+    else:
+        host = os.getenv("DB_HOST", "localhost")
+        port = os.getenv("DB_PORT", "5432")
+        database = os.getenv("DB_NAME", "precog_dev")
+        user = os.getenv("DB_USER", "postgres")
+        password = os.getenv("DB_PASSWORD")
+
+        if not password:
+            raise ValueError("DB_PASSWORD environment variable not set")
+
+        conn = psycopg2.connect(
+            host=host, port=port, database=database, user=user, password=password
+        )
+    conn.autocommit = False
+
+    try:
+        with conn.cursor() as cur:
+            print("Rolling back Migration 027: Drop Team Rankings Table")
+            print("=" * 70)
+
+            # Drop table (cascades to indexes, constraints)
+            cur.execute("DROP TABLE IF EXISTS team_rankings CASCADE;")
+            print("    [OK] team_rankings table dropped")
+
+            conn.commit()
+            print("=" * 70)
+            print("[OK] Migration 027 rollback completed!")
+
+    except Exception as e:
+        conn.rollback()
+        print(f"[FAIL] Rollback failed: {e}")
+        raise
+
+    finally:
+        conn.close()
+
+
+def verify_migration(connection_string: str | None = None) -> bool:
+    """
+    Verify migration was applied correctly.
+
+    Returns:
+        True if verification passes, False otherwise
+    """
+    if connection_string:
+        conn = psycopg2.connect(connection_string)
+    else:
+        host = os.getenv("DB_HOST", "localhost")
+        port = os.getenv("DB_PORT", "5432")
+        database = os.getenv("DB_NAME", "precog_dev")
+        user = os.getenv("DB_USER", "postgres")
+        password = os.getenv("DB_PASSWORD")
+
+        if not password:
+            raise ValueError("DB_PASSWORD environment variable not set")
+
+        conn = psycopg2.connect(
+            host=host, port=port, database=database, user=user, password=password
+        )
+
+    try:
+        with conn.cursor() as cur:
+            print("Verifying Migration 027...")
+
+            # Check table exists
+            cur.execute("""
+                SELECT EXISTS (
+                    SELECT FROM information_schema.tables
+                    WHERE table_name = 'team_rankings'
+                );
+            """)
+            table_exists = cur.fetchone()[0]
+
+            # Check columns
+            cur.execute("""
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_name = 'team_rankings'
+                ORDER BY ordinal_position;
+            """)
+            columns = [row[0] for row in cur.fetchall()]
+            expected_columns = [
+                "ranking_id",
+                "team_id",
+                "ranking_type",
+                "rank",
+                "season",
+                "week",
+                "ranking_date",
+                "points",
+                "first_place_votes",
+                "previous_rank",
+                "created_at",
+            ]
+
+            # Check indexes
+            cur.execute("""
+                SELECT indexname FROM pg_indexes
+                WHERE tablename = 'team_rankings';
+            """)
+            indexes = [row[0] for row in cur.fetchall()]
+
+            # Check foreign key
+            cur.execute("""
+                SELECT COUNT(*) FROM information_schema.table_constraints
+                WHERE table_name = 'team_rankings'
+                AND constraint_type = 'FOREIGN KEY';
+            """)
+            fk_count = cur.fetchone()[0]
+
+            # Results
+            print(f"    Table exists: {table_exists}")
+            print(f"    Columns: {columns}")
+            print(f"    Indexes: {indexes}")
+            print(f"    Foreign keys: {fk_count}")
+
+            success: bool = (
+                table_exists
+                and all(col in columns for col in expected_columns)
+                and len(indexes) >= 4
+                and fk_count >= 1
+            )
+
+            if success:
+                print("[OK] Migration 027 verification passed!")
+            else:
+                print("[FAIL] Migration 027 verification failed!")
+
+            return success
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--rollback":
+        rollback_migration()
+    elif len(sys.argv) > 1 and sys.argv[1] == "--verify":
+        verify_migration()
+    else:
+        apply_migration()

--- a/src/precog/database/migrations/migration_028_enhance_teams_table.py
+++ b/src/precog/database/migrations/migration_028_enhance_teams_table.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""
+Migration 028: Enhance Teams Table with ESPN IDs and Multi-Sport Support
+
+**Purpose:**
+Add ESPN integration fields and multi-sport support to existing teams table.
+Enables cross-referencing with ESPN API data and supporting 6 leagues.
+
+**Schema Changes (ALTER TABLE teams):**
+- espn_team_id: VARCHAR(50) - ESPN's unique team identifier
+- display_name: VARCHAR(100) - Short display name (e.g., "Chiefs" vs "Kansas City Chiefs")
+- conference: VARCHAR(100) - Conference affiliation (AFC, NFC, Big Ten, SEC, etc.)
+- division: VARCHAR(100) - Division within conference (AFC West, etc.)
+- sport: VARCHAR(20) DEFAULT 'nfl' - Sport category (football, basketball, hockey)
+- league: VARCHAR(20) DEFAULT 'nfl' - Specific league (nfl, ncaaf, nba, ncaab, nhl, wnba)
+
+**Indexes:**
+- idx_teams_espn_id: UNIQUE index on espn_team_id for ESPN API lookups
+- idx_teams_league: Filter by league for multi-sport queries
+- idx_teams_conference: Conference-based queries
+
+**Supported Leagues:**
+- NFL (32 teams) - Already seeded
+- NCAAF (130+ teams) - Partially seeded
+- NBA (30 teams) - To be seeded
+- NCAAB (350+ Division I teams) - Top 100+ to be seeded
+- NHL (32 teams) - To be seeded
+- WNBA (12 teams) - To be seeded
+
+**Backfill Strategy:**
+- Existing teams get league/sport based on current data
+- ESPN IDs populated via ESPN API team lookup endpoint
+- Conference/division populated from ESPN team metadata
+
+**References:**
+- REQ-DATA-003: Multi-Sport Support
+- ADR-029: ESPN Data Model with Normalized Schema
+
+**Migration Safe:** YES
+- All new columns are nullable or have defaults
+- Existing data preserved
+- Rollback script included
+
+**Estimated Time:** <1 second (column additions only)
+
+Created: 2025-11-29
+Phase: 2 (Live Data Integration)
+"""
+
+import os
+
+import psycopg2
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+
+def apply_migration(connection_string: str | None = None) -> None:
+    """
+    Apply migration: Enhance teams table with ESPN integration fields.
+
+    Args:
+        connection_string: PostgreSQL connection string (defaults to env vars)
+    """
+    if connection_string:
+        conn = psycopg2.connect(connection_string)
+    else:
+        # Build connection from individual env vars
+        host = os.getenv("DB_HOST", "localhost")
+        port = os.getenv("DB_PORT", "5432")
+        database = os.getenv("DB_NAME", "precog_dev")
+        user = os.getenv("DB_USER", "postgres")
+        password = os.getenv("DB_PASSWORD")
+
+        if not password:
+            raise ValueError("DB_PASSWORD environment variable not set")
+
+        conn = psycopg2.connect(
+            host=host, port=port, database=database, user=user, password=password
+        )
+    conn.autocommit = False  # Use transaction
+
+    try:
+        with conn.cursor() as cur:
+            print("Starting Migration 028: Enhance Teams Table")
+            print("=" * 70)
+
+            # =================================================================
+            # Step 1: Add new columns
+            # =================================================================
+            print("[1/4] Adding new columns to teams table...")
+
+            # ESPN team ID
+            cur.execute("""
+                ALTER TABLE teams
+                ADD COLUMN IF NOT EXISTS espn_team_id VARCHAR(50);
+            """)
+            print("    [OK] espn_team_id column added")
+
+            # Display name (short form)
+            cur.execute("""
+                ALTER TABLE teams
+                ADD COLUMN IF NOT EXISTS display_name VARCHAR(100);
+            """)
+            print("    [OK] display_name column added")
+
+            # Conference
+            cur.execute("""
+                ALTER TABLE teams
+                ADD COLUMN IF NOT EXISTS conference VARCHAR(100);
+            """)
+            print("    [OK] conference column added")
+
+            # Division
+            cur.execute("""
+                ALTER TABLE teams
+                ADD COLUMN IF NOT EXISTS division VARCHAR(100);
+            """)
+            print("    [OK] division column added")
+
+            # Sport category
+            cur.execute("""
+                ALTER TABLE teams
+                ADD COLUMN IF NOT EXISTS sport VARCHAR(20) DEFAULT 'football';
+            """)
+            print("    [OK] sport column added")
+
+            # League
+            cur.execute("""
+                ALTER TABLE teams
+                ADD COLUMN IF NOT EXISTS league VARCHAR(20) DEFAULT 'nfl';
+            """)
+            print("    [OK] league column added")
+
+            # =================================================================
+            # Step 2: Create indexes
+            # =================================================================
+            print("[2/4] Creating indexes...")
+
+            # Unique ESPN ID index
+            cur.execute("""
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_teams_espn_id
+                ON teams(espn_team_id)
+                WHERE espn_team_id IS NOT NULL;
+            """)
+            print("    [OK] idx_teams_espn_id (unique, partial) created")
+
+            # League index
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_teams_league
+                ON teams(league);
+            """)
+            print("    [OK] idx_teams_league created")
+
+            # Conference index
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_teams_conference
+                ON teams(conference)
+                WHERE conference IS NOT NULL;
+            """)
+            print("    [OK] idx_teams_conference (partial) created")
+
+            # Sport index
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_teams_sport
+                ON teams(sport);
+            """)
+            print("    [OK] idx_teams_sport created")
+
+            # =================================================================
+            # Step 3: Add CHECK constraints
+            # =================================================================
+            print("[3/4] Adding CHECK constraints...")
+
+            # Valid sport values
+            cur.execute("""
+                ALTER TABLE teams
+                ADD CONSTRAINT teams_sport_check
+                CHECK (sport IN ('football', 'basketball', 'hockey'));
+            """)
+            print("    [OK] teams_sport_check constraint added")
+
+            # Valid league values
+            cur.execute("""
+                ALTER TABLE teams
+                ADD CONSTRAINT teams_league_check
+                CHECK (league IN ('nfl', 'ncaaf', 'nba', 'ncaab', 'nhl', 'wnba'));
+            """)
+            print("    [OK] teams_league_check constraint added")
+
+            # ESPN ID format (alphanumeric)
+            cur.execute("""
+                ALTER TABLE teams
+                ADD CONSTRAINT teams_espn_id_format_check
+                CHECK (espn_team_id IS NULL OR espn_team_id ~ '^[0-9A-Za-z_-]+$');
+            """)
+            print("    [OK] teams_espn_id_format_check constraint added")
+
+            # =================================================================
+            # Step 4: Backfill existing teams
+            # =================================================================
+            print("[4/4] Backfilling existing teams...")
+
+            # Set sport=football, league=nfl for existing NFL teams
+            cur.execute("""
+                UPDATE teams
+                SET sport = 'football', league = 'nfl'
+                WHERE sport IS NULL OR league IS NULL;
+            """)
+            updated_count = cur.rowcount
+            print(f"    [OK] Updated {updated_count} teams with default sport/league")
+
+            # =================================================================
+            # Commit transaction
+            # =================================================================
+            conn.commit()
+            print("=" * 70)
+            print("[OK] Migration 028 completed successfully!")
+            print("    - New columns: 6 (espn_team_id, display_name, conference,")
+            print("                      division, sport, league)")
+            print("    - Indexes: 4 (espn_id, league, conference, sport)")
+            print("    - Constraints: 3 (sport, league, espn_id_format)")
+            print(f"    - Backfilled: {updated_count} teams")
+
+    except Exception as e:
+        conn.rollback()
+        print(f"[FAIL] Migration 028 failed: {e}")
+        raise
+
+    finally:
+        conn.close()
+
+
+def rollback_migration(connection_string: str | None = None) -> None:
+    """
+    Rollback migration: Remove added columns and indexes.
+
+    Args:
+        connection_string: PostgreSQL connection string (defaults to env vars)
+    """
+    if connection_string:
+        conn = psycopg2.connect(connection_string)
+    else:
+        host = os.getenv("DB_HOST", "localhost")
+        port = os.getenv("DB_PORT", "5432")
+        database = os.getenv("DB_NAME", "precog_dev")
+        user = os.getenv("DB_USER", "postgres")
+        password = os.getenv("DB_PASSWORD")
+
+        if not password:
+            raise ValueError("DB_PASSWORD environment variable not set")
+
+        conn = psycopg2.connect(
+            host=host, port=port, database=database, user=user, password=password
+        )
+    conn.autocommit = False
+
+    try:
+        with conn.cursor() as cur:
+            print("Rolling back Migration 028: Remove Teams Enhancements")
+            print("=" * 70)
+
+            # Drop constraints first
+            cur.execute("""
+                ALTER TABLE teams DROP CONSTRAINT IF EXISTS teams_sport_check;
+            """)
+            cur.execute("""
+                ALTER TABLE teams DROP CONSTRAINT IF EXISTS teams_league_check;
+            """)
+            cur.execute("""
+                ALTER TABLE teams DROP CONSTRAINT IF EXISTS teams_espn_id_format_check;
+            """)
+            print("    [OK] Constraints dropped")
+
+            # Drop indexes
+            cur.execute("DROP INDEX IF EXISTS idx_teams_espn_id;")
+            cur.execute("DROP INDEX IF EXISTS idx_teams_league;")
+            cur.execute("DROP INDEX IF EXISTS idx_teams_conference;")
+            cur.execute("DROP INDEX IF EXISTS idx_teams_sport;")
+            print("    [OK] Indexes dropped")
+
+            # Drop columns
+            cur.execute("ALTER TABLE teams DROP COLUMN IF EXISTS espn_team_id;")
+            cur.execute("ALTER TABLE teams DROP COLUMN IF EXISTS display_name;")
+            cur.execute("ALTER TABLE teams DROP COLUMN IF EXISTS conference;")
+            cur.execute("ALTER TABLE teams DROP COLUMN IF EXISTS division;")
+            cur.execute("ALTER TABLE teams DROP COLUMN IF EXISTS sport;")
+            cur.execute("ALTER TABLE teams DROP COLUMN IF EXISTS league;")
+            print("    [OK] Columns dropped")
+
+            conn.commit()
+            print("=" * 70)
+            print("[OK] Migration 028 rollback completed!")
+
+    except Exception as e:
+        conn.rollback()
+        print(f"[FAIL] Rollback failed: {e}")
+        raise
+
+    finally:
+        conn.close()
+
+
+def verify_migration(connection_string: str | None = None) -> bool:
+    """
+    Verify migration was applied correctly.
+
+    Returns:
+        True if verification passes, False otherwise
+    """
+    if connection_string:
+        conn = psycopg2.connect(connection_string)
+    else:
+        host = os.getenv("DB_HOST", "localhost")
+        port = os.getenv("DB_PORT", "5432")
+        database = os.getenv("DB_NAME", "precog_dev")
+        user = os.getenv("DB_USER", "postgres")
+        password = os.getenv("DB_PASSWORD")
+
+        if not password:
+            raise ValueError("DB_PASSWORD environment variable not set")
+
+        conn = psycopg2.connect(
+            host=host, port=port, database=database, user=user, password=password
+        )
+
+    try:
+        with conn.cursor() as cur:
+            print("Verifying Migration 028...")
+
+            # Check new columns exist
+            cur.execute("""
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_name = 'teams'
+                AND column_name IN (
+                    'espn_team_id', 'display_name', 'conference',
+                    'division', 'sport', 'league'
+                );
+            """)
+            new_columns = [row[0] for row in cur.fetchall()]
+
+            # Check indexes
+            cur.execute("""
+                SELECT indexname FROM pg_indexes
+                WHERE tablename = 'teams'
+                AND indexname LIKE 'idx_teams_%';
+            """)
+            indexes = [row[0] for row in cur.fetchall()]
+
+            # Results
+            print(f"    New columns: {new_columns}")
+            print(f"    Indexes: {indexes}")
+
+            expected_columns = [
+                "espn_team_id",
+                "display_name",
+                "conference",
+                "division",
+                "sport",
+                "league",
+            ]
+
+            success = all(col in new_columns for col in expected_columns) and len(indexes) >= 4
+
+            if success:
+                print("[OK] Migration 028 verification passed!")
+            else:
+                print("[FAIL] Migration 028 verification failed!")
+
+            return success
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--rollback":
+        rollback_migration()
+    elif len(sys.argv) > 1 and sys.argv[1] == "--verify":
+        verify_migration()
+    else:
+        apply_migration()

--- a/src/precog/database/migrations/migration_029_create_game_states_table.py
+++ b/src/precog/database/migrations/migration_029_create_game_states_table.py
@@ -1,0 +1,553 @@
+#!/usr/bin/env python3
+"""
+Migration 029: Create Game States Table (SCD Type 2)
+
+**Purpose:**
+Create game_states table for live game state tracking with complete history
+preservation using SCD Type 2 versioning. Enables historical playback and
+backtesting.
+
+**SCD Type 2 Architecture:**
+- Each game state change creates a NEW row (not an update)
+- row_start_timestamp: When this version became current
+- row_end_timestamp: When this version was superseded (NULL if current)
+- row_current_ind: TRUE for the current version, FALSE for historical
+- Partial unique index ensures only ONE current row per game
+
+**Schema:**
+Core Fields:
+- id: SERIAL PRIMARY KEY (surrogate key for SCD Type 2)
+- game_state_id: VARCHAR(50) (business key - e.g., "GS-12345")
+- espn_event_id: VARCHAR(50) NOT NULL (ESPN's game identifier)
+- home_team_id: INTEGER REFERENCES teams(team_id)
+- away_team_id: INTEGER REFERENCES teams(team_id)
+- venue_id: INTEGER REFERENCES venues(venue_id)
+
+Score Fields:
+- home_score: INTEGER NOT NULL DEFAULT 0
+- away_score: INTEGER NOT NULL DEFAULT 0
+- period: INTEGER NOT NULL DEFAULT 0 (quarter, half, period)
+- clock_seconds: DECIMAL(10,2) (remaining time in period)
+- clock_display: VARCHAR(20) (formatted clock - "12:34")
+- game_status: VARCHAR(50) NOT NULL (pre, in_progress, halftime, final, etc.)
+
+Metadata:
+- game_date: TIMESTAMP WITH TIME ZONE
+- broadcast: VARCHAR(100) (TV network)
+- neutral_site: BOOLEAN DEFAULT FALSE
+- season_type: VARCHAR(20) (preseason, regular, playoff, bowl)
+- week_number: INTEGER
+- league: VARCHAR(20) NOT NULL (nfl, ncaaf, nba, ncaab, nhl, wnba)
+
+Sport-Specific JSONB:
+- situation: JSONB (downs, fouls, power plays, etc.)
+- linescores: JSONB (period-by-period scores)
+
+SCD Type 2:
+- row_start_timestamp: TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+- row_end_timestamp: TIMESTAMP WITH TIME ZONE (NULL if current)
+- row_current_ind: BOOLEAN DEFAULT TRUE
+
+**Indexes:**
+- idx_game_states_event: espn_event_id for fast event lookups
+- idx_game_states_current: Partial index for current rows
+- idx_game_states_current_unique: Ensures one current row per event
+- idx_game_states_date: game_date for date-range queries
+- idx_game_states_status: game_status for finding live games
+- idx_game_states_league: league for multi-sport filtering
+- idx_game_states_situation: GIN index on JSONB situation
+
+**Storage Estimate:**
+~1.8M rows/year (9,500 games x ~190 updates/game average)
+~900 MB/year with indexes
+
+**Use Cases:**
+- "What was the score at halftime?" - Historical query
+- "Get all current live games" - Current row query
+- Backtesting model accuracy on historical game states
+
+**References:**
+- REQ-DATA-001: Game State Collection
+- ADR-029: ESPN Data Model with Normalized Schema
+- Migration 016: SCD Type 2 surrogate key pattern
+
+**Migration Safe:** YES
+- New table creation, no existing data affected
+- Rollback script included
+
+**Estimated Time:** <1 second
+
+Created: 2025-11-29
+Phase: 2 (Live Data Integration)
+"""
+
+import os
+
+import psycopg2
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+
+def apply_migration(connection_string: str | None = None) -> None:
+    """
+    Apply migration: Create game_states table with SCD Type 2 versioning.
+
+    Args:
+        connection_string: PostgreSQL connection string (defaults to env vars)
+    """
+    if connection_string:
+        conn = psycopg2.connect(connection_string)
+    else:
+        # Build connection from individual env vars
+        host = os.getenv("DB_HOST", "localhost")
+        port = os.getenv("DB_PORT", "5432")
+        database = os.getenv("DB_NAME", "precog_dev")
+        user = os.getenv("DB_USER", "postgres")
+        password = os.getenv("DB_PASSWORD")
+
+        if not password:
+            raise ValueError("DB_PASSWORD environment variable not set")
+
+        conn = psycopg2.connect(
+            host=host, port=port, database=database, user=user, password=password
+        )
+    conn.autocommit = False  # Use transaction
+
+    try:
+        with conn.cursor() as cur:
+            print("Starting Migration 029: Create Game States Table (SCD Type 2)")
+            print("=" * 70)
+
+            # =================================================================
+            # Step 1: Create game_states table
+            # =================================================================
+            print("[1/4] Creating game_states table...")
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS game_states (
+                    -- Surrogate primary key (SCD Type 2)
+                    id SERIAL PRIMARY KEY,
+
+                    -- Business key
+                    game_state_id VARCHAR(50) NOT NULL,
+
+                    -- Event identification
+                    espn_event_id VARCHAR(50) NOT NULL,
+
+                    -- Team references
+                    home_team_id INTEGER REFERENCES teams(team_id),
+                    away_team_id INTEGER REFERENCES teams(team_id),
+
+                    -- Venue reference
+                    venue_id INTEGER REFERENCES venues(venue_id),
+
+                    -- Score fields
+                    home_score INTEGER NOT NULL DEFAULT 0,
+                    away_score INTEGER NOT NULL DEFAULT 0,
+                    period INTEGER NOT NULL DEFAULT 0,
+                    clock_seconds DECIMAL(10,2),
+                    clock_display VARCHAR(20),
+                    game_status VARCHAR(50) NOT NULL,
+
+                    -- Metadata
+                    game_date TIMESTAMP WITH TIME ZONE,
+                    broadcast VARCHAR(100),
+                    neutral_site BOOLEAN DEFAULT FALSE NOT NULL,
+                    season_type VARCHAR(20),
+                    week_number INTEGER,
+                    league VARCHAR(20) NOT NULL,
+
+                    -- Sport-specific JSONB
+                    situation JSONB,
+                    linescores JSONB,
+
+                    -- Data source tracking
+                    data_source VARCHAR(50) DEFAULT 'espn' NOT NULL,
+
+                    -- SCD Type 2 versioning
+                    row_start_timestamp TIMESTAMP WITH TIME ZONE DEFAULT NOW() NOT NULL,
+                    row_end_timestamp TIMESTAMP WITH TIME ZONE,
+                    row_current_ind BOOLEAN DEFAULT TRUE NOT NULL
+                );
+            """)
+            print("    [OK] game_states table created")
+
+            # =================================================================
+            # Step 2: Create indexes
+            # =================================================================
+            print("[2/4] Creating indexes...")
+
+            # Event ID lookup
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_game_states_event
+                ON game_states(espn_event_id);
+            """)
+            print("    [OK] idx_game_states_event created")
+
+            # Current rows only (partial index)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_game_states_current
+                ON game_states(espn_event_id)
+                WHERE row_current_ind = TRUE;
+            """)
+            print("    [OK] idx_game_states_current (partial) created")
+
+            # Unique constraint on current rows (SCD Type 2 integrity)
+            cur.execute("""
+                CREATE UNIQUE INDEX IF NOT EXISTS idx_game_states_current_unique
+                ON game_states(espn_event_id)
+                WHERE row_current_ind = TRUE;
+            """)
+            print("    [OK] idx_game_states_current_unique (SCD Type 2) created")
+
+            # Date-based queries
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_game_states_date
+                ON game_states(game_date);
+            """)
+            print("    [OK] idx_game_states_date created")
+
+            # Status queries (find live games)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_game_states_status
+                ON game_states(game_status)
+                WHERE row_current_ind = TRUE;
+            """)
+            print("    [OK] idx_game_states_status (partial) created")
+
+            # League queries (multi-sport)
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_game_states_league
+                ON game_states(league)
+                WHERE row_current_ind = TRUE;
+            """)
+            print("    [OK] idx_game_states_league (partial) created")
+
+            # GIN index on situation JSONB
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_game_states_situation
+                ON game_states USING GIN (situation);
+            """)
+            print("    [OK] idx_game_states_situation (GIN) created")
+
+            # Teams lookup
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_game_states_teams
+                ON game_states(home_team_id, away_team_id)
+                WHERE row_current_ind = TRUE;
+            """)
+            print("    [OK] idx_game_states_teams (partial) created")
+
+            # Business key index
+            cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_game_states_business_key
+                ON game_states(game_state_id);
+            """)
+            print("    [OK] idx_game_states_business_key created")
+
+            # =================================================================
+            # Step 3: Add CHECK constraints
+            # =================================================================
+            print("[3/4] Adding CHECK constraints...")
+
+            # Valid game status values
+            cur.execute("""
+                ALTER TABLE game_states
+                ADD CONSTRAINT game_states_status_check
+                CHECK (game_status IN (
+                    'pre',
+                    'in_progress',
+                    'halftime',
+                    'end_of_period',
+                    'final',
+                    'final_ot',
+                    'delayed',
+                    'postponed',
+                    'cancelled',
+                    'suspended'
+                ));
+            """)
+            print("    [OK] game_states_status_check constraint added")
+
+            # Valid season type values
+            cur.execute("""
+                ALTER TABLE game_states
+                ADD CONSTRAINT game_states_season_type_check
+                CHECK (season_type IS NULL OR season_type IN (
+                    'preseason',
+                    'regular',
+                    'playoff',
+                    'bowl',
+                    'allstar',
+                    'exhibition'
+                ));
+            """)
+            print("    [OK] game_states_season_type_check constraint added")
+
+            # Valid league values
+            cur.execute("""
+                ALTER TABLE game_states
+                ADD CONSTRAINT game_states_league_check
+                CHECK (league IN ('nfl', 'ncaaf', 'nba', 'ncaab', 'nhl', 'wnba'));
+            """)
+            print("    [OK] game_states_league_check constraint added")
+
+            # Scores must be non-negative
+            cur.execute("""
+                ALTER TABLE game_states
+                ADD CONSTRAINT game_states_scores_check
+                CHECK (home_score >= 0 AND away_score >= 0);
+            """)
+            print("    [OK] game_states_scores_check constraint added")
+
+            # Period must be non-negative
+            cur.execute("""
+                ALTER TABLE game_states
+                ADD CONSTRAINT game_states_period_check
+                CHECK (period >= 0);
+            """)
+            print("    [OK] game_states_period_check constraint added")
+
+            # Clock seconds must be non-negative if present
+            cur.execute("""
+                ALTER TABLE game_states
+                ADD CONSTRAINT game_states_clock_check
+                CHECK (clock_seconds IS NULL OR clock_seconds >= 0);
+            """)
+            print("    [OK] game_states_clock_check constraint added")
+
+            # Week number validation (0-20 for regular season + playoffs)
+            cur.execute("""
+                ALTER TABLE game_states
+                ADD CONSTRAINT game_states_week_check
+                CHECK (week_number IS NULL OR (week_number >= 0 AND week_number <= 25));
+            """)
+            print("    [OK] game_states_week_check constraint added")
+
+            # =================================================================
+            # Step 4: Create SCD Type 2 trigger function
+            # =================================================================
+            print("[4/4] Creating SCD Type 2 trigger function...")
+
+            # Note: The actual SCD Type 2 logic is in the CRUD upsert_game_state()
+            # function, not a database trigger. This is intentional because:
+            # 1. Python logic is easier to test
+            # 2. More flexibility for batch operations
+            # 3. Clearer error handling
+
+            # However, we'll create a simple trigger to set row_start_timestamp
+            cur.execute("""
+                CREATE OR REPLACE FUNCTION set_game_states_timestamp()
+                RETURNS TRIGGER AS $$
+                BEGIN
+                    IF NEW.row_start_timestamp IS NULL THEN
+                        NEW.row_start_timestamp = NOW();
+                    END IF;
+                    RETURN NEW;
+                END;
+                $$ LANGUAGE plpgsql;
+            """)
+
+            cur.execute("""
+                DROP TRIGGER IF EXISTS trigger_game_states_timestamp ON game_states;
+                CREATE TRIGGER trigger_game_states_timestamp
+                    BEFORE INSERT ON game_states
+                    FOR EACH ROW
+                    EXECUTE FUNCTION set_game_states_timestamp();
+            """)
+            print("    [OK] row_start_timestamp trigger created")
+
+            # =================================================================
+            # Commit transaction
+            # =================================================================
+            conn.commit()
+            print("=" * 70)
+            print("[OK] Migration 029 completed successfully!")
+            print("    - Table: game_states (SCD Type 2)")
+            print("    - Indexes: 9 (event, current, current_unique, date, status,")
+            print("                  league, situation GIN, teams, business_key)")
+            print("    - Constraints: 7 (status, season_type, league, scores,")
+            print("                      period, clock, week)")
+            print("    - FKs: 3 (home_team, away_team, venue)")
+            print("    - Trigger: row_start_timestamp auto-set")
+
+    except Exception as e:
+        conn.rollback()
+        print(f"[FAIL] Migration 029 failed: {e}")
+        raise
+
+    finally:
+        conn.close()
+
+
+def rollback_migration(connection_string: str | None = None) -> None:
+    """
+    Rollback migration: Drop game_states table and related objects.
+
+    Args:
+        connection_string: PostgreSQL connection string (defaults to env vars)
+    """
+    if connection_string:
+        conn = psycopg2.connect(connection_string)
+    else:
+        host = os.getenv("DB_HOST", "localhost")
+        port = os.getenv("DB_PORT", "5432")
+        database = os.getenv("DB_NAME", "precog_dev")
+        user = os.getenv("DB_USER", "postgres")
+        password = os.getenv("DB_PASSWORD")
+
+        if not password:
+            raise ValueError("DB_PASSWORD environment variable not set")
+
+        conn = psycopg2.connect(
+            host=host, port=port, database=database, user=user, password=password
+        )
+    conn.autocommit = False
+
+    try:
+        with conn.cursor() as cur:
+            print("Rolling back Migration 029: Drop Game States Table")
+            print("=" * 70)
+
+            # Drop table (cascades to indexes, constraints, triggers)
+            cur.execute("DROP TABLE IF EXISTS game_states CASCADE;")
+            print("    [OK] game_states table dropped")
+
+            # Drop trigger function
+            cur.execute("DROP FUNCTION IF EXISTS set_game_states_timestamp() CASCADE;")
+            print("    [OK] set_game_states_timestamp function dropped")
+
+            conn.commit()
+            print("=" * 70)
+            print("[OK] Migration 029 rollback completed!")
+
+    except Exception as e:
+        conn.rollback()
+        print(f"[FAIL] Rollback failed: {e}")
+        raise
+
+    finally:
+        conn.close()
+
+
+def verify_migration(connection_string: str | None = None) -> bool:
+    """
+    Verify migration was applied correctly.
+
+    Returns:
+        True if verification passes, False otherwise
+    """
+    if connection_string:
+        conn = psycopg2.connect(connection_string)
+    else:
+        host = os.getenv("DB_HOST", "localhost")
+        port = os.getenv("DB_PORT", "5432")
+        database = os.getenv("DB_NAME", "precog_dev")
+        user = os.getenv("DB_USER", "postgres")
+        password = os.getenv("DB_PASSWORD")
+
+        if not password:
+            raise ValueError("DB_PASSWORD environment variable not set")
+
+        conn = psycopg2.connect(
+            host=host, port=port, database=database, user=user, password=password
+        )
+
+    try:
+        with conn.cursor() as cur:
+            print("Verifying Migration 029...")
+
+            # Check table exists
+            cur.execute("""
+                SELECT EXISTS (
+                    SELECT FROM information_schema.tables
+                    WHERE table_name = 'game_states'
+                );
+            """)
+            table_exists = cur.fetchone()[0]
+
+            # Check SCD Type 2 columns
+            cur.execute("""
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_name = 'game_states'
+                AND column_name IN (
+                    'id', 'game_state_id', 'row_start_timestamp',
+                    'row_end_timestamp', 'row_current_ind'
+                );
+            """)
+            scd_columns = [row[0] for row in cur.fetchall()]
+
+            # Check unique index for SCD Type 2
+            cur.execute("""
+                SELECT indexname FROM pg_indexes
+                WHERE tablename = 'game_states'
+                AND indexname = 'idx_game_states_current_unique';
+            """)
+            unique_index = cur.fetchone()
+
+            # Check foreign keys
+            cur.execute("""
+                SELECT COUNT(*) FROM information_schema.table_constraints
+                WHERE table_name = 'game_states'
+                AND constraint_type = 'FOREIGN KEY';
+            """)
+            fk_count = cur.fetchone()[0]
+
+            # Check indexes count
+            cur.execute("""
+                SELECT COUNT(*) FROM pg_indexes
+                WHERE tablename = 'game_states';
+            """)
+            index_count = cur.fetchone()[0]
+
+            # Results
+            print(f"    Table exists: {table_exists}")
+            print(f"    SCD Type 2 columns: {scd_columns}")
+            print(f"    Unique index exists: {unique_index is not None}")
+            print(f"    Foreign keys: {fk_count}")
+            print(f"    Total indexes: {index_count}")
+
+            expected_scd_columns = [
+                "id",
+                "game_state_id",
+                "row_start_timestamp",
+                "row_end_timestamp",
+                "row_current_ind",
+            ]
+
+            success: bool = (
+                table_exists
+                and all(col in scd_columns for col in expected_scd_columns)
+                and unique_index is not None
+                and fk_count >= 3
+                and index_count >= 8
+            )
+
+            if success:
+                print("[OK] Migration 029 verification passed!")
+                print("    SCD Type 2 architecture validated:")
+                print("    - Surrogate PK (id)")
+                print("    - Business key (game_state_id)")
+                print("    - Temporal columns (row_start/end_timestamp)")
+                print("    - Current indicator (row_current_ind)")
+                print("    - Unique constraint on current rows")
+            else:
+                print("[FAIL] Migration 029 verification failed!")
+
+            return success
+
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--rollback":
+        rollback_migration()
+    elif len(sys.argv) > 1 and sys.argv[1] == "--verify":
+        verify_migration()
+    else:
+        apply_migration()


### PR DESCRIPTION
## Summary

Creates 4 database migrations for the ESPN data model (Phase 2B):

- **Migration 026**: `venues` table - Normalized stadium data (~150 unique venues)
- **Migration 027**: `team_rankings` table - AP Poll, CFP, Coaches Poll, ESPN rankings with FK to teams
- **Migration 028**: `teams` table enhancements - espn_team_id, sport, league, conference for multi-sport support
- **Migration 029**: `game_states` table - SCD Type 2 versioning, JSONB situation, ~1.8M rows/year capacity

### Schema Features

- **SCD Type 2** for complete game state history (`row_current_ind` pattern)
- **JSONB situation** field for sport-specific data (downs, fouls, power plays)
- **Multi-sport support**: NFL, NCAAF, NBA, NCAAB, NHL, WNBA (6 leagues)
- **Partial unique index** ensures one current row per event
- **Triggers** for updated_at auto-update on venues table

### Storage Estimates
- ~1.1 GB/year for all 6 sports
- ~1.8M game state records/year
- PostgreSQL 8-20 GB tier covers 7-18 years of data

### Bonus Fix
- Fixed S110 security rule violation in `scripts/audit_test_type_coverage.py` (replaced bare except-pass with specific exception handling)

## Test Plan

- [x] All pre-commit hooks pass (19 checks)
- [x] All pre-push hooks pass (11 checks)
- [ ] CI pipeline checks pass
- [ ] Migrations can be applied to fresh database (manual verification)
- [ ] Migrations can be rolled back (manual verification)

Phase 2B: Database Migrations - **COMPLETE**

Closes: Phase B from ESPN_DATA_MODEL_IMPLEMENTATION_PLAN_V1.0.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)