### PR TITLE
fix: Switch poller to fetch_all_markets() for full pagination

### DIFF
--- a/src/precog/schedulers/kalshi_poller.py
+++ b/src/precog/schedulers/kalshi_poller.py
@@ -23,7 +23,7 @@ Educational Notes:
 ------------------
 Polling Frequency Considerations:
     - Kalshi rate limit: 100 requests/minute
-    - get_markets() with pagination may use 2-3 requests per poll
+    - fetch_all_markets() handles pagination internally (2-3 requests per poll)
     - 30-60 second intervals allow ~2-3 polls per minute (safe margin)
     - Don't poll faster than 30s - wastes API quota without benefit
 
@@ -102,7 +102,7 @@ class KalshiMarketPoller(BasePoller):
     MIN_POLL_INTERVAL: ClassVar[int] = 5  # seconds (rate limit: 100 req/min)
     DEFAULT_POLL_INTERVAL: ClassVar[int] = 15  # seconds (balanced for near real-time)
     DEFAULT_SERIES_TICKERS: ClassVar[list[str]] = ["KXNFLGAME"]
-    MAX_MARKETS_PER_REQUEST: ClassVar[int] = 200  # Kalshi API limit
+    # Note: pagination is handled internally by fetch_all_markets()
 
     # Rate limit guidance:
     # - Kalshi allows 100 requests/minute
@@ -479,44 +479,19 @@ class KalshiMarketPoller(BasePoller):
             requests.HTTPError: If API request fails after retries.
 
         Educational Note:
-            Kalshi limits responses to 200 markets max. We use cursor-based
-            pagination to fetch all markets in a series. Most NFL series
-            have 50-100 markets, so pagination is rarely needed.
+            Kalshi limits responses to 200 markets per page. We use
+            fetch_all_markets() which handles cursor-based pagination
+            internally, ensuring ALL markets are fetched regardless of
+            how many pages exist.
         """
         logger.debug("Polling Kalshi series: %s", series_ticker)
 
-        all_markets: list[ProcessedMarketData] = []
-        cursor: str | None = None
-
-        # Paginate through all markets in the series
-        # Uses get_markets() with size-based heuristic for backward compatibility.
-        # For full cursor-based pagination, use client.fetch_all_markets() directly.
-        while True:
-            markets = self.kalshi_client.get_markets(
-                series_ticker=series_ticker,
-                limit=self.MAX_MARKETS_PER_REQUEST,
-                cursor=cursor,
-            )
-
-            if not markets:
-                break
-
-            all_markets.extend(markets)
-
-            # If we got fewer than the limit, this is the last page
-            if len(markets) < self.MAX_MARKETS_PER_REQUEST:
-                break
-
-            # For series with exactly MAX_MARKETS_PER_REQUEST results,
-            # we cannot determine if more pages exist without cursor access.
-            # Most sports series have <200 markets, so this is acceptable.
-            # For guaranteed full pagination, use fetch_all_markets() instead.
-            logger.debug(
-                "Fetched %d markets for %s (at page limit, may have more)",
-                len(markets),
-                series_ticker,
-            )
-            break
+        # Use fetch_all_markets() for guaranteed full pagination.
+        # This handles cursor-chasing internally, returning ALL markets
+        # regardless of how many pages exist.
+        all_markets = self.kalshi_client.fetch_all_markets(
+            series_tickers=[series_ticker],
+        )
 
         markets_updated = 0
         markets_created = 0

--- a/tests/chaos/schedulers/test_kalshi_poller_chaos.py
+++ b/tests/chaos/schedulers/test_kalshi_poller_chaos.py
@@ -55,7 +55,7 @@ class TestKalshiMarketPollerChaos:
                 raise Exception("Random API failure")
             return []
 
-        mock_client.get_markets.side_effect = flaky_api
+        mock_client.fetch_all_markets.side_effect = flaky_api
 
         poller = KalshiMarketPoller(
             series_tickers=["KXNFLGAME"],
@@ -105,7 +105,7 @@ class TestKalshiMarketPollerChaos:
         ]
 
         for response in malformed_responses:
-            mock_client.get_markets.return_value = response
+            mock_client.fetch_all_markets.return_value = response
 
             poller = KalshiMarketPoller(
                 series_tickers=["KXNFLGAME"],
@@ -172,7 +172,7 @@ class TestKalshiMarketPollerChaos:
             for i in range(500)
         ]
 
-        mock_client.get_markets.return_value = large_response
+        mock_client.fetch_all_markets.return_value = large_response
 
         poller = KalshiMarketPoller(
             series_tickers=["KXNFLGAME"],
@@ -222,7 +222,7 @@ class TestKalshiMarketPollerChaos:
             successful_polls[0] += 1
             return []
 
-        mock_client.get_markets.side_effect = network_partition_api
+        mock_client.fetch_all_markets.side_effect = network_partition_api
 
         poller = KalshiMarketPoller(
             series_tickers=["KXNFLGAME"],
@@ -276,7 +276,7 @@ class TestKalshiMarketPollerChaos:
         from precog.schedulers.kalshi_poller import KalshiMarketPoller
 
         mock_client = MagicMock()
-        mock_client.get_markets.return_value = []
+        mock_client.fetch_all_markets.return_value = []
         mock_client.close.return_value = None
 
         for _ in range(5):

--- a/tests/integration/schedulers/test_kalshi_poller_integration.py
+++ b/tests/integration/schedulers/test_kalshi_poller_integration.py
@@ -34,7 +34,7 @@ pytestmark = [pytest.mark.integration]
 def mock_kalshi_client() -> MagicMock:
     """Create a mock Kalshi client."""
     client = MagicMock()
-    client.get_markets.return_value = []
+    client.fetch_all_markets.return_value = []
     client.close = MagicMock()
     return client
 
@@ -100,7 +100,7 @@ class TestPollerClientIntegration:
         sample_market_data: list[dict[str, Any]],
     ) -> None:
         """Poller should use KalshiClient to fetch markets."""
-        mock_kalshi_client.get_markets.return_value = sample_market_data
+        mock_kalshi_client.fetch_all_markets.return_value = sample_market_data
 
         with patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None):
             with patch("precog.schedulers.kalshi_poller.create_market"):
@@ -108,7 +108,7 @@ class TestPollerClientIntegration:
                     result = poller_with_mock_client.poll_once()
 
         # Verify client was called
-        mock_kalshi_client.get_markets.assert_called()
+        mock_kalshi_client.fetch_all_markets.assert_called()
         assert result["items_fetched"] == len(sample_market_data)
 
     def test_poller_calls_client_with_correct_series(
@@ -131,10 +131,8 @@ class TestPollerClientIntegration:
                         poller.poll_once()
 
         # Verify correct series was requested
-        mock_kalshi_client.get_markets.assert_called_with(
-            series_ticker="KXNCAAFGAME",
-            limit=KalshiMarketPoller.MAX_MARKETS_PER_REQUEST,
-            cursor=None,
+        mock_kalshi_client.fetch_all_markets.assert_called_with(
+            series_tickers=["KXNCAAFGAME"],
         )
 
     def test_poller_closes_client_on_stop(
@@ -171,7 +169,7 @@ class TestPollerDatabaseIntegration:
         """
         # Reset mock to ensure clean state
         mock_kalshi_client.reset_mock()
-        mock_kalshi_client.get_markets.return_value = [sample_market_data[0]]
+        mock_kalshi_client.fetch_all_markets.return_value = [sample_market_data[0]]
         expected_event_id = sample_market_data[0]["event_ticker"]
 
         with patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None):
@@ -195,7 +193,7 @@ class TestPollerDatabaseIntegration:
     ) -> None:
         """Existing markets with price changes should be updated."""
         market = sample_market_data[0]
-        mock_kalshi_client.get_markets.return_value = [market]
+        mock_kalshi_client.fetch_all_markets.return_value = [market]
 
         # Existing market with different price
         existing = {
@@ -221,7 +219,7 @@ class TestPollerDatabaseIntegration:
     ) -> None:
         """Existing markets with no changes should be skipped."""
         market = sample_market_data[0]
