### PR TITLE
fix: Prevent ESPN validator cascade corruption for shared team codes

### DIFF
--- a/src/precog/api_connectors/espn_team_validator.py
+++ b/src/precog/api_connectors/espn_team_validator.py
@@ -41,7 +41,7 @@ from typing import Any
 
 import requests
 
-from precog.database.connection import fetch_one, get_cursor
+from precog.database.connection import fetch_all, get_cursor
 from precog.database.crud_operations import create_team, get_team_by_espn_id
 
 logger = logging.getLogger(__name__)
@@ -246,31 +246,33 @@ def _get_team_by_espn_id_or_code(
     espn_id: str,
     team_code: str,
     league: str,
+    exclude_team_ids: set[int] | None = None,
+    espn_display_name: str | None = None,
 ) -> dict[str, Any] | None:
     """Look up a team by ESPN ID first, falling back to team_code + league.
 
     ESPN-ID-first lookup is critical for NCAAF where multiple teams share
-    the same abbreviation code (e.g., 5 teams with code 'WES'). Looking up
-    by code alone causes ping-ponging between wrong team records on every
-    validator restart.
+    the same abbreviation code (e.g., 5 teams with code 'WES').
 
     Lookup order:
         1. Try ESPN ID + league (unique, authoritative match)
-        2. Fall back to team_code + league (backward compat for teams
-           that don't have an ESPN ID yet)
+        2. Fall back to team_code + league with disambiguation:
+           a. Exclude already-matched team_ids (prevents cascade)
+           b. Prefer name match when codes collide
+           c. Fall back to NULL-ESPN-ID-first ordering
 
     Args:
         espn_id: ESPN's unique team identifier (e.g., '12' for Chiefs)
         team_code: Our database team code (e.g., 'KC', 'WAS')
         league: League identifier (nfl, nba, nhl, ncaaf)
+        exclude_team_ids: Team IDs already matched in this validation run.
+            Prevents cascade where correcting team A's ESPN ID makes it
+            match team B's lookup in the same run.
+        espn_display_name: ESPN's displayName for the team. Used to
+            disambiguate when multiple teams share the same code.
 
     Returns:
         Dictionary with team data, or None if not found by either method.
-
-    Educational Note:
-        After migration 0018, the teams table uses espn_team_id + league
-        as the preferred lookup path. The code+league fallback handles
-        legacy teams that were created before ESPN IDs were populated.
 
     Related:
         - src/precog/database/crud_operations.py (get_team_by_espn_id)
@@ -292,20 +294,32 @@ def _get_team_by_espn_id_or_code(
                 )
             return db_team
 
-    # Fallback: code + league (for teams without ESPN IDs yet).
-    # ORDER BY prefers unassigned teams (espn_team_id IS NULL) first,
-    # then by team_id for determinism.  This prevents NCAAF ping-pong
-    # where duplicate codes (e.g. 5 teams all coded 'WES') caused a
-    # random row to be matched and "corrected" each run.
-    # NOTE: Code-only matching may assign the wrong ESPN ID when codes
-    # collide (e.g. Wesleyan vs Western Michigan).  A deeper fix using
-    # name matching is tracked separately.
-    return fetch_one(
-        "SELECT * FROM teams WHERE team_code = %s AND league = %s "
-        "ORDER BY CASE WHEN espn_team_id IS NULL THEN 0 ELSE 1 END, team_id "
-        "LIMIT 1",
-        (team_code, league),
-    )
+    # Fallback: code + league with cascade prevention.
+    # Fetch ALL candidates so we can disambiguate in Python.
+    query = "SELECT * FROM teams WHERE team_code = %s AND league = %s "
+    params: list[Any] = [team_code, league]
+
+    if exclude_team_ids:
+        query += "AND team_id != ALL(%s) "
+        params.append(list(exclude_team_ids))
+
+    query += "ORDER BY CASE WHEN espn_team_id IS NULL THEN 0 ELSE 1 END, team_id"
+
+    candidates = fetch_all(query, tuple(params))
+
+    if not candidates:
+        return None
+
+    # Name disambiguation: when multiple teams share a code, prefer
+    # the one whose team_name matches ESPN's displayName.
+    if espn_display_name and len(candidates) > 1:
+        name_lower = espn_display_name.lower()
+        name_matches = [c for c in candidates if c.get("team_name", "").lower() == name_lower]
+        if len(name_matches) == 1:
+            return name_matches[0]
+
+    # Default: first candidate (NULL ESPN ID first, then lowest team_id)
+    return candidates[0]
 
 
 # =============================================================================
@@ -465,10 +479,14 @@ def validate_league_teams(
         logger.info("No teams returned from ESPN API for %s", league.upper())
         return result
 
-    # Step 2: Compare each ESPN team against the database
+    # Step 2: Compare each ESPN team against the database.
+    # Track matched team_ids to prevent cascade: when multiple teams share
+    # a code (e.g., 5 NCAAF teams with 'HAM'), correcting one must not
+    # make it match a different ESPN team's fallback lookup in the same run.
     teams_checked = 0
     teams_created = 0
     mismatches: list[dict[str, str]] = []
+    matched_team_ids: set[int] = set()
 
     for espn_team_raw in espn_teams:
         espn_id = str(espn_team_raw.get("id", ""))
@@ -481,8 +499,16 @@ def validate_league_teams(
         # Resolve the ESPN code to our DB code (applying aliases)
         db_code = _resolve_db_code(espn_code, league)
 
-        # Look up the team: ESPN ID first, then fall back to code + league
-        db_team = _get_team_by_espn_id_or_code(espn_id, db_code, league)
+        # Look up the team: ESPN ID first, then fall back to code + league.
+        # Pass exclusion set and display name for cascade prevention and
+        # name-based disambiguation on code collisions.
+        db_team = _get_team_by_espn_id_or_code(
+            espn_id,
+            db_code,
+            league,
+            exclude_team_ids=matched_team_ids,
+            espn_display_name=espn_name,
+        )
 
         if db_team is None:
             # Auto-create missing teams for any polled league when
@@ -496,7 +522,7 @@ def validate_league_teams(
                 if created_id is not None:
                     teams_created += 1
                     teams_checked += 1
-                    # Team just created with correct ESPN ID, no mismatch
+                    matched_team_ids.add(created_id)
                     continue
             else:
                 logger.warning(
@@ -510,6 +536,7 @@ def validate_league_teams(
             continue
 
         teams_checked += 1
+        matched_team_ids.add(db_team["team_id"])
 
         # Compare ESPN IDs — NULL means "not yet assigned", treat as mismatch
         raw_espn_id = db_team.get("espn_team_id")

--- a/tests/unit/api_connectors/test_espn_team_validator.py
+++ b/tests/unit/api_connectors/test_espn_team_validator.py
@@ -245,9 +245,9 @@ class TestGetTeamByEspnIdOrCode:
         since integration tests mock this function away.
     """
 
