### PR TITLE
fix: Add fetch_all_series() to eliminate silent series truncation

### DIFF
--- a/src/precog/api_connectors/kalshi_client.py
+++ b/src/precog/api_connectors/kalshi_client.py
@@ -1282,7 +1282,7 @@ class KalshiClient:
         self,
         category: str | None = None,
         status: str | None = None,
-        limit: int = 100,
+        limit: int | None = None,
         cursor: str | None = None,
     ) -> tuple[list[SeriesData], str | None]:
         """
@@ -1291,7 +1291,8 @@ class KalshiClient:
         Args:
             category: Filter by category (e.g., "sports", "politics", "economics")
             status: Filter by status ("active", "inactive", "closed")
-            limit: Max results per page (default 100)
+            limit: Max results per page. None means no client-side truncation
+                   (return all results from the API response).
             cursor: Pagination cursor
 
         Returns:
@@ -1304,10 +1305,18 @@ class KalshiClient:
                 - Events (individual games, elections, etc.)
                   - Markets (specific outcome contracts)
 
+            Client-Side vs Server-Side Limiting:
+            - The Kalshi /series endpoint currently ignores the limit param
+              and returns all series in one response (~9,000+)
+            - Client-side truncation is only applied when limit is explicitly set
+            - Use limit=None (default) to get all results without truncation
+
         Reference: docs/api-integration/API_INTEGRATION_GUIDE_V2.0.md
         """
-        params: dict[str, Any] = {"limit": limit}
+        params: dict[str, Any] = {}
 
+        if limit is not None:
+            params["limit"] = limit
         if category:
             params["category"] = category
         if status:
@@ -1331,8 +1340,8 @@ class KalshiClient:
                 s for s in series_list if s.get("category", "").lower() == category.lower()
             ]
 
-        # Apply limit client-side (API may return more than requested)
-        if limit and len(series_list) > limit:
+        # Apply limit client-side only when explicitly requested
+        if limit is not None and len(series_list) > limit:
             series_list = series_list[:limit]
 
         logger.info(
@@ -1350,19 +1359,21 @@ class KalshiClient:
         self,
         category: str | None = None,
         status: str | None = None,
-        limit: int = 100,
+        limit: int | None = None,
         cursor: str | None = None,
     ) -> list[SeriesData]:
         """
-        Get available market series.
+        Get available market series (single page).
 
         A series groups related markets (e.g., KXNFLGAME contains all NFL game markets).
         Use this to discover what series are available for trading.
 
+        For fetching all series with automatic pagination, use fetch_all_series().
+
         Args:
             category: Filter by category (e.g., "sports", "politics", "economics")
             status: Filter by status ("active", "inactive", "closed")
-            limit: Max results per page (default 100)
+            limit: Max results to return. None (default) means no truncation.
             cursor: Pagination cursor
 
         Returns:
@@ -1399,6 +1410,88 @@ class KalshiClient:
             cursor=cursor,
         )
         return series_list
+
+    def fetch_all_series(
+        self,
+        category: str | None = None,
+        status: str | None = None,
+        max_pages: int = 50,
+    ) -> list[SeriesData]:
+        """
+        Fetch ALL series with automatic pagination.
+
+        This method handles Kalshi's pagination automatically, chasing cursors
+        until no more data is available. Currently the /series endpoint returns
+        all results in one response, but this method is future-proof against
+        server-side pagination being added.
+
+        Args:
+            category: Filter by category (e.g., "Sports", "politics", "economics")
+            status: Filter by status ("active", "inactive", "closed")
+            max_pages: Maximum pages to fetch (default 50, safety limit).
+
+        Returns:
+            List of all SeriesData matching the filter criteria.
+
+        Example:
+            >>> client = KalshiClient("demo")
+            >>> # Fetch all Sports series (no truncation)
+            >>> sports_series = client.fetch_all_series(category="Sports")
+            >>> print(f"Total sports series: {len(sports_series)}")
+            Total sports series: 1533
+
+        Educational Note:
+            Why cursor-chasing instead of a large limit?
+            - The Kalshi /series endpoint currently returns all results in one
+              response (cursor=None), so this typically completes in 1 request
+            - However, if Kalshi adds server-side pagination later, this method
+              will automatically handle it without code changes
+            - Follows the same pattern as fetch_all_markets() for consistency
+
+        Reference: docs/api-integration/API_INTEGRATION_GUIDE_V2.0.md
+        """
+        all_series: list[SeriesData] = []
+        cursor: str | None = None
+        pages_fetched = 0
+
+        while pages_fetched < max_pages:
+            series_page, cursor = self._get_series_page(
+                category=category,
+                status=status,
+                cursor=cursor,
+            )
+
+            if not series_page:
+                break
+
+            all_series.extend(series_page)
+            pages_fetched += 1
+
+            # No cursor means last page
+            if not cursor:
+                break
+
+            logger.debug(
+                f"Fetched page {pages_fetched} of series: "
+                f"{len(series_page)} series, more pages available"
+            )
+
+        if pages_fetched >= max_pages:
+            logger.warning(
+                f"Hit max_pages limit ({max_pages}) while fetching series. "
+                f"Some series may be missing. Total fetched: {len(all_series)}"
+            )
+
+        logger.info(
+            f"Fetched {len(all_series)} total series across {pages_fetched} page(s)",
+            extra={
+                "total_count": len(all_series),
+                "pages": pages_fetched,
+                "category": category,
+            },
+        )
+
+        return all_series
 
     def fetch_all_markets(
         self,
@@ -1580,8 +1673,8 @@ class KalshiClient:
         """
         target_sports = sports or self.DEFAULT_SPORTS
 
