### PR TITLE
docs: Update BasePoller references in Phase 2.5 documentation

### DIFF
--- a/docs/foundation/DEVELOPMENT_PHASES_V1.9.md
+++ b/docs/foundation/DEVELOPMENT_PHASES_V1.9.md
@@ -1221,8 +1221,11 @@ python scripts/validate_phase_start.py --phase 2
 
 ### Reference
 - GitHub Issue #193: Phase 2.5 - Live Data Collection Service
-- `src/precog/schedulers/market_updater.py`: MarketUpdater class
-- `src/precog/schedulers/kalshi_poller.py`: KalshiMarketPoller class
+- **ADR-103**: BasePoller Unified Design Pattern (Template Method for polling infrastructure)
+- **REQ-SCHED-003**: Base Poller Infrastructure (generic statistics, thread-safe operations)
+- `src/precog/schedulers/base_poller.py`: BasePoller abstract class (shared infrastructure)
+- `src/precog/schedulers/espn_game_poller.py`: ESPNGamePoller class (extends BasePoller)
+- `src/precog/schedulers/kalshi_poller.py`: KalshiMarketPoller class (extends BasePoller)
 - `src/precog/validation/espn_validation.py`: Data validation
 
 ---

--- a/docs/guides/LIVE_DATA_INTEGRATION_GUIDE_V1.0.md
+++ b/docs/guides/LIVE_DATA_INTEGRATION_GUIDE_V1.0.md
@@ -6,8 +6,8 @@
 **Last Updated:** 2025-12-07
 **Status:** Complete
 **Phase:** 2.5 (Live Data Collection Service)
-**Related ADRs:** ADR-100 (Service Supervisor Pattern), ADR-029 (ESPN Data Model)
-**Related Requirements:** REQ-SCHED-001, REQ-SCHED-002, REQ-DATA-001, REQ-OBSERV-003
+**Related ADRs:** ADR-100 (Service Supervisor Pattern), ADR-103 (BasePoller Unified Design), ADR-029 (ESPN Data Model)
+**Related Requirements:** REQ-SCHED-001, REQ-SCHED-002, REQ-SCHED-003, REQ-DATA-001, REQ-OBSERV-003
 ---
 
 ## Overview
@@ -32,8 +32,8 @@ This guide documents the live data integration architecture for the Precog predi
            │                                 │                                 │
            ▼                                 ▼                                 ▼
 ┌─────────────────────┐          ┌─────────────────────┐          ┌─────────────────────┐
-│   ESPN MarketUpdater │         │  Kalshi REST Poller  │         │ Kalshi WebSocket    │
-│   (APScheduler)      │         │   (APScheduler)      │         │  (Real-time)        │
+│   ESPNGamePoller     │         │  KalshiMarketPoller  │         │ KalshiWebSocket     │
+│   (BasePoller)       │         │   (BasePoller)       │         │  Handler            │
 │   15s poll interval  │         │   30s poll interval  │         │  <1s latency        │
 └──────────┬──────────┘          └──────────┬──────────┘          └──────────┬──────────┘
            │                                 │                                 │


### PR DESCRIPTION
## Summary

- Add ADR-103 (BasePoller Unified Design) and REQ-SCHED-003 references
- Rename MarketUpdater -> ESPNGamePoller in code references
- Update architecture diagram to show BasePoller hierarchy
- Fix file path references: market_updater.py -> espn_game_poller.py

## Changes

**DEVELOPMENT_PHASES_V1.9.md:**
- Added ADR-103 and REQ-SCHED-003 to Phase 2.5 Reference section
- Updated file paths to reflect renamed poller classes

**LIVE_DATA_INTEGRATION_GUIDE_V1.0.md:**
- Added ADR-103 and REQ-SCHED-003 to Related ADRs/Requirements
- Updated architecture diagram: ESPN MarketUpdater -> ESPNGamePoller (BasePoller)

## Test Plan

- [x] Documentation validation passed
- [x] No code changes (docs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)