-    @patch("precog.api_connectors.espn_team_validator.fetch_one")
+    @patch("precog.api_connectors.espn_team_validator.fetch_all")
     @patch("precog.api_connectors.espn_team_validator.get_team_by_espn_id")
-    def test_espn_id_found_returns_team(self, mock_get_by_espn, mock_fetch_one):
+    def test_espn_id_found_returns_team(self, mock_get_by_espn, mock_fetch_all):
         """Should return team when ESPN ID lookup succeeds."""
         expected = {"team_id": 1, "team_code": "KC", "espn_team_id": "12"}
         mock_get_by_espn.return_value = expected
@@ -256,12 +256,12 @@ class TestGetTeamByEspnIdOrCode:
 
         assert result == expected
         mock_get_by_espn.assert_called_once_with("12", league="nfl")
-        mock_fetch_one.assert_not_called()
+        mock_fetch_all.assert_not_called()
 
-    @patch("precog.api_connectors.espn_team_validator.fetch_one")
+    @patch("precog.api_connectors.espn_team_validator.fetch_all")
     @patch("precog.api_connectors.espn_team_validator.get_team_by_espn_id")
     def test_espn_id_found_with_code_mismatch_logs_warning(
-        self, mock_get_by_espn, mock_fetch_one, caplog
+        self, mock_get_by_espn, mock_fetch_all, caplog
     ):
         """Should log warning when ESPN ID matches but DB code differs."""
         mock_get_by_espn.return_value = {
@@ -278,45 +278,93 @@ class TestGetTeamByEspnIdOrCode:
         assert result is not None
         assert result["team_code"] == "WAS"
         assert "differs" in caplog.text
-        mock_fetch_one.assert_not_called()
+        mock_fetch_all.assert_not_called()
 
-    @patch("precog.api_connectors.espn_team_validator.fetch_one")
+    @patch("precog.api_connectors.espn_team_validator.fetch_all")
     @patch("precog.api_connectors.espn_team_validator.get_team_by_espn_id")
-    def test_fallback_when_espn_id_not_found(self, mock_get_by_espn, mock_fetch_one):
+    def test_fallback_when_espn_id_not_found(self, mock_get_by_espn, mock_fetch_all):
         """Should fall back to code+league when ESPN ID lookup returns None."""
         mock_get_by_espn.return_value = None
         expected = {"team_id": 5, "team_code": "TEST", "espn_team_id": None}
-        mock_fetch_one.return_value = expected
+        mock_fetch_all.return_value = [expected]
 
         result = _get_team_by_espn_id_or_code("999", "TEST", "nfl")
 
         assert result == expected
         mock_get_by_espn.assert_called_once_with("999", league="nfl")
-        mock_fetch_one.assert_called_once()
+        mock_fetch_all.assert_called_once()
 
-    @patch("precog.api_connectors.espn_team_validator.fetch_one")
+    @patch("precog.api_connectors.espn_team_validator.fetch_all")
     @patch("precog.api_connectors.espn_team_validator.get_team_by_espn_id")
-    def test_fallback_when_espn_id_empty(self, mock_get_by_espn, mock_fetch_one):
+    def test_fallback_when_espn_id_empty(self, mock_get_by_espn, mock_fetch_all):
         """Should skip ESPN ID lookup and go straight to fallback when ID is empty."""
         expected = {"team_id": 5, "team_code": "OLD", "espn_team_id": None}
-        mock_fetch_one.return_value = expected
+        mock_fetch_all.return_value = [expected]
 
         result = _get_team_by_espn_id_or_code("", "OLD", "nfl")
 
         assert result == expected
         mock_get_by_espn.assert_not_called()
-        mock_fetch_one.assert_called_once()
+        mock_fetch_all.assert_called_once()
 
-    @patch("precog.api_connectors.espn_team_validator.fetch_one")
+    @patch("precog.api_connectors.espn_team_validator.fetch_all")
     @patch("precog.api_connectors.espn_team_validator.get_team_by_espn_id")
-    def test_both_paths_return_none(self, mock_get_by_espn, mock_fetch_one):
+    def test_both_paths_return_none(self, mock_get_by_espn, mock_fetch_all):
         """Should return None when team not found by either method."""
         mock_get_by_espn.return_value = None
-        mock_fetch_one.return_value = None
+        mock_fetch_all.return_value = []
 
         result = _get_team_by_espn_id_or_code("999", "UNKNOWN", "nfl")
 
         assert result is None
+
+    @patch("precog.api_connectors.espn_team_validator.fetch_all")
+    @patch("precog.api_connectors.espn_team_validator.get_team_by_espn_id")
+    def test_name_disambiguation_picks_correct_team(self, mock_get_by_espn, mock_fetch_all):
+        """When multiple teams share a code, prefer the name match."""
+        mock_get_by_espn.return_value = None
+        mock_fetch_all.return_value = [
+            {
+                "team_id": 10,
+                "team_code": "HAM",
+                "team_name": "Hamilton Continentals",
+                "espn_team_id": None,
+            },
+            {
+                "team_id": 20,
+                "team_code": "HAM",
+                "team_name": "Hamline Pipers",
+                "espn_team_id": None,
+            },
+        ]
+
+        result = _get_team_by_espn_id_or_code(
+            "162", "HAM", "ncaaf", espn_display_name="Hamline Pipers"
+        )
+
+        assert result["team_id"] == 20
+        assert result["team_name"] == "Hamline Pipers"
+
+    @patch("precog.api_connectors.espn_team_validator.fetch_all")
+    @patch("precog.api_connectors.espn_team_validator.get_team_by_espn_id")
+    def test_exclusion_set_filters_matched_teams(self, mock_get_by_espn, mock_fetch_all):
+        """Already-matched team_ids should be excluded from fallback."""
+        mock_get_by_espn.return_value = None
+        mock_fetch_all.return_value = [
+            {
+                "team_id": 20,
+                "team_code": "HAM",
+                "team_name": "Hamline Pipers",
+                "espn_team_id": None,
+            },
+        ]
+
+        result = _get_team_by_espn_id_or_code("297", "HAM", "ncaaf", exclude_team_ids={10})
+
+        # Verify the exclusion was passed in the SQL query
+        call_args = mock_fetch_all.call_args
+        assert [10] in list(call_args[0][1])  # list(exclude_ids) in params
+        assert result["team_id"] == 20
 
 
 # =============================================================================
@@ -386,7 +434,13 @@ class TestValidateLeagueTeams:
         result = validate_league_teams("nfl")
 
         # Should have looked up with ESPN ID '28', resolved code 'WAS', league 'nfl'
-        mock_get_team.assert_called_with("28", "WAS", "nfl")
+        mock_get_team.assert_called_with(
+            "28",
+            "WAS",
+            "nfl",
+            exclude_team_ids=mock_get_team.call_args[1]["exclude_team_ids"],
+            espn_display_name="Washington Commanders",
+        )
         assert result["teams_checked"] == 1
         assert len(result["mismatches"]) == 0
 
@@ -519,7 +573,7 @@ class TestValidateLeagueTeams:
             {"id": "25", "abbreviation": "SF", "displayName": "San Francisco 49ers"},
         ]
 
