### PR TITLE
fix: Soak test stability — ESPN validator, sleep prevention, metrics

### DIFF
--- a/src/precog/api_connectors/espn_team_validator.py
+++ b/src/precog/api_connectors/espn_team_validator.py
@@ -292,10 +292,19 @@ def _get_team_by_espn_id_or_code(
                 )
             return db_team
 
-    # Fallback: code + league (for teams without ESPN IDs)
+    # Fallback: code + league (for teams without ESPN IDs yet).
+    # ORDER BY prefers unassigned teams (espn_team_id IS NULL) first,
+    # then by team_id for determinism.  This prevents NCAAF ping-pong
+    # where duplicate codes (e.g. 5 teams all coded 'WES') caused a
+    # random row to be matched and "corrected" each run.
+    # NOTE: Code-only matching may assign the wrong ESPN ID when codes
+    # collide (e.g. Wesleyan vs Western Michigan).  A deeper fix using
+    # name matching is tracked separately.
     return fetch_one(
-        "SELECT * FROM teams WHERE team_code = %s AND (sport = %s OR league = %s)",
-        (team_code, league, league),
+        "SELECT * FROM teams WHERE team_code = %s AND league = %s "
+        "ORDER BY CASE WHEN espn_team_id IS NULL THEN 0 ELSE 1 END, team_id "
+        "LIMIT 1",
+        (team_code, league),
     )
 
 
@@ -502,30 +511,36 @@ def validate_league_teams(
 
         teams_checked += 1
 
-        # Compare ESPN IDs
+        # Compare ESPN IDs — NULL means "not yet assigned", treat as mismatch
         raw_espn_id = db_team.get("espn_team_id")
-        if raw_espn_id is None:
-            continue
-
-        db_espn_id = str(raw_espn_id)
+        db_espn_id = str(raw_espn_id) if raw_espn_id is not None else ""
 
         if db_espn_id != espn_id:
             mismatch = {
                 "team_code": db_code,
                 "espn_code": espn_code,
                 "team_name": espn_name,
-                "db_espn_id": db_espn_id,
+                "db_espn_id": db_espn_id or "(NULL)",
                 "api_espn_id": espn_id,
             }
             mismatches.append(mismatch)
-            logger.warning(
-                "ESPN ID mismatch for %s %s (%s): DB has '%s', ESPN API has '%s'",
-                league.upper(),
-                db_code,
-                espn_name,
-                db_espn_id,
-                espn_id,
-            )
+            if not db_espn_id:
+                logger.info(
+                    "Populating ESPN ID for %s %s (%s): setting to '%s'",
+                    league.upper(),
+                    db_code,
+                    espn_name,
+                    espn_id,
+                )
+            else:
+                logger.warning(
+                    "ESPN ID mismatch for %s %s (%s): DB has '%s', ESPN API has '%s'",
+                    league.upper(),
+                    db_code,
+                    espn_name,
+                    db_espn_id,
+                    espn_id,
+                )
 
             # Auto-correct if configured
             if auto_correct:

--- a/src/precog/cli/scheduler.py
+++ b/src/precog/cli/scheduler.py
@@ -128,7 +128,10 @@ def _prevent_system_sleep_for_supervised(logger: Any) -> None:
 
         es_continuous = 0x80000000
         es_system_required = 0x00000001
-        flags = es_continuous | es_system_required
+        es_display_required = 0x00000002
+        # ES_DISPLAY_REQUIRED prevents display sleep, which some laptops
+        # use as a trigger for system sleep/hibernate (especially on lid close).
+        flags = es_continuous | es_system_required | es_display_required
 
         result = ctypes.windll.kernel32.SetThreadExecutionState(flags)
         if result == 0:
@@ -137,8 +140,17 @@ def _prevent_system_sleep_for_supervised(logger: Any) -> None:
             )
             console.print("[yellow]Warning: Could not prevent system sleep[/yellow]")
         else:
-            logger.info("System sleep prevention enabled (ES_CONTINUOUS | ES_SYSTEM_REQUIRED)")
+            logger.info(
+                "System sleep prevention enabled"
+                " (ES_CONTINUOUS | ES_SYSTEM_REQUIRED | ES_DISPLAY_REQUIRED)"
+            )
             console.print("[green]System sleep prevention enabled[/green]")
+
+        # Warn about lid close action — this overrides SetThreadExecutionState
+        console.print(
+            "[dim]Note: Closing the laptop lid may still trigger sleep."
+            " Check Power Options > Lid Close Action.[/dim]"
+        )
 
         def _restore_sleep() -> None:
             ctypes.windll.kernel32.SetThreadExecutionState(es_continuous)

--- a/src/precog/schedulers/service_supervisor.py
+++ b/src/precog/schedulers/service_supervisor.py
@@ -727,16 +727,25 @@ class ServiceSupervisor:
             self._output_metrics()
 
     def _output_metrics(self) -> None:
-        """Collect and output aggregate metrics."""
+        """Collect and output aggregate metrics with per-service poll counts."""
         aggregate = self.get_aggregate_metrics()
 