-        mock_kalshi_client.get_markets.return_value = [market]
+        mock_kalshi_client.fetch_all_markets.return_value = [market]
 
         # Existing market with same price and status
         existing = {
@@ -249,7 +247,7 @@ class TestPollerDatabaseIntegration:
         """Status changes should trigger market update."""
         market = sample_market_data[0].copy()
         market["status"] = "closed"  # Changed status
-        mock_kalshi_client.get_markets.return_value = [market]
+        mock_kalshi_client.fetch_all_markets.return_value = [market]
 
         existing = {
             "yes_price": Decimal("0.5525"),  # Same price
@@ -297,10 +295,11 @@ class TestMultipleSeriesIntegration:
                         poller.poll_once()
 
         # Verify each series was polled
-        assert mock_kalshi_client.get_markets.call_count == len(series)
+        assert mock_kalshi_client.fetch_all_markets.call_count == len(series)
 
         called_series = [
-            call[1]["series_ticker"] for call in mock_kalshi_client.get_markets.call_args_list
+            call[1]["series_tickers"][0]
+            for call in mock_kalshi_client.fetch_all_markets.call_args_list
         ]
         assert set(called_series) == set(series)
 
@@ -312,7 +311,7 @@ class TestMultipleSeriesIntegration:
         series = ["KXNFLGAME", "KXNCAAFGAME"]
 
         # First call fails, second succeeds
-        mock_kalshi_client.get_markets.side_effect = [
+        mock_kalshi_client.fetch_all_markets.side_effect = [
             Exception("API Error"),
             [],  # Empty success
         ]
@@ -328,7 +327,7 @@ class TestMultipleSeriesIntegration:
                 # Should not raise, and should call both
                 poller._poll_once()
 
-        assert mock_kalshi_client.get_markets.call_count == 2
+        assert mock_kalshi_client.fetch_all_markets.call_count == 2
 
 
 # =============================================================================
@@ -360,7 +359,7 @@ class TestStatusMappingIntegration:
         """API status should be mapped correctly when creating markets."""
         market = sample_market_data[0].copy()
         market["status"] = api_status
-        mock_kalshi_client.get_markets.return_value = [market]
+        mock_kalshi_client.fetch_all_markets.return_value = [market]
 
         with patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None):
             with patch("precog.schedulers.kalshi_poller.create_market") as mock_create:
@@ -437,7 +436,7 @@ class TestFallbackPriceIntegration:
             "event_ticker": "EVT-TEST",
             "series_ticker": "KXNFLGAME",
         }
-        mock_kalshi_client.get_markets.return_value = [market]
+        mock_kalshi_client.fetch_all_markets.return_value = [market]
 
         with patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None):
             with patch("precog.schedulers.kalshi_poller.create_market") as mock_create:
@@ -465,7 +464,7 @@ class TestEventCreationIntegration:
         sample_market_data: list[dict[str, Any]],
     ) -> None:
         """Events should be created with correct category."""
-        mock_kalshi_client.get_markets.return_value = [sample_market_data[0]]
+        mock_kalshi_client.fetch_all_markets.return_value = [sample_market_data[0]]
 
         with patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None):
             with patch("precog.schedulers.kalshi_poller.create_market"):
@@ -515,7 +514,7 @@ class TestEventCreationIntegration:
             # Note: series_ticker in market dict is for reference only;
             # real API doesn't include this field in responses
         }
-        mock_kalshi_client.get_markets.return_value = [market]
+        mock_kalshi_client.fetch_all_markets.return_value = [market]
 
         # Create poller configured for THIS specific series
         with patch("precog.schedulers.kalshi_poller.KalshiClient", return_value=mock_kalshi_client):

--- a/tests/performance/schedulers/test_kalshi_poller_performance.py
+++ b/tests/performance/schedulers/test_kalshi_poller_performance.py
@@ -50,7 +50,7 @@ class TestKalshiMarketPollerPerformance:
         from precog.schedulers.kalshi_poller import KalshiMarketPoller
 
         mock_client = MagicMock()
