### PR TITLE
docs: Add examples to system CLI, close #281

### DIFF
--- a/src/precog/cli/system.py
+++ b/src/precog/cli/system.py
@@ -58,6 +58,10 @@ def health(
         - API credentials configuration
         - Service status
         - Configuration validity
+
+    Examples:
+        precog system health
+        precog system health --verbose
     """
     console.print("[bold]Precog Health Check[/bold]\n")
 
@@ -163,7 +167,11 @@ def health(
 
 @app.command()
 def version() -> None:
-    """Show version information."""
+    """Show version information.
+
+    Examples:
+        precog system version
+    """
     try:
         from precog import __version__
 
@@ -186,6 +194,9 @@ def info() -> None:
         - Key dependency versions
         - Configuration paths
         - Environment settings
+
+    Examples:
+        precog system info
     """
     console.print("[bold]Precog System Information[/bold]\n")
 


### PR DESCRIPTION
## Summary
- Add `Examples:` blocks to the 3 system CLI commands (health, version, info) — the only commands missing them out of 30+
- Close #281 by adopting a self-documenting approach: Builder HEADER rules + Reviewer checklist enforce CLI help text on every new command, eliminating the need for periodic doc sprints

Closes #281

## Test plan
- [x] 60 CLI unit tests pass
- [x] 933 pre-push tests pass
- [x] Doc-only change (docstring additions) — no runtime behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)