-        # First, get all Sports category series
-        all_series = self.get_series(category="Sports", limit=200)
+        # Fetch all Sports category series (no truncation)
+        all_series = self.fetch_all_series(category="Sports")
 
         # Filter by sport using both tags and ticker prefixes
         filtered_series: list[SeriesData] = []

--- a/src/precog/database/seeding/kalshi_historical_cache.py
+++ b/src/precog/database/seeding/kalshi_historical_cache.py
@@ -387,7 +387,7 @@ def fetch_and_cache_series(
             return cached
 
     # Fetch series and convert TypedDict to plain dict for JSON serialization
-    series_list = client.get_series(category=category, limit=200)
+    series_list = client.fetch_all_series(category=category)
     series_dicts: list[dict[str, Any]] = [dict(s) for s in series_list]
 
     # Save to cache

--- a/src/precog/schedulers/kalshi_poller.py
+++ b/src/precog/schedulers/kalshi_poller.py
@@ -258,11 +258,10 @@ class KalshiMarketPoller(BasePoller):
         try:
             # Fetch series from API
             if series_tickers:
-                # Fetch all Sports series and filter to our target tickers
-                # We use category="Sports" with a large limit because the generic
-                # get_series() returns alphabetically and our tickers may be
-                # beyond the first 100 results
-                all_sports = self.kalshi_client.get_series(category="Sports", limit=200)
+                # Fetch all Sports series and filter to our target tickers.
+                # Uses fetch_all_series() with cursor-chasing to ensure we get
+                # every series without client-side truncation.
+                all_sports = self.kalshi_client.fetch_all_series(category="Sports")
                 target_set = set(series_tickers)
                 api_series_list = [s for s in all_sports if s.get("ticker") in target_set]
 

--- a/tests/integration/api_connectors/test_kalshi_series_integration.py
+++ b/tests/integration/api_connectors/test_kalshi_series_integration.py
@@ -1,0 +1,223 @@
+"""
+Integration tests for Kalshi series fetching and pagination.
+
+Tests the fetch_all_series() cursor-chasing pagination and get_series()
+single-page fetch. Uses mocked HTTP responses to verify:
+- Cursor-chasing across multiple pages
+- Client-side category filtering
+- No silent truncation (the bug this fixes)
+- Empty response handling
+- max_pages safety limit
+
+Pattern 13 Exception: External API mock
+These tests mock HTTP responses to test API client behavior.
+
+Related Requirements:
+    - REQ-API-001: Kalshi API Integration
+"""
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from precog.api_connectors.kalshi_client import KalshiClient
+
+
+def _make_mock_client() -> KalshiClient:
+    """Create a KalshiClient with mocked auth (no real credentials needed)."""
+    mock_auth = MagicMock()
+    mock_auth.get_headers.return_value = {"Authorization": "Bearer mock"}
+    return KalshiClient(
+        environment="demo",
+        auth=mock_auth,
+        session=MagicMock(),
+        rate_limiter=MagicMock(),
+    )
+
+
+def _mock_series(ticker: str, category: str = "Sports") -> dict:
+    """Create a minimal series dict for testing."""
+    return {
+        "ticker": ticker,
+        "title": f"Test {ticker}",
+        "category": category,
+        "tags": [],
+    }
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestFetchAllSeries:
+    """Tests for fetch_all_series() cursor-chasing pagination."""
+
+    def test_single_page_no_cursor(self) -> None:
+        """fetch_all_series returns all results when API has one page (cursor=None)."""
+        client = _make_mock_client()
+        series_data = [_mock_series("KXNFLGAME"), _mock_series("KXNBAGAME")]
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"series": series_data, "cursor": ""}
+        mock_response.raise_for_status = Mock()
+        client.session.request.return_value = mock_response
+
+        result = client.fetch_all_series(category="Sports")
+
+        assert len(result) == 2
+        assert result[0]["ticker"] == "KXNFLGAME"
+        assert result[1]["ticker"] == "KXNBAGAME"
+
+    def test_cursor_chasing_across_pages(self) -> None:
+        """fetch_all_series follows cursors until no more pages.
+
+        Educational Note:
+            This simulates the scenario where Kalshi adds server-side pagination
+            to the /series endpoint. The method should chase cursors automatically,
+            returning the combined results from all pages.
+        """
+        client = _make_mock_client()
+
+        page1_response = Mock()
+        page1_response.status_code = 200
+        page1_response.json.return_value = {
+            "series": [_mock_series("KXNFLGAME"), _mock_series("KXNBAGAME")],
+            "cursor": "page2_cursor",
+        }
+        page1_response.raise_for_status = Mock()
+
+        page2_response = Mock()
+        page2_response.status_code = 200
+        page2_response.json.return_value = {
+            "series": [_mock_series("KXNHLGAME")],
+            "cursor": "",  # No more pages
+        }
+        page2_response.raise_for_status = Mock()
+
+        client.session.request.side_effect = [page1_response, page2_response]
+
+        result = client.fetch_all_series(category="Sports")
+
+        assert len(result) == 3
+        assert [s["ticker"] for s in result] == ["KXNFLGAME", "KXNBAGAME", "KXNHLGAME"]
+        assert client.session.request.call_count == 2
+
+    def test_max_pages_safety_limit(self) -> None:
+        """fetch_all_series stops at max_pages to prevent infinite loops."""
+        client = _make_mock_client()
+
+        # Every page returns data + cursor (infinite pagination)
+        infinite_response = Mock()
+        infinite_response.status_code = 200
+        infinite_response.json.return_value = {
+            "series": [_mock_series("KXTEST")],
+            "cursor": "next_page",
+        }
+        infinite_response.raise_for_status = Mock()
+        client.session.request.return_value = infinite_response
+
+        result = client.fetch_all_series(max_pages=3)
+
+        assert len(result) == 3  # 1 series per page * 3 pages
+        assert client.session.request.call_count == 3
+
+    def test_empty_first_page(self) -> None:
+        """fetch_all_series returns empty list when API returns no series."""
+        client = _make_mock_client()
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"series": [], "cursor": ""}
+        mock_response.raise_for_status = Mock()
+        client.session.request.return_value = mock_response
+
+        result = client.fetch_all_series(category="Sports")
+
+        assert result == []
+
+    def test_category_filtering_applied(self) -> None:
+        """fetch_all_series applies client-side category filtering.
+
+        Educational Note:
+            Kalshi's /series endpoint ignores the category param and returns
+            all series. Client-side filtering in _get_series_page() ensures
+            only the requested category is returned.
+        """
+        client = _make_mock_client()
+
+        mixed_series = [
+            _mock_series("KXNFLGAME", category="Sports"),
+            _mock_series("KXPRES2028", category="Politics"),
+            _mock_series("KXNBAGAME", category="Sports"),
+        ]
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"series": mixed_series, "cursor": ""}
+        mock_response.raise_for_status = Mock()
+        client.session.request.return_value = mock_response
+
+        result = client.fetch_all_series(category="Sports")
+
+        assert len(result) == 2
+        assert all(s["category"] == "Sports" for s in result)
+
+    def test_no_silent_truncation(self) -> None:
+        """fetch_all_series does NOT truncate results (the bug this fixes).
+
+        Educational Note:
+            The old code used get_series(limit=200) which client-side truncated
+            1,533 Sports series to 200. fetch_all_series() has no limit param
+            and returns everything the API provides.
+        """
+        client = _make_mock_client()
+
+        # Simulate 500 series in one response (more than old limit=200)
+        large_series = [_mock_series(f"KX{i:04d}", category="Sports") for i in range(500)]
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"series": large_series, "cursor": ""}
+        mock_response.raise_for_status = Mock()
+        client.session.request.return_value = mock_response
+
+        result = client.fetch_all_series(category="Sports")
+
+        assert len(result) == 500  # All 500, not truncated to 200
+
+
+@pytest.mark.integration
+@pytest.mark.api
+class TestGetSeriesLimitBehavior:
+    """Tests for get_series() limit parameter behavior."""
+
+    def test_limit_none_returns_all(self) -> None:
+        """get_series with limit=None (default) returns all results."""
+        client = _make_mock_client()
+
+        series = [_mock_series(f"KX{i:03d}") for i in range(300)]
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"series": series, "cursor": ""}
+        mock_response.raise_for_status = Mock()
+        client.session.request.return_value = mock_response
+
+        result = client.get_series()
+
+        assert len(result) == 300  # No truncation
+
+    def test_explicit_limit_truncates(self) -> None:
+        """get_series with explicit limit truncates client-side."""
+        client = _make_mock_client()
+
+        series = [_mock_series(f"KX{i:03d}") for i in range(300)]
+
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"series": series, "cursor": ""}
+        mock_response.raise_for_status = Mock()
+        client.session.request.return_value = mock_response
+
+        result = client.get_series(limit=10)
+
+        assert len(result) == 10  # Explicitly truncated


