### PR TITLE
feat: Export ESPN CRUD operations from database package (Issue #184)

### DIFF
--- a/src/precog/database/__init__.py
+++ b/src/precog/database/__init__.py
@@ -26,54 +26,84 @@ from .crud_operations import (
     close_position,
     # Account balance operations
     create_account_balance,
+    # Game state operations (ESPN, SCD Type 2)
+    create_game_state,
     # Market operations
     create_market,
     # Position operations
     create_position,
     create_settlement,
     create_strategy,
+    # Team ranking operations (ESPN)
+    create_team_ranking,
     # Trade operations
     create_trade,
+    # Venue operations (ESPN)
+    create_venue,
+    get_current_game_state,
     get_current_market,
     get_current_positions,
+    get_current_rankings,
+    get_game_state_history,
+    get_games_by_date,
+    get_live_games,
     get_market_history,
     get_recent_trades,
     get_strategy_by_name_and_version,
+    get_team_rankings,
     get_trades_by_market,
+    get_venue_by_espn_id,
+    get_venue_by_id,
     update_account_balance_with_versioning,
     update_market_with_versioning,
     update_position_price,
+    upsert_game_state,
 )
 
 __all__ = [
     "close_position",
     # Account balance CRUD
     "create_account_balance",
+    # Game state CRUD (ESPN, SCD Type 2)
+    "create_game_state",
     # Market CRUD
     "create_market",
     # Position CRUD
     "create_position",
     "create_settlement",
     "create_strategy",
+    # Team ranking CRUD (ESPN)
+    "create_team_ranking",
     # Trade CRUD
     "create_trade",
+    # Venue CRUD (ESPN)
+    "create_venue",
     "execute_query",
     "fetch_all",
     "fetch_one",
     # Connection utilities
     "get_connection",
+    "get_current_game_state",
     "get_current_market",
     "get_current_positions",
+    "get_current_rankings",
     "get_cursor",
     # Environment safety (Issue #161)
     "get_environment",
+    "get_game_state_history",
+    "get_games_by_date",
+    "get_live_games",
     "get_market_history",
     "get_recent_trades",
     "get_strategy_by_name_and_version",
+    "get_team_rankings",
     "get_trades_by_market",
+    "get_venue_by_espn_id",
+    "get_venue_by_id",
     "protect_dangerous_operation",
     "require_environment",
     "update_account_balance_with_versioning",
     "update_market_with_versioning",
     "update_position_price",
+    "upsert_game_state",
 ]


### PR DESCRIPTION
## Summary
- Add 12 ESPN data model functions to `database/__init__.py` exports
- Makes ESPN CRUD operations accessible via standard package imports:
  - **Venue Operations**: `create_venue`, `get_venue_by_espn_id`, `get_venue_by_id`
  - **Game States (SCD Type 2)**: `create_game_state`, `upsert_game_state`, `get_current_game_state`, `get_game_state_history`, `get_live_games`, `get_games_by_date`
  - **Team Rankings**: `create_team_ranking`, `get_team_rankings`, `get_current_rankings`

## Discovery
All ESPN CRUD functions already exist in `crud_operations.py` (lines 1883-2642) with:
- 24 comprehensive unit tests in `test_crud_operations_unit.py`
- 95.20% test coverage on crud_operations.py
- Full SCD Type 2 implementation for game state versioning

## Test Plan
- [x] Unit tests: 24/24 ESPN CRUD tests passing
- [x] Full test suite: 1331/1331 tests passing
- [x] Coverage: 95.20% on crud_operations.py

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)