### PR TITLE
bugfix: Fix poll-once CLI key names to match poller return values

### DIFF
--- a/main.py
+++ b/main.py
@@ -2795,8 +2795,8 @@ def scheduler_poll_once(
             updater = MarketUpdater(leagues=league_list)
             result = updater.poll_once()
             console.print(
-                f"[green][OK] ESPN: {result['games_fetched']} games fetched, "
-                f"{result['games_updated']} updated[/green]"
+                f"[green][OK] ESPN: {result['items_fetched']} games fetched, "
+                f"{result['items_updated']} updated[/green]"
             )
         except Exception as e:
             console.print(f"[red][FAIL] ESPN poll failed: {e}[/red]")
@@ -2814,8 +2814,8 @@ def scheduler_poll_once(
             )
             result = poller.poll_once()
             console.print(
-                f"[green][OK] Kalshi: {result['markets_fetched']} markets fetched, "
-                f"{result['markets_updated']} updated, {result['markets_created']} created[/green]"
+                f"[green][OK] Kalshi: {result['items_fetched']} markets fetched, "
+                f"{result['items_updated']} updated, {result['items_created']} created[/green]"
             )
             poller.kalshi_client.close()
         except ValueError as e:


### PR DESCRIPTION
## Summary
- Fixed key name mismatch in `scheduler poll-once` CLI command
- ESPN: Changed from `games_fetched`/`games_updated` to `items_fetched`/`items_updated`  
- Kalshi: Changed from `markets_fetched`/`markets_updated`/`markets_created` to `items_*`

## Problem
The `scheduler poll-once` command was failing with `KeyError: 'games_fetched'` because:
- CLI expected `games_fetched`, `games_updated`, `markets_fetched`, etc.
- BasePoller standard returns `items_fetched`, `items_updated`, `items_created`

## Solution
Updated CLI to use the correct key names that match what the pollers actually return.

## Test plan
- [x] Manual test: `python main.py scheduler poll-once --no-kalshi --leagues nfl` works
- [x] 241 scheduler unit tests passing
- [x] 3,018 total tests passing (all 8 test types)

## Verification
```bash
$ python main.py scheduler poll-once --no-kalshi --leagues nfl
Polling ESPN (nfl)...
[OK] ESPN: 16 games fetched, 16 updated
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)