+        # Build per-service summary for operator visibility
+        svc_parts = []
+        for name, svc_data in aggregate.get("per_service", {}).items():
+            stats = svc_data.get("stats", {})
+            polls = stats.get("polls_completed", "?")
+            errs = svc_data.get("error_count", 0)
+            svc_parts.append(f"{name}={polls}polls/{errs}err")
+
+        svc_summary = ", ".join(svc_parts) if svc_parts else "no services"
+
         self.logger.info(
-            "Metrics: healthy=%d/%d, errors=%d, restarts=%d, uptime=%.0fs",
+            "Metrics: healthy=%d/%d, uptime=%.0fs | %s",
             aggregate["services_healthy"],
             aggregate["services_total"],
-            aggregate["total_errors"],
-            aggregate["total_restarts"],
             aggregate["uptime_seconds"],
+            svc_summary,
             extra={
                 "event": "metrics",
                 "metrics": aggregate,

--- a/tests/unit/api_connectors/test_espn_team_validator.py
+++ b/tests/unit/api_connectors/test_espn_team_validator.py
@@ -406,21 +406,48 @@ class TestValidateLeagueTeams:
 
     @patch("precog.api_connectors.espn_team_validator._get_team_by_espn_id_or_code")
     @patch("precog.api_connectors.espn_team_validator.fetch_espn_teams")
-    def test_skips_teams_without_espn_id_in_db(self, mock_fetch, mock_get_team):
-        """Should skip comparison if DB team has no ESPN ID yet."""
+    def test_reports_teams_without_espn_id_as_needing_population(self, mock_fetch, mock_get_team):
+        """Teams with NULL ESPN ID should be reported as needing population."""
         mock_fetch.return_value = [
             {"id": "12", "abbreviation": "KC", "displayName": "Kansas City Chiefs"},
         ]
         mock_get_team.return_value = {
             "team_id": 1,
             "team_code": "KC",
-            "espn_team_id": None,  # No ESPN ID in DB yet
+            "espn_team_id": None,  # No ESPN ID in DB yet — should be populated
         }
 
         result = validate_league_teams("nfl")
 
-        assert result["teams_checked"] == 1  # Team found in DB, but ESPN ID is None
-        assert len(result["mismatches"]) == 0
+        assert result["teams_checked"] == 1
+        assert len(result["mismatches"]) == 1
+        assert result["mismatches"][0]["db_espn_id"] == "(NULL)"
+        assert result["mismatches"][0]["api_espn_id"] == "12"
+
+    @patch("precog.api_connectors.espn_team_validator._correct_espn_id")
+    @patch("precog.api_connectors.espn_team_validator._get_team_by_espn_id_or_code")
+    @patch("precog.api_connectors.espn_team_validator.fetch_espn_teams")
+    def test_auto_correct_populates_null_espn_id(self, mock_fetch, mock_get_team, mock_correct):
+        """Auto-correct should populate ESPN ID when DB has NULL."""
+        mock_fetch.return_value = [
+            {"id": "12", "abbreviation": "KC", "displayName": "Kansas City Chiefs"},
+        ]
+        mock_get_team.return_value = {
+            "team_id": 1,
+            "team_code": "KC",
+            "espn_team_id": None,
+        }
+
+        result = validate_league_teams("nfl", auto_correct=True)
+
+        assert len(result["mismatches"]) == 1
+        mock_correct.assert_called_once_with(
+            team_id=1,
+            team_code="KC",
+            league="nfl",
+            old_espn_id="",
+            new_espn_id="12",
+        )
 
     @patch("precog.api_connectors.espn_team_validator.fetch_espn_teams")
     def test_handles_api_network_error_gracefully(self, mock_fetch):


### PR DESCRIPTION
## Summary
- **ESPN team validator**: Fix NCAAF ping-pong corrections (deterministic fallback query with NULL-first ordering) and populate NULL ESPN IDs instead of silently skipping them
- **Sleep prevention**: Add `ES_DISPLAY_REQUIRED` flag to `SetThreadExecutionState` and warn about lid close action override
- **Supervisor metrics**: Enrich periodic metrics output with per-service poll counts and error tallies

## Agent Review Trail
| Agent | Role | Verdict | Findings |
|-------|------|---------|----------|
| Nagilum | Builder | Implemented | Three-bug fix: deterministic fallback, NULL population, cleaner league matching |
| Spock | Reviewer | APPROVE WITH NOTES | SQL correct, NULL handling correct, recommended 2 test additions (addressed 1) |
| Ripley | QA Sentinel | PASS | Progressive stabilization logic verified, no false positive scenarios |

## Test plan
- [x] All 36 ESPN validator unit tests pass (including new `test_auto_correct_populates_null_espn_id`)
- [x] Full unit suite: 1,760 passed
- [x] Pre-push suite: 974 passed, 18 skipped (Docker-dependent)
- [x] Ruff lint + format clean
- [x] Mypy clean
- [ ] CI: 5 jobs must pass
- [ ] Soak test: verify no NCAAF ping-pong corrections after first run

🤖 Generated with [Claude Code](https://claude.com/claude-code)