### PR TITLE
fix: Thread CLI params through to supervisor service factories

### DIFF
--- a/src/precog/cli/scheduler.py
+++ b/src/precog/cli/scheduler.py
@@ -63,6 +63,7 @@ def _start_supervised_mode(
     espn_interval: int,
     kalshi_interval: int,
     kalshi_env: str,
+    supervisor_env: str,
     leagues: str,
     series: str,
     max_restarts: int,
@@ -80,7 +81,8 @@ def _start_supervised_mode(
         kalshi: Enable Kalshi market price polling
         espn_interval: ESPN poll interval in seconds
         kalshi_interval: Kalshi poll interval in seconds
-        kalshi_env: Kalshi environment (demo or prod)
+        kalshi_env: Kalshi API environment (demo or prod)
+        supervisor_env: Deployment environment (development/staging/production)
         leagues: Comma-separated list of ESPN leagues
         series: Comma-separated list of Kalshi series
         max_restarts: Maximum service restarts before circuit breaker
@@ -134,14 +136,14 @@ def _start_supervised_mode(
 
     try:
         # Create supervisor using factory function
-        # Note: supervisor environment (development/staging/production) is separate
-        # from Kalshi API environment (demo/prod). Map appropriately.
-        supervisor_env = "production" if kalshi_env == "prod" else "development"
         _supervisor = create_supervisor(
             environment=supervisor_env,
             kalshi_env=kalshi_env,
             enabled_services=enabled_services,
-            poll_interval=espn_interval,
+            leagues=league_list,
+            series_tickers=series_list,
+            espn_poll_interval=espn_interval,
+            kalshi_poll_interval=kalshi_interval,
             health_check_interval=health_interval,
         )
 
@@ -349,6 +351,12 @@ def start(
         "-f",
         help="Run in foreground (blocks until Ctrl+C)",
     ),
+    supervisor_env: str = typer.Option(
+        "development",
+        "--environment",
+        "--env",
+        help="Supervisor deployment environment (development/staging/production)",
+    ),
     supervised: bool = typer.Option(
         False,
         "--supervised",
@@ -420,6 +428,7 @@ def start(
             espn_interval=espn_interval,
             kalshi_interval=kalshi_interval,
             kalshi_env=kalshi_env,
+            supervisor_env=supervisor_env,
             leagues=leagues,
             series=series,
             max_restarts=max_restarts,

--- a/src/precog/schedulers/service_supervisor.py
+++ b/src/precog/schedulers/service_supervisor.py
@@ -783,6 +783,10 @@ def create_services(
     config: RunnerConfig,
     enabled_services: set[str] | None = None,
     kalshi_env: str = "demo",
+    leagues: list[str] | None = None,
+    series_tickers: list[str] | None = None,
+    espn_poll_interval: int = 15,
+    kalshi_poll_interval: int = 15,
 ) -> dict[str, tuple[EventLoopService, ServiceConfig]]:
     """
     Create service instances based on configuration.
@@ -793,15 +797,14 @@ def create_services(
     Args:
         config: Runner configuration
         enabled_services: Set of service names to enable (None = all)
+        kalshi_env: Kalshi API environment (demo/prod)
+        leagues: ESPN leagues to poll (None = use ESPNGamePoller defaults)
+        series_tickers: Kalshi series to poll (None = use KalshiMarketPoller defaults)
+        espn_poll_interval: ESPN poll interval in seconds
+        kalshi_poll_interval: Kalshi poll interval in seconds
 
     Returns:
         Dict mapping service name to (service, config) tuple
-
-    Educational Note:
-        This factory pattern centralizes service creation, making it easy to:
-        1. Add new services (just add a case)
-        2. Configure services differently per environment
-        3. Mock services for testing
     """
     services: dict[str, tuple[EventLoopService, ServiceConfig]] = {}
     logger = logging.getLogger("precog.factory")
@@ -814,18 +817,18 @@ def create_services(
         try:
             if name == "espn":
                 espn_service = create_espn_poller(
-                    leagues=["nfl", "ncaaf", "nba", "ncaab", "nhl", "wnba"],
-                    poll_interval=svc_config.poll_interval,
+                    leagues=leagues,
+                    poll_interval=espn_poll_interval,
                 )
                 services[name] = (cast("EventLoopService", espn_service), svc_config)
-                logger.info("Created ESPN Game Poller (interval=%ds)", svc_config.poll_interval)
+                logger.info("Created ESPN Game Poller (interval=%ds)", espn_poll_interval)
 
             elif name == "kalshi_rest":
                 # Check for Kalshi credentials using two-axis naming convention
                 if _has_kalshi_credentials(config.environment):
                     kalshi_rest_service = create_kalshi_poller(
-                        series_tickers=["KXNFLGAME", "KXNCAAFGAME", "KXNBAGAME"],
-                        poll_interval=svc_config.poll_interval,
+                        series_tickers=series_tickers,
+                        poll_interval=kalshi_poll_interval,
                         environment=kalshi_env,
                     )
                     services[name] = (
@@ -834,7 +837,7 @@ def create_services(
                     )
                     logger.info(
                         "Created Kalshi REST Poller (interval=%ds)",
-                        svc_config.poll_interval,
+                        kalshi_poll_interval,
                     )
                 else:
                     logger.warning("Kalshi API credentials not found, skipping REST poller")
@@ -885,7 +888,10 @@ def create_supervisor(
     environment: str = "development",
     kalshi_env: str = "demo",
     enabled_services: set[str] | None = None,
-    poll_interval: int = 15,
+    leagues: list[str] | None = None,
+    series_tickers: list[str] | None = None,
+    espn_poll_interval: int = 15,
+    kalshi_poll_interval: int = 15,
     health_check_interval: int = 60,
     metrics_interval: int = 300,
 ) -> ServiceSupervisor:
@@ -899,7 +905,10 @@ def create_supervisor(
         environment: Deployment environment (development/staging/production)
         kalshi_env: Kalshi API environment (demo/prod)
         enabled_services: Set of services to enable (None = all)
-        poll_interval: Default poll interval for services
+        leagues: ESPN leagues to poll (None = use ESPNGamePoller defaults)
+        series_tickers: Kalshi series to poll (None = use KalshiMarketPoller defaults)
+        espn_poll_interval: ESPN poll interval in seconds
+        kalshi_poll_interval: Kalshi poll interval in seconds
         health_check_interval: Seconds between health checks
         metrics_interval: Seconds between metrics output
 
@@ -910,7 +919,7 @@ def create_supervisor(
         >>> supervisor = create_supervisor(
         ...     environment="development",
         ...     enabled_services={"espn"},
-        ...     poll_interval=30
+        ...     espn_poll_interval=30,
         ... )
         >>> supervisor.start_all()
     """
@@ -921,12 +930,16 @@ def create_supervisor(
         metrics_interval=metrics_interval,
     )
 
-    # Update poll intervals
-    for svc_config in config.services.values():
-        svc_config.poll_interval = poll_interval
-
-    # Create services
-    services = create_services(config, enabled_services, kalshi_env=kalshi_env)
+    # Create services with user-specified parameters
+    services = create_services(
+        config,
+        enabled_services,
+        kalshi_env=kalshi_env,
+        leagues=leagues,
+        series_tickers=series_tickers,
+        espn_poll_interval=espn_poll_interval,
+        kalshi_poll_interval=kalshi_poll_interval,
+    )
 
     # Create supervisor
     supervisor = ServiceSupervisor(config)

--- a/tests/unit/schedulers/test_service_supervisor.py
+++ b/tests/unit/schedulers/test_service_supervisor.py
@@ -801,7 +801,8 @@ class TestCreateSupervisor:
 
         supervisor = create_supervisor(
             environment="production",
-            poll_interval=30,
+            espn_poll_interval=30,
+            kalshi_poll_interval=30,
             health_check_interval=120,
             metrics_interval=600,
         )


### PR DESCRIPTION
## Summary
- Supervised mode was ignoring `--leagues`, `--series`, and `--kalshi-interval` CLI flags
- Root cause: `create_supervisor` → `create_services` used hardcoded values instead of CLI params
- Now all CLI parameters flow through: leagues, series_tickers, espn_poll_interval, kalshi_poll_interval, kalshi_env
- Removed hardcoded league/series lists from `create_services`; uses poller defaults when None

## Test plan
- [x] 39 supervisor unit tests pass
- [x] Manual: `--leagues nfl --series KXNFLGAME` correctly creates single-league/single-series pollers
- [x] Manual: default (no flags) uses expanded multi-sport defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)