-        def side_effect(espn_id, code, league):
+        def side_effect(espn_id, code, league, **kwargs):
             db_teams = {
                 "KC": {"team_id": 1, "team_code": "KC", "espn_team_id": "12"},  # match
                 "BUF": {"team_id": 2, "team_code": "BUF", "espn_team_id": "99"},  # mismatch
@@ -534,6 +588,75 @@ class TestValidateLeagueTeams:
         assert result["teams_checked"] == 3
         assert len(result["mismatches"]) == 1
         assert result["mismatches"][0]["team_code"] == "BUF"
+
+    @patch("precog.api_connectors.espn_team_validator._correct_espn_id")
+    @patch("precog.api_connectors.espn_team_validator._get_team_by_espn_id_or_code")
+    @patch("precog.api_connectors.espn_team_validator.fetch_espn_teams")
+    def test_cascade_prevention_same_code_teams(self, mock_fetch, mock_get_team, mock_correct):
+        """Three ESPN teams sharing code 'HAM' must each match a DIFFERENT DB row.
+
+        This is the cascade prevention test: without the exclusion set,
+        correcting team 1's ESPN ID in the DB makes it visible to team 2's
+        primary lookup, causing team 2 to steal team 1's row. The exclusion
+        set prevents any row from being matched twice in one run.
+        """
+        mock_fetch.return_value = [
+            {"id": "162", "abbreviation": "HAM", "displayName": "Hamline Pipers"},
+            {"id": "297", "abbreviation": "HAM", "displayName": "Hampden-Sydney Tigers"},
+            {"id": "348", "abbreviation": "HAM", "displayName": "Hamilton Continentals"},
+        ]
+
+        # Simulate 3 DB rows with code 'HAM', all with NULL ESPN IDs.
+        # The exclusion set should grow after each match, preventing re-use.
+        call_count = 0
+
+        def side_effect(espn_id, code, league, **kwargs):
+            nonlocal call_count
+            exclude = kwargs.get("exclude_team_ids", set())
+
+            # Each call should see a growing exclusion set
+            if call_count == 0:
+                assert len(exclude) == 0
+                call_count += 1
+                return {
+                    "team_id": 100,
+                    "team_code": "HAM",
+                    "team_name": "Hamline Pipers",
+                    "espn_team_id": None,
+                }
+            if call_count == 1:
+                assert 100 in exclude  # team_id 100 already matched
+                call_count += 1
+                return {
+                    "team_id": 200,
+                    "team_code": "HAM",
+                    "team_name": "Hampden-Sydney Tigers",
+                    "espn_team_id": None,
+                }
+            assert 100 in exclude  # both already matched
+            assert 200 in exclude
+            call_count += 1
+            return {
+                "team_id": 300,
+                "team_code": "HAM",
+                "team_name": "Hamilton Continentals",
+                "espn_team_id": None,
+            }
+
+        mock_get_team.side_effect = side_effect
+
+        result = validate_league_teams("ncaaf", auto_correct=True)
+
+        assert result["teams_checked"] == 3
+        assert len(result["mismatches"]) == 3
+
+        # Each correction must target a DIFFERENT team_id
+        corrected_ids = [call.kwargs["team_id"] for call in mock_correct.call_args_list]
+        assert corrected_ids == [100, 200, 300], f"Expected [100, 200, 300], got {corrected_ids}"
+
+        # Each correction must set the correct ESPN ID
+        corrected_espn = [call.kwargs["new_espn_id"] for call in mock_correct.call_args_list]
+        assert corrected_espn == ["162", "297", "348"]
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- **Root cause**: When multiple NCAAF teams share the same code (e.g., 5 teams with 'HAM'), `_correct_espn_id` commits immediately (`commit=True`), making corrected rows visible to subsequent loop iterations. This caused in-run cascade corruption — each team would steal the previous team's DB row.
- **Fix**: Track `matched_team_ids` exclusion set within `validate_league_teams`. Pass to `_get_team_by_espn_id_or_code` which uses `fetch_all` + SQL exclusion (`AND team_id != ALL(%s)`) to prevent any DB row from matching twice. Added name-based disambiguation when multiple candidates share a code.
- **Previous fix** (PR #348) only addressed cross-run ping-pong via ORDER BY, not the in-run cascade.

## Changes
- `espn_team_validator.py`: Switched from `fetch_one` to `fetch_all`, added exclusion set tracking, added name disambiguation logic
- `test_espn_team_validator.py`: Updated all mocks for new signature, added 3 new tests (cascade prevention, exclusion set, name disambiguation)

## Agent Review Trail
| Agent | Role | Verdict | Key Finding |
|-------|------|---------|-------------|
| **Galadriel** (Plan) | Architect/Diagnosis | Designed dual fix | Exclusion set + name disambiguation approach |
| **Brawne** | Reviewer | APPROVE WITH NOTES | Primary path safe due to ESPN ID uniqueness |
| **Marvin** | Sentinel/QA | CONDITIONAL PASS | Name disambiguation is weakest link (exact match only) |
| **Armitage** | Quant/Retrospective | Process findings | 4 missed S-table triggers identified, proposed S23 + Mock Fidelity Rule |

## Retrospective Actions (workflow improvements)
- Added **S23** trigger: "Mutation Loop Audit" — code that iterates + commits inside loop → mandatory Holden + Brawne + Marvin
- Updated **T8**: Clarified Marvin escalation for idempotency violations
- Added **Mock Fidelity Rule** to protocols.md: stateful mocks required when code reads-then-writes DB in a loop
- Added **feedback memory**: enforce subagent template usage for all delegations

## Test plan
- [x] All 1,764 unit tests pass
- [x] Ruff lint + format clean
- [x] Pre-push hooks pass (all checks green)
- [x] Key new test: `test_cascade_prevention_same_code_teams` — 3 ESPN teams sharing code 'HAM' must each match a DIFFERENT DB row
- [ ] Verify in production soak test: startup should show 0 auto-corrections (or only legitimate new teams)

🤖 Generated with [Claude Code](https://claude.com/claude-code)