### PR TITLE
feat: ESPN-ID-first validator lookup and periodic team validation

### DIFF
--- a/src/precog/api_connectors/espn_team_validator.py
+++ b/src/precog/api_connectors/espn_team_validator.py
@@ -42,7 +42,7 @@ from typing import Any
 import requests
 
 from precog.database.connection import fetch_one, get_cursor
-from precog.database.crud_operations import create_team
+from precog.database.crud_operations import create_team, get_team_by_espn_id
 
 logger = logging.getLogger(__name__)
 
@@ -242,31 +242,59 @@ def _resolve_db_code(espn_code: str, league: str) -> str:
     return aliases.get(espn_code, espn_code)
 
 
-def _get_team_by_code_and_league(
+def _get_team_by_espn_id_or_code(
+    espn_id: str,
     team_code: str,
     league: str,
 ) -> dict[str, Any] | None:
-    """Look up a team by team_code and league in the database.
+    """Look up a team by ESPN ID first, falling back to team_code + league.
+
+    ESPN-ID-first lookup is critical for NCAAF where multiple teams share
+    the same abbreviation code (e.g., 5 teams with code 'WES'). Looking up
+    by code alone causes ping-ponging between wrong team records on every
+    validator restart.
+
+    Lookup order:
+        1. Try ESPN ID + league (unique, authoritative match)
+        2. Fall back to team_code + league (backward compat for teams
+           that don't have an ESPN ID yet)
 
     Args:
+        espn_id: ESPN's unique team identifier (e.g., '12' for Chiefs)
         team_code: Our database team code (e.g., 'KC', 'WAS')
         league: League identifier (nfl, nba, nhl, ncaaf)
 
     Returns:
-        Dictionary with team data, or None if not found.
+        Dictionary with team data, or None if not found by either method.
 
     Educational Note:
-        The teams table uses (team_code, sport) as a composite unique
-        constraint. In our schema, the 'sport' column stores the league
-        code (e.g., 'nfl') for NFL teams. We also check the 'league'
-        column for cases where sport and league differ.
+        After migration 0018, the teams table uses espn_team_id + league
+        as the preferred lookup path. The code+league fallback handles
+        legacy teams that were created before ESPN IDs were populated.
 
     Related:
-        - src/precog/database/crud_operations.py (get_team_elo_by_code)
+        - src/precog/database/crud_operations.py (get_team_by_espn_id)
     """
+    # Primary lookup: ESPN ID + league (authoritative)
+    if espn_id:
+        db_team = get_team_by_espn_id(espn_id, league=league)
+        if db_team is not None:
+            # If found by ESPN ID but code differs, warn for visibility
+            db_code = db_team.get("team_code", "")
+            if db_code != team_code:
+                logger.warning(
+                    "Team found by ESPN ID %s in %s: DB code '%s' differs "
+                    "from resolved code '%s' (alias or code change)",
+                    espn_id,
+                    league.upper(),
+                    db_code,
+                    team_code,
+                )
+            return db_team
+
+    # Fallback: code + league (for teams without ESPN IDs)
     return fetch_one(
-        "SELECT team_id, team_code, espn_team_id FROM teams "
-        "WHERE team_code = %s AND (sport = %s OR league = %s)",
+        "SELECT * FROM teams WHERE team_code = %s AND (sport = %s OR league = %s)",
         (team_code, league, league),
     )
 
@@ -444,8 +472,8 @@ def validate_league_teams(
         # Resolve the ESPN code to our DB code (applying aliases)
         db_code = _resolve_db_code(espn_code, league)
 
-        # Look up the team in our database by code + league
-        db_team = _get_team_by_code_and_league(db_code, league)
+        # Look up the team: ESPN ID first, then fall back to code + league
+        db_team = _get_team_by_espn_id_or_code(espn_id, db_code, league)
 
         if db_team is None:
             # Auto-create missing teams for any polled league when

--- a/src/precog/schedulers/espn_game_poller.py
+++ b/src/precog/schedulers/espn_game_poller.py
@@ -51,6 +51,7 @@ Related ADR: ADR-100 (Service Supervisor Pattern)
 """
 
 import logging
+import time
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
 from typing import Any, ClassVar
@@ -235,6 +236,9 @@ class ESPNGamePoller(BasePoller):
             self.leagues, self.DEFAULT_DISCOVERY_INTERVAL
         )
 
+        # Track last validation time for dedup guard (Part F)
+        self._last_validation_time: float = 0.0
+
         # Initialize ESPN client (or use provided mock)
         self.espn_client = espn_client or ESPNClient()
 
@@ -359,6 +363,24 @@ class ESPNGamePoller(BasePoller):
                     replace_existing=True,
                 )
 
