### PR TITLE
fix: Testcontainers fixture registration and deprecated parameter (Issue #168)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,16 +52,20 @@ except ImportError:
 
 # Import stress testcontainers fixtures (Issue #168)
 # Function-scoped containers for stress tests that exhaust connection pools
+# NOTE: Must import _stress_postgres_container_session for pytest to discover
+# the session-scoped fixture that stress_postgres_container depends on
 try:
     from tests.fixtures.stress_testcontainers import (
         DOCKER_AVAILABLE as STRESS_DOCKER_AVAILABLE,
     )
     from tests.fixtures.stress_testcontainers import (
+        _stress_postgres_container_session,
         stress_db_connection,
         stress_postgres_container,
     )
 except ImportError:
     STRESS_DOCKER_AVAILABLE = False
+    _stress_postgres_container_session = None  # type: ignore[assignment, misc]
     stress_postgres_container = None  # type: ignore[assignment, misc]
     stress_db_connection = None  # type: ignore[assignment, misc]
 

--- a/tests/fixtures/stress_testcontainers.py
+++ b/tests/fixtures/stress_testcontainers.py
@@ -232,9 +232,10 @@ def _stress_postgres_container_session() -> Generator[dict[str, str], None, None
         pytest.skip("Docker not available - start Docker Desktop to run stress tests")
 
     # Start PostgreSQL container with higher connection limits
+    # NOTE: testcontainers 4.x uses 'username' instead of deprecated 'user'
     container = PostgresContainer(
         image="postgres:15",
-        user="stress_user",
+        username="stress_user",
         password="stress_password",
         dbname="stress_test_db",
     ).with_command(

--- a/tests/fixtures/testcontainers_fixtures.py
+++ b/tests/fixtures/testcontainers_fixtures.py
@@ -743,9 +743,10 @@ def postgres_container() -> Generator[dict[str, str], None, None]:
         pytest.skip("testcontainers not installed - run: pip install testcontainers[postgres]")
 
     # Start PostgreSQL container
+    # NOTE: testcontainers 4.x uses 'username' instead of deprecated 'user'
     container = PostgresContainer(
         image="postgres:15",
-        user="test_user",
+        username="test_user",
         password="test_password",
         dbname="precog_test",
     )


### PR DESCRIPTION
## Summary

- Import `_stress_postgres_container_session` in conftest.py for pytest discovery
- Fix deprecated `user` -> `username` in PostgresContainer (testcontainers 4.x API)
- Applies to both `stress_testcontainers.py` and `testcontainers_fixtures.py`

## Root Cause

The session-scoped fixture `_stress_postgres_container_session` wasn't being discovered by pytest because it wasn't imported in `conftest.py` alongside its dependent function-scoped fixtures. This caused all stress tests to fail with "fixture not found" errors.

## Testing

- All 9 connection stress tests passing with testcontainers isolation
- All 58 stress tests passing (34.70s)
- All 409 unit tests passing
- CI should pass (fresh database avoids pre-existing isolation issues)

## Pre-push Hook Note

The pre-push hook shows 1 ERROR and 6 XPASS locally - these are **pre-existing database isolation issues** (not caused by this PR):
- ERROR: `test_open_position_invalid_price_too_high` - ForeignKeyViolation due to database state pollution
- XPASSes: Tests pass locally but were marked xfail for CI isolation

These are tracked in Issue #171 (hybrid test isolation strategy).

## Test plan

- [x] Run stress tests locally with Docker - all pass
- [x] Verify testcontainers creates isolated PostgreSQL container
- [ ] CI tests pass (fresh database state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)