### PR TITLE
docs: Update DEVELOPMENT_PHASES V1.10→V1.11 - Phase 2.5 CLI commands complete

### DIFF
--- a/docs/foundation/ARCHITECTURE_DECISIONS_V2.29.md
+++ b/docs/foundation/ARCHITECTURE_DECISIONS_V2.29.md
@@ -6797,7 +6797,7 @@ CREATE TABLE brier_score_metrics (...);
 
 **References:**
 - `docs/database/DATABASE_SCHEMA_SUMMARY_V1.12.md` (Section 8: Performance Tracking & Analytics)
-- `docs/foundation/DEVELOPMENT_PHASES_V1.10.md` (Phase 2 Task #5: Performance Metrics Infrastructure)
+- `docs/foundation/DEVELOPMENT_PHASES_V1.11.md` (Phase 2 Task #5: Performance Metrics Infrastructure)
 - `docs/utility/STRATEGIC_WORK_ROADMAP_V1.1.md` (STRAT-026 implementation guidance)
 
 ---
@@ -7554,7 +7554,7 @@ Cons:
 ### References
 
 - `docs/database/DATABASE_SCHEMA_SUMMARY_V1.12.md` (Section 8: Performance Tracking & Analytics)
-- `docs/foundation/DEVELOPMENT_PHASES_V1.10.md` (Phase 2 Task #5: Performance Metrics Infrastructure)
+- `docs/foundation/DEVELOPMENT_PHASES_V1.11.md` (Phase 2 Task #5: Performance Metrics Infrastructure)
 - `docs/utility/STRATEGIC_WORK_ROADMAP_V1.1.md` (STRAT-026 implementation guidance)
 
 ---
@@ -8321,7 +8321,7 @@ WebSocket for Position Monitoring (real-time):
 
 ### References
 
-- `docs/foundation/DEVELOPMENT_PHASES_V1.10.md` (Phase 7 Task #2: Frontend Development)
+- `docs/foundation/DEVELOPMENT_PHASES_V1.11.md` (Phase 7 Task #2: Frontend Development)
 - `docs/database/DATABASE_SCHEMA_SUMMARY_V1.12.md` (Section 8.9: Materialized Views)
 - Next.js Documentation: https://nextjs.org/docs
 - Recharts Documentation: https://recharts.org/
@@ -9243,7 +9243,7 @@ def run_holdout_validation(
 - `docs/guides/MODEL_EVALUATION_GUIDE_V1.0.md` (implementation guide - to be created)
 - `docs/foundation/MASTER_REQUIREMENTS_V2.22.md` (REQ-MODEL-EVAL-001, REQ-MODEL-EVAL-002)
 - `docs/foundation/STRATEGIC_WORK_ROADMAP_V1.1.md` (STRAT-027)
-- `docs/foundation/DEVELOPMENT_PHASES_V1.10.md` (Phase 2 Task #3, Phase 6 Task #1)
+- `docs/foundation/DEVELOPMENT_PHASES_V1.11.md` (Phase 2 Task #3, Phase 6 Task #1)
 - `docs/database/DATABASE_SCHEMA_SUMMARY_V1.12.md` (Section 8.7: Evaluation Runs Table)
 
 ---
@@ -9966,7 +9966,7 @@ ON position_risk_by_strategy(league, strategy_name);
 - `docs/guides/DASHBOARD_DEVELOPMENT_GUIDE_V1.0.md` (React dashboard + API integration - to be created)
 - `docs/foundation/MASTER_REQUIREMENTS_V2.22.md` (REQ-ANALYTICS-003, REQ-REPORTING-001)
 - `docs/foundation/STRATEGIC_WORK_ROADMAP_V1.1.md` (STRAT-028)
-- `docs/foundation/DEVELOPMENT_PHASES_V1.10.md` (Phase 6 Task #3, Phase 7 Task #2)
+- `docs/foundation/DEVELOPMENT_PHASES_V1.11.md` (Phase 6 Task #3, Phase 7 Task #2)
 - `docs/database/DATABASE_SCHEMA_SUMMARY_V1.12.md` (Section 8.8: Materialized Views Reference)
 
 ---
@@ -10797,7 +10797,7 @@ print(f"Required sample size: {n} trades per group ({n*2} total)")
 - `docs/guides/ANALYTICS_ARCHITECTURE_GUIDE_V1.0.md` (includes A/B testing architecture)
 - `docs/foundation/MASTER_REQUIREMENTS_V2.22.md` (REQ-ANALYTICS-004, REQ-VALIDATION-003)
 - `docs/foundation/STRATEGIC_WORK_ROADMAP_V1.1.md` (STRAT-029, STRAT-030)
-- `docs/foundation/DEVELOPMENT_PHASES_V1.10.md` (Phase 7 Task #3, Phase 8 Task #2)
+- `docs/foundation/DEVELOPMENT_PHASES_V1.11.md` (Phase 7 Task #3, Phase 8 Task #2)
 - `docs/database/DATABASE_SCHEMA_SUMMARY_V1.12.md` (Section 8.9: A/B Tests Table)
 
 ---
@@ -11713,7 +11713,7 @@ CREATE TABLE strategies (
 ### References
 
 - `docs/database/DATABASE_SCHEMA_SUMMARY_V1.12.md` (edges table schema)
-- `docs/foundation/DEVELOPMENT_PHASES_V1.10.md` (Phase 1.5 manager components)
+- `docs/foundation/DEVELOPMENT_PHASES_V1.11.md` (Phase 1.5 manager components)
 - `src/precog/trading/model_manager.py` (edge calculation logic - Phase 1.5 implementation)
 - `src/precog/trading/strategy_manager.py` (edge query logic - Phase 1.5 implementation)
 

--- a/docs/foundation/DEVELOPMENT_PHASES_V1.11.md
+++ b/docs/foundation/DEVELOPMENT_PHASES_V1.11.md
@@ -1,9 +1,17 @@
 # Development Phases & Roadmap
 
 ---
-**Version:** 1.10
-**Last Updated:** 2025-12-09
+**Version:** 1.11
+**Last Updated:** 2025-12-15
 **Status:** ✅ Current
+**Changes in v1.11:**
+- **PHASE 2.5 CLI COMPLETE**: All scheduler CLI commands implemented and verified
+  - `scheduler start` - Start background data polling (simple + supervised modes)
+  - `scheduler stop` - Graceful shutdown of scheduler
+  - `scheduler status` - Show running jobs, last poll times
+  - `scheduler poll-once` - Single poll execution (bonus command)
+- **BUGFIX PR #231**: Fixed poll-once key names (`items_fetched` vs `games_fetched`)
+- **DELIVERABLES UPDATED**: CLI commands + main.py scheduler group marked complete
 **Changes in v1.10:**
 - **DEF-P2.5-007 ADDED**: Two-Axis Environment Configuration deferred task (Issue #202, ADR-105, HIGH priority)
 - **DEFERRED DOCS UPDATED**: `docs/utility/PHASE_2.5_DEFERRED_TASKS_V1.0.md` -> V1.1 (7 deferred tasks total)
@@ -1181,10 +1189,11 @@ python scripts/validate_phase_start.py --phase 2
 ### Tasks
 
 #### 1. CLI Scheduler Commands (Day 1-2)
-- [  ] `scheduler start` - Start background data polling
-- [  ] `scheduler stop` - Graceful shutdown of scheduler
-- [  ] `scheduler status` - Show running jobs, last poll times
-- [  ] Rich console output with job status tables
+- [✅] `scheduler start` - Start background data polling
+- [✅] `scheduler stop` - Graceful shutdown of scheduler
+- [✅] `scheduler status` - Show running jobs, last poll times
+- [✅] Rich console output with job status tables
+- [✅] `scheduler poll-once` - Single poll execution (bonus command)
 
 #### 2. Service Runner Script (Day 2-3)
 - [✅] `scripts/run_data_collector.py` - Long-running service entry point (ServiceSupervisor pattern)
@@ -1232,11 +1241,11 @@ python scripts/validate_phase_start.py --phase 2
 - No overlap: Seeder handles past seasons, Poller handles current games
 
 ### Deliverables
-- [  ] CLI commands: `scheduler start`, `scheduler stop`, `scheduler status`
+- [✅] CLI commands: `scheduler start`, `scheduler stop`, `scheduler status`, `poll-once`
 - [✅] Service runner script with graceful shutdown (ServiceSupervisor pattern, ADR-100)
 - [  ] Kalshi production configuration
 - [⏭️] Data monitoring/alerting - **DEFERRED** to Phase 4 (CloudWatch/ELK, REQ-OBSERV-003)
-- [  ] Updated main.py with scheduler command group
+- [✅] Updated main.py with scheduler command group
 
 ### Success Criteria
 - [  ] Scheduler runs continuously for 24+ hours without failure

--- a/docs/foundation/DEVELOPMENT_PHILOSOPHY_V1.3.md
+++ b/docs/foundation/DEVELOPMENT_PHILOSOPHY_V1.3.md
@@ -987,7 +987,7 @@ def is_market_tradeable(m):
 
 2. **Cascade to:**
    - REQUIREMENT_INDEX.md (add to table)
-   - DEVELOPMENT_PHASES_V1.10.md (add to phase tasks)
+   - DEVELOPMENT_PHASES_V1.11.md (add to phase tasks)
    - MASTER_INDEX_V2.11.md (update version if renamed)
    - SESSION_HANDOFF.md (document change)
 
@@ -2120,7 +2120,7 @@ Logger module was Phase 1 deliverable but missing from coverage targets checklis
 **Related Documents:**
 - `CLAUDE.md` Section 3, Step 2 (Phase start coverage validation)
 - `CLAUDE.md` Section 9, Step 1 (Phase completion coverage verification)
-- `DEVELOPMENT_PHASES_V1.10.md` (Phase-specific coverage targets)
+- `DEVELOPMENT_PHASES_V1.11.md` (Phase-specific coverage targets)
 
 ---
 

--- a/docs/foundation/MASTER_INDEX_V2.50.md
+++ b/docs/foundation/MASTER_INDEX_V2.50.md
@@ -442,7 +442,7 @@ Core architecture, requirements, and system design documents.
 | **REQUIREMENT_INDEX_V1.14.md** | ✅ | v1.14 | `/docs/foundation/` | 0 | All phases | 🔴 Critical | Systematic catalog of all 128 requirements (REQ-{CATEGORY}-{NUMBER}) - **UPDATED V1.14** (added REQ-SCHED-003 for BasePoller Unified Design Pattern; 127 → 128 total requirements) |
 | **ADR_INDEX_V1.22.md** | ✅ | v1.22 | `/docs/foundation/` | 0 | All phases | 🔴 Critical | Systematic catalog of all 106 architecture decisions - **UPDATED V1.22** (added ADR-105 for Two-Axis Environment Configuration; 105 → 106 total ADRs) |
 | **GLOSSARY.md** | ✅ | n/a | `/docs/foundation/` | 0 | All phases | 🟢 Medium | Terminology reference (living document, no version) |
-| **DEVELOPMENT_PHASES_V1.10.md** | ✅ | v1.10 | `/docs/foundation/` | 0 | All phases | 🟡 High | Complete roadmap Phase 0-10 - **UPDATED V1.10** (Added DEF-P2.5-007 deferred task for Two-Axis Environment Config) |
+| **DEVELOPMENT_PHASES_V1.11.md** | ✅ | v1.10 | `/docs/foundation/` | 0 | All phases | 🟡 High | Complete roadmap Phase 0-10 - **UPDATED V1.10** (Added DEF-P2.5-007 deferred task for Two-Axis Environment Config) |
 | **TESTING_STRATEGY_V3.8.md** | ✅ | v3.8 | `/docs/foundation/` | 2 | Phases 1-10 | 🔴 Critical | **UPDATED V3.8** - Property Tests with DB Access pattern: `@pytest.mark.database` for DB-dependent property tests (~25 tests) enabling parallel execution with unit tests (~43s savings); Mypy incremental caching (~27s savings); V3.7: Three-Layer E2E Testing Gap Pattern; V3.6: Fast Chaos Tests; V3.5: Test Failure Response; V3.4: CI-Safe Stress Testing; V3.3: Test Isolation; V3.2: All 8 test types MANDATORY |
 | **TEST_REQUIREMENTS_COMPREHENSIVE_V2.1.md** | ✅ | v2.1 | `/docs/foundation/` | 1.9 | Phases 1.5+ | 🔴 Critical | **UPDATED V2.1** - Added REQ-TEST-020 through REQ-TEST-024 (Test Isolation Requirements from Phase 1.9): transaction-based isolation, FK dependency chain management, cleanup fixture ordering, parallel execution safety, SCD Type 2 isolation; cross-references TEST_ISOLATION_PATTERNS_V1.1.md; V2.0: REQ-TEST-012-019 (8 test types, mock restrictions, fixture requirements, coverage standards) |
 | **VALIDATION_LINTING_ARCHITECTURE_V1.0.md** | ✅ | v1.0 | `/docs/foundation/` | 0.6c | Phases 0.6c-0.7 | 🟡 High | **NEW** - Code quality and documentation validation architecture (Phase 0.6c) |
@@ -532,7 +532,7 @@ Roadmap, timelines, and project management.
 
 | Document | Status | Version | Location | Phase | Phase Ties | Priority | Notes |
 |----------|--------|---------|----------|-------|------------|----------|-------|
-| **DEVELOPMENT_PHASES_V1.10.md** | ✅ | v1.10 | `/docs/foundation/` | 0.5 | All phases | 🟡 High | Phase 2.5 progress: Service Runner complete, added DEF-P2.5-007 - UPDATED V1.10 |
+| **DEVELOPMENT_PHASES_V1.11.md** | ✅ | v1.10 | `/docs/foundation/` | 0.5 | All phases | 🟡 High | Phase 2.5 progress: Service Runner complete, added DEF-P2.5-007 - UPDATED V1.10 |
 | **DEPLOYMENT_GUIDE_V1.0.md** | 🔵 | - | `/docs/deployment/` | 1 | Phase 1 ✅ | 🟡 High | Local/AWS deployment stubs |
 | **USER_GUIDE_V1.0.md** | 🔵 | - | `/docs/guides/` | 5 | Phase 5 ✅ | 🟢 Medium | CLI examples (edges-list, trade-execute) |
 | **DEVELOPER_ONBOARDING_V1.0.md** | 🔵 | - | `/docs/utility/` | 0 | Phase 0 ✅ | 🟡 High | Merged with ENVIRONMENT_CHECKLIST, onboarding steps |

--- a/docs/foundation/TESTING_STRATEGY_V3.8.md
+++ b/docs/foundation/TESTING_STRATEGY_V3.8.md
@@ -2122,7 +2122,7 @@ All critical paths tested:
 python -m pytest tests/ --cov=src/precog --cov-report=term-missing
 
 # Compare to DEVELOPMENT_PHASES targets
-grep "≥" docs/foundation/DEVELOPMENT_PHASES_V1.10.md
+grep "≥" docs/foundation/DEVELOPMENT_PHASES_V1.11.md
 
 # Verify gaps documented in PR descriptions
 gh pr list --state merged --search "merged:>=2025-11-01"
@@ -2170,7 +2170,7 @@ connection.py         81.82%  (target: 80%, gap: +1.82pp ✅)
 - Write tests before/during implementation (TDD/test-driven)
 
 ### Cross-References
-- **DEVELOPMENT_PHASES_V1.10.md:** Phase-specific module targets
+- **DEVELOPMENT_PHASES_V1.11.md:** Phase-specific module targets
 - **Phase Completion Protocol (CLAUDE.md Step 5):** Coverage validation checklist
 - **Pattern 10:** Property-Based Testing (achieving high coverage with generated inputs)
 - **DEVELOPMENT_PHILOSOPHY_V1.3.md:** Test-Driven Development principle


### PR DESCRIPTION
## Summary
- Updated DEVELOPMENT_PHASES from V1.10 to V1.11
- Marked all scheduler CLI commands as complete:
  - `scheduler start` (simple + supervised modes)
  - `scheduler stop` (graceful shutdown)  
  - `scheduler status` (job status display)
  - `scheduler poll-once` (single poll execution - bonus command)
- Updated deliverables section with CLI completion
- Documented PR #231 bugfix for poll-once key names
- Updated cross-references in ARCHITECTURE_DECISIONS, MASTER_INDEX, TESTING_STRATEGY, DEVELOPMENT_PHILOSOPHY

## Phase 2.5 Status: ~95% Complete

| Deliverable | Status |
|-------------|--------|
| CLI scheduler commands | ✅ Complete |
| Service runner script | ✅ Complete |
| ServiceSupervisor pattern | ✅ Complete |
| BasePoller infrastructure | ✅ Complete |
| ESPNGamePoller | ✅ Complete |
| KalshiMarketPoller | ✅ Complete |
| SeedingManager | ✅ Complete |
| Historical Elo seeding | ✅ Complete (31,636 records) |
| Kalshi production config | ⏸️ Pending |
| 24-hour reliability test | ⏸️ Pending |

## Test plan
- [x] Documentation validation passes (pre-commit hook)
- [x] All cross-references updated and valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)