### PR DESCRIPTION
## Summary

- Added `fetch_all_series()` method with cursor-chasing pagination, mirroring the existing `fetch_all_markets()` pattern
- Changed `get_series()` limit default from `int=100` to `int|None=None` — no client-side truncation unless explicitly requested
- Updated all 3 callers that used `get_series(limit=200)`: `get_sports_series()`, `sync_series()`, `fetch_and_cache_series()`
- Added 8 integration tests covering cursor-chasing, max_pages safety, category filtering, empty responses, and no-truncation regression

## Bug Fixed

`get_series(category="Sports", limit=200)` was silently truncating 1,533 Sports series to 200 via client-side limit in `_get_series_page()`. After sport-tag filtering, only ~81 series were returned — **87% data loss** with no errors or warnings.

## Test plan

- [x] 8 new integration tests pass (cursor-chasing, max_pages, filtering, no-truncation regression)
- [x] 32 existing poller integration tests pass  
- [x] 1,672 unit tests pass
- [x] Pre-push hook passes (275s)
- [x] Verified against live Kalshi Demo API: 607 sports series returned (was 81)

## Related

- Closes silent truncation bug discovered during API failure investigation
- #291: Companion markets truncation bug in `fetch_and_cache_markets()` (follow-up)
- #292: Manager integration tests fail under parallel execution (pre-existing, tracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)