-        mock_client.get_markets.return_value = []
+        mock_client.fetch_all_markets.return_value = []
         mock_client.close.return_value = None
 
         poller = KalshiMarketPoller(
@@ -88,7 +88,7 @@ class TestKalshiMarketPollerPerformance:
         from precog.schedulers.kalshi_poller import KalshiMarketPoller
 
         mock_client = MagicMock()
-        mock_client.get_markets.return_value = []
+        mock_client.fetch_all_markets.return_value = []
         mock_client.close.return_value = None
 
         poller = KalshiMarketPoller(
@@ -134,7 +134,7 @@ class TestKalshiMarketPollerPerformance:
         # IMPORTANT: event_ticker must include date (e.g., KXNFLGAME-25DEC15)
         # NOT just series ticker (KXNFLGAME) - the series is a different field
         mock_client = MagicMock()
-        mock_client.get_markets.return_value = [
+        mock_client.fetch_all_markets.return_value = [
             {
                 "ticker": f"KXNFLGAME-25DEC15-PERF-{i:04d}",
                 "event_ticker": "KXNFLGAME-25DEC15-PERF",  # CORRECT: includes date
@@ -185,7 +185,7 @@ class TestKalshiMarketPollerPerformance:
         from precog.schedulers.kalshi_poller import KalshiMarketPoller
 
         mock_client = MagicMock()
-        mock_client.get_markets.return_value = []
+        mock_client.fetch_all_markets.return_value = []
         mock_client.close.return_value = None
 
         poller = KalshiMarketPoller(

--- a/tests/property/schedulers/test_kalshi_poller_properties.py
+++ b/tests/property/schedulers/test_kalshi_poller_properties.py
@@ -357,13 +357,6 @@ class TestClassConstantProperties:
         """
         assert KalshiMarketPoller.DEFAULT_POLL_INTERVAL >= KalshiMarketPoller.MIN_POLL_INTERVAL
 
-    def test_max_markets_reasonable(self) -> None:
-        """MAX_MARKETS_PER_REQUEST should be reasonable.
-
-        Property: 1 <= MAX_MARKETS <= 1000.
-        """
-        assert 1 <= KalshiMarketPoller.MAX_MARKETS_PER_REQUEST <= 1000
-
     def test_platform_id_is_kalshi(self) -> None:
         """PLATFORM_ID should be 'kalshi'.
 

--- a/tests/stress/schedulers/test_kalshi_poller_race.py
+++ b/tests/stress/schedulers/test_kalshi_poller_race.py
@@ -58,7 +58,7 @@ class TestKalshiMarketPollerRace:
         from precog.schedulers.kalshi_poller import KalshiMarketPoller
 
         mock_client = MagicMock()
-        mock_client.get_markets.return_value = []
+        mock_client.fetch_all_markets.return_value = []
         mock_client.close.return_value = None
 
         poller = KalshiMarketPoller(
@@ -110,7 +110,7 @@ class TestKalshiMarketPollerRace:
         from precog.schedulers.kalshi_poller import KalshiMarketPoller
 
         mock_client = MagicMock()
-        mock_client.get_markets.return_value = []
+        mock_client.fetch_all_markets.return_value = []
         mock_client.close.return_value = None
 
         poller = KalshiMarketPoller(
@@ -182,7 +182,7 @@ class TestKalshiMarketPollerRace:
         from precog.schedulers.kalshi_poller import KalshiMarketPoller
 
         mock_client = MagicMock()
-        mock_client.get_markets.return_value = []
+        mock_client.fetch_all_markets.return_value = []
         mock_client.close.return_value = None
 
         poller = KalshiMarketPoller(
@@ -226,7 +226,7 @@ class TestKalshiMarketPollerRace:
         from precog.schedulers.kalshi_poller import KalshiMarketPoller
 
         mock_client = MagicMock()
-        mock_client.get_markets.return_value = []
+        mock_client.fetch_all_markets.return_value = []
         mock_client.close.return_value = None
 
         poller = KalshiMarketPoller(

--- a/tests/stress/schedulers/test_kalshi_poller_stress.py
+++ b/tests/stress/schedulers/test_kalshi_poller_stress.py
@@ -49,7 +49,7 @@ class TestKalshiMarketPollerStress:
 
         # Mock the KalshiClient to avoid real API calls (REQ-TEST-013 allows this)
         mock_client = MagicMock()
-        mock_client.get_markets.return_value = []
+        mock_client.fetch_all_markets.return_value = []
         mock_client.close.return_value = None
 
         poller = KalshiMarketPoller(
@@ -85,7 +85,7 @@ class TestKalshiMarketPollerStress:
         from precog.schedulers.kalshi_poller import KalshiMarketPoller
 
         mock_client = MagicMock()
-        mock_client.get_markets.return_value = []
+        mock_client.fetch_all_markets.return_value = []
         mock_client.close.return_value = None
 
         poller = KalshiMarketPoller(
@@ -127,7 +127,7 @@ class TestKalshiMarketPollerStress:
         from precog.schedulers.kalshi_poller import KalshiMarketPoller
 
         mock_client = MagicMock()
-        mock_client.get_markets.return_value = []
+        mock_client.fetch_all_markets.return_value = []
         mock_client.close.return_value = None
 
         poller = KalshiMarketPoller(
@@ -167,7 +167,7 @@ class TestKalshiMarketPollerStress:
         from precog.schedulers.kalshi_poller import KalshiMarketPoller
 
         mock_client = MagicMock()
-        mock_client.get_markets.return_value = []
+        mock_client.fetch_all_markets.return_value = []
         mock_client.close.return_value = None
 
         poller = KalshiMarketPoller(

--- a/tests/unit/schedulers/test_kalshi_poller.py
+++ b/tests/unit/schedulers/test_kalshi_poller.py
@@ -34,7 +34,7 @@ from precog.schedulers.kalshi_poller import (
 def mock_kalshi_client():
     """Create a mock KalshiClient for testing."""
     mock_client = Mock()
-    mock_client.get_markets.return_value = []
+    mock_client.fetch_all_markets.return_value = []
     mock_client.close = Mock()
     return mock_client
 
@@ -219,7 +219,7 @@ class TestKalshiMarketPollerPolling:
     @pytest.mark.unit
     def test_poll_once_returns_counts(self, poller_with_mock_client, mock_market_data_list):
         """Test that poll_once returns correct counts."""
-        poller_with_mock_client.kalshi_client.get_markets.return_value = mock_market_data_list
+        poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = mock_market_data_list
 
         with (
             patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None),
@@ -235,7 +235,7 @@ class TestKalshiMarketPollerPolling:
     @pytest.mark.unit
     def test_poll_once_updates_existing_markets(self, poller_with_mock_client, mock_market_data):
         """Test that poll_once updates existing markets."""
-        poller_with_mock_client.kalshi_client.get_markets.return_value = [mock_market_data]
+        poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = [mock_market_data]
 
         existing_market = {
             "ticker": mock_market_data["ticker"],
@@ -263,7 +263,7 @@ class TestKalshiMarketPollerPolling:
     @pytest.mark.unit
     def test_poll_once_skips_unchanged_markets(self, poller_with_mock_client, mock_market_data):
         """Test that poll_once skips markets with unchanged prices."""
-        poller_with_mock_client.kalshi_client.get_markets.return_value = [mock_market_data]
+        poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = [mock_market_data]
 
         # Same prices as mock_market_data
         existing_market = {
@@ -289,7 +289,7 @@ class TestKalshiMarketPollerPolling:
     @pytest.mark.unit
     def test_poll_updates_stats(self, poller_with_mock_client, mock_market_data_list):
         """Test that polling updates stats correctly."""
-        poller_with_mock_client.kalshi_client.get_markets.return_value = mock_market_data_list
+        poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = mock_market_data_list
 
         with (
             patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None),
@@ -307,7 +307,7 @@ class TestKalshiMarketPollerPolling:
     @pytest.mark.unit
     def test_poll_handles_api_error(self, poller_with_mock_client):
         """Test that polling handles API errors gracefully."""
-        poller_with_mock_client.kalshi_client.get_markets.side_effect = Exception("API Error")
+        poller_with_mock_client.kalshi_client.fetch_all_markets.side_effect = Exception("API Error")
 
         # Should not raise, just log error
         poller_with_mock_client._poll_wrapper()
@@ -450,7 +450,7 @@ class TestKalshiPollerFactoryFunctions:
             patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None),
             patch("precog.schedulers.kalshi_poller.create_market", return_value="MKT-123"),
         ):
-            mock_kalshi_client.get_markets.return_value = [
+            mock_kalshi_client.fetch_all_markets.return_value = [
                 {"ticker": "TEST-MARKET", "event_ticker": "TEST", "title": "Test"}
             ]
 


### PR DESCRIPTION
## Summary
- Replaced broken `get_markets()` pagination in `_poll_series()` with `fetch_all_markets()` which handles cursor-chasing internally
- **Before:** 200 markets fetched (first page only, 70% data loss)
- **After:** 676 markets fetched (all 4 pages)
- Updated all 8 test files to mock `fetch_all_markets` instead of `get_markets`

Closes #287

## Test plan
- [x] 69 tests pass across unit/integration/property/chaos/stress/race/performance
- [x] Pre-push validation passed (1,039 tests)
- [x] Manual `poll-once` verified: 676 markets fetched vs 200 before

## Related
- #298: Add `spec=` to mock fixtures to prevent future silent mock drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)