+            # Periodic team validation job (6hr interval).
+            # Re-validates ESPN team IDs during long soak tests to catch
+            # any data drift without requiring a restart.
+            if self.validate_teams_on_start:
+                validation_interval = 21600  # 6 hours in seconds
+                self._scheduler.add_job(
+                    self._periodic_team_validation,
+                    IntervalTrigger(seconds=validation_interval),
+                    id="espn_team_validation",
+                    name="ESPN Team ID Periodic Validation",
+                    replace_existing=True,
+                )
+                logger.info(
+                    "Added periodic team validation job (interval=%ds / %dh)",
+                    validation_interval,
+                    validation_interval // 3600,
+                )
+
             self._scheduler.start()
             self._enabled = True
 
@@ -416,6 +438,7 @@ class ESPNGamePoller(BasePoller):
                 leagues=self.leagues,
                 auto_correct=True,
             )
+            self._last_validation_time = time.monotonic()
             if results["total_mismatches"] > 0:
                 logger.warning(
                     "ESPN team ID validation found %d mismatches "
@@ -431,6 +454,59 @@ class ESPNGamePoller(BasePoller):
         except Exception as e:
             # Never let validation failure prevent the poller from starting
             logger.warning("ESPN team ID validation failed (non-fatal): %s", e)
+
+    def _periodic_team_validation(self) -> None:
+        """Run periodic ESPN team ID validation (called by APScheduler).
+
+        Skips execution if the last validation (startup or periodic) happened
+        less than 10 minutes ago, to avoid redundant work when the poller
+        was recently started or restarted.
+
+        Educational Note:
+            This method is registered as an APScheduler interval job with a
+            6-hour interval. It uses auto_correct=True so any ESPN ID drift
+            detected during long soak tests is fixed automatically without
+            requiring a restart. The 10-minute dedup guard prevents the first
+            periodic run from duplicating the startup validation.
+
+        Related:
+            - _on_start() (startup validation)
+            - validate_espn_teams() in espn_team_validator.py
+        """
+        # Dedup guard: skip if validated recently (within 10 minutes)
+        elapsed = time.monotonic() - self._last_validation_time
+        if elapsed < 600:  # 600 seconds = 10 minutes
+            logger.debug(
+                "Skipping periodic team validation: last run %.0fs ago (< 600s)",
+                elapsed,
+            )
+            return
+
+        try:
+            from precog.api_connectors.espn_team_validator import validate_espn_teams
+
+            logger.info("Running periodic ESPN team ID validation...")
+            results = validate_espn_teams(
+                leagues=self.leagues,
+                auto_correct=True,
+            )
+            self._last_validation_time = time.monotonic()
+
+            if results["total_mismatches"] > 0:
+                logger.warning(
+                    "Periodic validation found %d ESPN ID mismatches "
+                    "across %d leagues (auto-corrected). Review warnings above.",
+                    results["total_mismatches"],
+                    len(results["leagues"]),
+                )
+            else:
+                logger.info(
+                    "Periodic validation passed: %d teams checked, no mismatches",
+                    results["total_checked"],
+                )
+        except Exception as e:
+            # Never let validation failure crash the scheduler
+            logger.warning("Periodic ESPN team validation failed (non-fatal): %s", e)
 
     def _on_stop(self) -> None:
         """Clean up ESPN client on stop."""

--- a/tests/unit/api_connectors/test_espn_team_validator.py
+++ b/tests/unit/api_connectors/test_espn_team_validator.py
@@ -26,6 +26,7 @@ import requests
 from precog.api_connectors.espn_team_validator import (
     CODE_ALIASES,
     LEAGUE_CONFIGS,
+    _get_team_by_espn_id_or_code,
     _resolve_db_code,
     fetch_espn_teams,
     validate_espn_teams,
@@ -231,6 +232,94 @@ class TestFetchESPNTeams:
 
 
 # =============================================================================
+# Tests: ESPN-ID-First Team Lookup
+# =============================================================================
+
+
+class TestGetTeamByEspnIdOrCode:
+    """Tests for _get_team_by_espn_id_or_code function.
+
+    Educational Note:
+        This function has two lookup paths: ESPN ID (primary) and
+        team_code+league (fallback). Both must be tested directly
+        since integration tests mock this function away.
+    """
+
+    @patch("precog.api_connectors.espn_team_validator.fetch_one")
+    @patch("precog.api_connectors.espn_team_validator.get_team_by_espn_id")
+    def test_espn_id_found_returns_team(self, mock_get_by_espn, mock_fetch_one):
+        """Should return team when ESPN ID lookup succeeds."""
+        expected = {"team_id": 1, "team_code": "KC", "espn_team_id": "12"}
+        mock_get_by_espn.return_value = expected
+
+        result = _get_team_by_espn_id_or_code("12", "KC", "nfl")
+
+        assert result == expected
+        mock_get_by_espn.assert_called_once_with("12", league="nfl")
+        mock_fetch_one.assert_not_called()
+
+    @patch("precog.api_connectors.espn_team_validator.fetch_one")
+    @patch("precog.api_connectors.espn_team_validator.get_team_by_espn_id")
+    def test_espn_id_found_with_code_mismatch_logs_warning(
+        self, mock_get_by_espn, mock_fetch_one, caplog
+    ):
+        """Should log warning when ESPN ID matches but DB code differs."""
+        mock_get_by_espn.return_value = {
+            "team_id": 1,
+            "team_code": "WAS",
+            "espn_team_id": "28",
+        }
+
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            result = _get_team_by_espn_id_or_code("28", "WSH", "nfl")
+
+        assert result is not None
+        assert result["team_code"] == "WAS"
+        assert "differs" in caplog.text
+        mock_fetch_one.assert_not_called()
+
+    @patch("precog.api_connectors.espn_team_validator.fetch_one")
+    @patch("precog.api_connectors.espn_team_validator.get_team_by_espn_id")
+    def test_fallback_when_espn_id_not_found(self, mock_get_by_espn, mock_fetch_one):
+        """Should fall back to code+league when ESPN ID lookup returns None."""
+        mock_get_by_espn.return_value = None
+        expected = {"team_id": 5, "team_code": "TEST", "espn_team_id": None}
+        mock_fetch_one.return_value = expected
+
+        result = _get_team_by_espn_id_or_code("999", "TEST", "nfl")
+
+        assert result == expected
+        mock_get_by_espn.assert_called_once_with("999", league="nfl")
+        mock_fetch_one.assert_called_once()
+
+    @patch("precog.api_connectors.espn_team_validator.fetch_one")
+    @patch("precog.api_connectors.espn_team_validator.get_team_by_espn_id")
+    def test_fallback_when_espn_id_empty(self, mock_get_by_espn, mock_fetch_one):
+        """Should skip ESPN ID lookup and go straight to fallback when ID is empty."""
+        expected = {"team_id": 5, "team_code": "OLD", "espn_team_id": None}
+        mock_fetch_one.return_value = expected
+
+        result = _get_team_by_espn_id_or_code("", "OLD", "nfl")
+
+        assert result == expected
+        mock_get_by_espn.assert_not_called()
+        mock_fetch_one.assert_called_once()
+
+    @patch("precog.api_connectors.espn_team_validator.fetch_one")
+    @patch("precog.api_connectors.espn_team_validator.get_team_by_espn_id")
+    def test_both_paths_return_none(self, mock_get_by_espn, mock_fetch_one):
+        """Should return None when team not found by either method."""
+        mock_get_by_espn.return_value = None
+        mock_fetch_one.return_value = None
+
+        result = _get_team_by_espn_id_or_code("999", "UNKNOWN", "nfl")
+
+        assert result is None
+
+
+# =============================================================================
 # Tests: League Validation
 # =============================================================================
 
@@ -238,7 +327,7 @@ class TestFetchESPNTeams:
 class TestValidateLeagueTeams:
     """Tests for validate_league_teams function."""
 
-    @patch("precog.api_connectors.espn_team_validator._get_team_by_code_and_league")
+    @patch("precog.api_connectors.espn_team_validator._get_team_by_espn_id_or_code")
     @patch("precog.api_connectors.espn_team_validator.fetch_espn_teams")
     def test_detects_espn_id_mismatch(self, mock_fetch, mock_get_team):
         """Should detect when DB has different ESPN ID than API."""
@@ -259,7 +348,7 @@ class TestValidateLeagueTeams:
         assert result["mismatches"][0]["db_espn_id"] == "99"
         assert result["mismatches"][0]["api_espn_id"] == "12"
 
-    @patch("precog.api_connectors.espn_team_validator._get_team_by_code_and_league")
+    @patch("precog.api_connectors.espn_team_validator._get_team_by_espn_id_or_code")
     @patch("precog.api_connectors.espn_team_validator.fetch_espn_teams")
     def test_no_mismatch_when_ids_match(self, mock_fetch, mock_get_team):
         """Should report zero mismatches when IDs match."""
@@ -277,7 +366,7 @@ class TestValidateLeagueTeams:
         assert result["teams_checked"] == 1
         assert len(result["mismatches"]) == 0
 
-    @patch("precog.api_connectors.espn_team_validator._get_team_by_code_and_league")
+    @patch("precog.api_connectors.espn_team_validator._get_team_by_espn_id_or_code")
     @patch("precog.api_connectors.espn_team_validator.fetch_espn_teams")
     def test_resolves_code_alias_before_lookup(self, mock_fetch, mock_get_team):
         """Should apply code alias when looking up team in DB.
@@ -296,12 +385,12 @@ class TestValidateLeagueTeams:
 
         result = validate_league_teams("nfl")
 
-        # Should have looked up 'WAS' (resolved from 'WSH')
-        mock_get_team.assert_called_with("WAS", "nfl")
+        # Should have looked up with ESPN ID '28', resolved code 'WAS', league 'nfl'
+        mock_get_team.assert_called_with("28", "WAS", "nfl")
         assert result["teams_checked"] == 1
         assert len(result["mismatches"]) == 0
 
-    @patch("precog.api_connectors.espn_team_validator._get_team_by_code_and_league")
+    @patch("precog.api_connectors.espn_team_validator._get_team_by_espn_id_or_code")
     @patch("precog.api_connectors.espn_team_validator.fetch_espn_teams")
     def test_skips_teams_not_in_db(self, mock_fetch, mock_get_team):
         """Should skip teams that are not in our database (not seeded)."""
@@ -315,7 +404,7 @@ class TestValidateLeagueTeams:
         assert result["teams_checked"] == 0
         assert len(result["mismatches"]) == 0
 
-    @patch("precog.api_connectors.espn_team_validator._get_team_by_code_and_league")
+    @patch("precog.api_connectors.espn_team_validator._get_team_by_espn_id_or_code")
     @patch("precog.api_connectors.espn_team_validator.fetch_espn_teams")
     def test_skips_teams_without_espn_id_in_db(self, mock_fetch, mock_get_team):
         """Should skip comparison if DB team has no ESPN ID yet."""
@@ -352,7 +441,7 @@ class TestValidateLeagueTeams:
         assert "Unsupported league" in result["errors"][0]
 
     @patch("precog.api_connectors.espn_team_validator._correct_espn_id")
-    @patch("precog.api_connectors.espn_team_validator._get_team_by_code_and_league")
+    @patch("precog.api_connectors.espn_team_validator._get_team_by_espn_id_or_code")
     @patch("precog.api_connectors.espn_team_validator.fetch_espn_teams")
     def test_auto_correct_calls_correction(self, mock_fetch, mock_get_team, mock_correct):
         """Should call _correct_espn_id when auto_correct=True and mismatch found."""
@@ -376,7 +465,7 @@ class TestValidateLeagueTeams:
         )
 
     @patch("precog.api_connectors.espn_team_validator._correct_espn_id")
-    @patch("precog.api_connectors.espn_team_validator._get_team_by_code_and_league")
+    @patch("precog.api_connectors.espn_team_validator._get_team_by_espn_id_or_code")
     @patch("precog.api_connectors.espn_team_validator.fetch_espn_teams")
     def test_no_auto_correct_by_default(self, mock_fetch, mock_get_team, mock_correct):
         """Should NOT call _correct_espn_id when auto_correct=False (default)."""
@@ -393,7 +482,7 @@ class TestValidateLeagueTeams:
 
         mock_correct.assert_not_called()
 
-    @patch("precog.api_connectors.espn_team_validator._get_team_by_code_and_league")
+    @patch("precog.api_connectors.espn_team_validator._get_team_by_espn_id_or_code")
     @patch("precog.api_connectors.espn_team_validator.fetch_espn_teams")
     def test_multiple_teams_with_mixed_results(self, mock_fetch, mock_get_team):
         """Should correctly count matches and mismatches across multiple teams."""
@@ -403,7 +492,7 @@ class TestValidateLeagueTeams:
             {"id": "25", "abbreviation": "SF", "displayName": "San Francisco 49ers"},
         ]
 
-        def side_effect(code, league):
+        def side_effect(espn_id, code, league):
             db_teams = {
                 "KC": {"team_id": 1, "team_code": "KC", "espn_team_id": "12"},  # match
                 "BUF": {"team_id": 2, "team_code": "BUF", "espn_team_id": "99"},  # mismatch

--- a/tests/unit/schedulers/test_espn_game_poller_unit.py
+++ b/tests/unit/schedulers/test_espn_game_poller_unit.py
@@ -1529,3 +1529,129 @@ class TestPollLeagueWrapper:
         poller._poll_league_wrapper("nfl")
 
         assert poller._league_states["nfl"] == LEAGUE_STATE_DISCOVERY
+
+
+# =============================================================================
+# Periodic Team Validation Tests (Part F)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestPeriodicTeamValidation:
+    """Tests for periodic ESPN team validation scheduling and dedup guard.
+
+    Educational Note:
+        Part F adds a 6-hour periodic validation job to catch ESPN ID drift
+        during long soak tests. The dedup guard prevents redundant validation
+        when the poller was recently started or restarted.
+    """
+
+    def test_periodic_validation_skips_when_recent(self, mock_espn_client):
+        """Should skip periodic validation if last run was < 10 minutes ago."""
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        with patch("precog.schedulers.espn_game_poller.time") as mock_time:
+            mock_time.monotonic.return_value = 1000.0
+            poller._last_validation_time = 500.0  # 500s ago (< 600s)
+
+            with patch(
+                "precog.api_connectors.espn_team_validator.validate_espn_teams"
+            ) as mock_validate:
+                poller._periodic_team_validation()
+                mock_validate.assert_not_called()
+
+    def test_periodic_validation_runs_when_stale(self, mock_espn_client):
+        """Should run periodic validation if last run was > 10 minutes ago."""
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        with patch("precog.schedulers.espn_game_poller.time") as mock_time:
+            mock_time.monotonic.return_value = 1200.0
+            poller._last_validation_time = 0.0
+
+            with patch(
+                "precog.api_connectors.espn_team_validator.validate_espn_teams"
+            ) as mock_validate:
+                mock_validate.return_value = {
+                    "total_checked": 32,
+                    "total_mismatches": 0,
+                    "leagues": {"nfl": {}},
+                }
+                poller._periodic_team_validation()
+                mock_validate.assert_called_once_with(leagues=["nfl"], auto_correct=True)
+
+    def test_periodic_validation_updates_timestamp(self, mock_espn_client):
+        """Should update _last_validation_time after successful run."""
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        with patch("precog.schedulers.espn_game_poller.time") as mock_time:
+            mock_time.monotonic.side_effect = [700.0, 700.0]  # check + update
+            poller._last_validation_time = 0.0
+
+            with patch(
+                "precog.api_connectors.espn_team_validator.validate_espn_teams"
+            ) as mock_validate:
+                mock_validate.return_value = {
+                    "total_checked": 32,
+                    "total_mismatches": 0,
+                    "leagues": {"nfl": {}},
+                }
+                poller._periodic_team_validation()
+                assert poller._last_validation_time == 700.0
+
+    def test_periodic_validation_handles_exception(self, mock_espn_client):
+        """Should catch exceptions without crashing the scheduler."""
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        with patch("precog.schedulers.espn_game_poller.time") as mock_time:
+            mock_time.monotonic.return_value = 1200.0
+            poller._last_validation_time = 0.0
+
+            with patch(
+                "precog.api_connectors.espn_team_validator.validate_espn_teams",
+                side_effect=RuntimeError("ESPN API down"),
+            ):
+                # Should not raise
+                poller._periodic_team_validation()
+                # Timestamp should NOT update on failure (so next run retries)
+                assert poller._last_validation_time == 0.0
+
+    def test_periodic_job_registered_in_start(self, mock_espn_client):
+        """Should register periodic validation job when validate_teams_on_start=True."""
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+            validate_teams_on_start=True,
+        )
+        with patch.object(poller, "_on_start"):
+            poller.start()
+
+        try:
+            job = poller._scheduler.get_job("espn_team_validation")
+            assert job is not None
+            assert job.name == "ESPN Team ID Periodic Validation"
+        finally:
+            poller.stop()
+
+    def test_periodic_job_not_registered_when_disabled(self, mock_espn_client):
+        """Should NOT register periodic validation job when validate_teams_on_start=False."""
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+            validate_teams_on_start=False,
+        )
+        with patch.object(poller, "_on_start"):
+            poller.start()
+
+        try:
+            job = poller._scheduler.get_job("espn_team_validation")
+            assert job is None
+        finally:
+            poller.stop()


### PR DESCRIPTION
## Summary
- **ESPN-ID-first lookup** in validator: `_get_team_by_espn_id_or_code()` tries `get_team_by_espn_id()` first, falls back to `team_code+league` for backward compat
- **Periodic validation**: 6-hour APScheduler job in ESPNGamePoller catches ESPN ID drift during long soak tests
- **10-minute dedup guard**: Prevents redundant validation when poller was recently started/restarted
- **11 new unit tests**: 5 for the dual-path lookup function, 6 for periodic validation + scheduling

## Context
Follow-up to PR #320 (partial unique index). The schema change allows NCAAF code collisions, but the validator still looked up teams by code — causing the same ping-pong bug. This PR fixes the validator's lookup strategy (Steps D+E) and adds periodic re-validation (Part F).

## Files Changed (4 files, +343/-24)
| Area | File | Change |
|------|------|--------|
| Validator | `espn_team_validator.py` | ESPN-ID-first lookup, code mismatch WARNING |
| Poller | `espn_game_poller.py` | Periodic validation job, dedup guard |
| Tests | `test_espn_team_validator.py` | 5 new lookup tests + 8 patch updates |
| Tests | `test_espn_game_poller_unit.py` | 6 new periodic validation tests |

## Agent Review Trail
- **Careful Dev Samwise**: Implementation
- **Ruthless Reviewer Glokta**: Found dict shape mismatch, duplicate imports, missing WARNING level — all fixed
- **Targeted QA Ripley**: Found untested lookup paths, missing timestamp assertion — all fixed

## Test plan
- [x] 1760 unit tests pass locally
- [x] Ruff lint + format clean
- [x] Mypy type check clean
- [x] All pre-commit hooks pass
- [ ] CI pipeline
- [ ] 24hr soak test after merge

Fixes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>