### PR TITLE
fix: Implement get_active_market_count() with CRUD query

### DIFF
--- a/src/precog/database/crud_operations.py
+++ b/src/precog/database/crud_operations.py
@@ -1155,6 +1155,34 @@ def get_current_market(ticker: str) -> dict[str, Any] | None:
     return fetch_one(query, (ticker,))
 
 
+def count_open_markets() -> int:
+    """
+    Count markets with status='open' and row_current_ind=TRUE.
+
+    Returns:
+        Number of currently open markets in the database.
+
+    Educational Note:
+        Uses SCD Type 2 filtering (row_current_ind = TRUE) to count only
+        the current version of each market. Without this filter, historical
+        rows would inflate the count.
+
+    Example:
+        >>> count = count_open_markets()
+        >>> print(f"Tracking {count} open markets")
+    """
+    query = """
+        SELECT COUNT(*) AS count
+        FROM markets
+        WHERE status = 'open'
+          AND row_current_ind = TRUE
+    """
+    result = fetch_one(query)
+    if result is None:
+        return 0
+    return int(result["count"])
+
+
 def update_market_with_versioning(
     ticker: str,
     yes_price: Decimal | None = None,

--- a/src/precog/schedulers/kalshi_poller.py
+++ b/src/precog/schedulers/kalshi_poller.py
@@ -47,6 +47,7 @@ from typing import ClassVar
 from precog.api_connectors.kalshi_client import KalshiClient
 from precog.api_connectors.types import ProcessedMarketData, SeriesData
 from precog.database.crud_operations import (
+    count_open_markets,
     create_market,
     get_current_market,
     get_or_create_event,
@@ -700,8 +701,11 @@ class KalshiMarketPoller(BasePoller):
             This is useful for monitoring - if count drops to 0, it might
             indicate an API issue or that all markets have settled.
         """
-        # TODO: Add CRUD operation to count open markets
-        return 0
+        try:
+            return count_open_markets()
+        except Exception as e:
+            logger.error("Failed to get active market count: %s", e)
+            return 0
 
 
 # =============================================================================

--- a/tests/unit/schedulers/test_kalshi_poller.py
+++ b/tests/unit/schedulers/test_kalshi_poller.py
@@ -474,3 +474,38 @@ class TestKalshiPollerSignalHandlers:
         with patch("signal.signal"):
             # Should not raise
             poller_with_mock_client.setup_signal_handlers()
+
+
+# =============================================================================
+# Active Market Count Tests
+# =============================================================================
+
+
+class TestGetActiveMarketCount:
+    """Test get_active_market_count method."""
+
+    @pytest.mark.unit
+    @patch("precog.schedulers.kalshi_poller.count_open_markets")
+    def test_get_active_market_count_returns_db_count(self, mock_count, poller_with_mock_client):
+        """get_active_market_count delegates to count_open_markets CRUD function."""
+        mock_count.return_value = 42
+        assert poller_with_mock_client.get_active_market_count() == 42
+        mock_count.assert_called_once()
+
+    @pytest.mark.unit
+    @patch("precog.schedulers.kalshi_poller.count_open_markets")
+    def test_get_active_market_count_returns_zero_on_error(
+        self, mock_count, poller_with_mock_client
+    ):
+        """get_active_market_count returns 0 if DB query fails."""
+        mock_count.side_effect = Exception("DB connection failed")
+        assert poller_with_mock_client.get_active_market_count() == 0
+
+    @pytest.mark.unit
+    @patch("precog.schedulers.kalshi_poller.count_open_markets")
+    def test_get_active_market_count_returns_zero_when_no_markets(
+        self, mock_count, poller_with_mock_client
+    ):
+        """get_active_market_count returns 0 when no open markets exist."""
+        mock_count.return_value = 0
+        assert poller_with_mock_client.get_active_market_count() == 0


### PR DESCRIPTION
## Summary
- Replace TODO stub in `KalshiPoller.get_active_market_count()` that always returned `0`
- Add `count_open_markets()` CRUD function with SCD Type 2 filter (`row_current_ind = TRUE`)
- Error-resilient: returns `0` on DB failure instead of crashing the poller

Closes #288

## Test plan
- [x] 3 new unit tests: happy path, DB error handling, zero-count edge case
- [x] All 27 poller tests pass (24 existing + 3 new)
- [x] Pre-push validation passed (1,039 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)