### PR TITLE
feat: Wire KalshiDataValidator into ingestion pipeline (#337)

### DIFF
--- a/src/precog/schedulers/kalshi_poller.py
+++ b/src/precog/schedulers/kalshi_poller.py
@@ -43,7 +43,7 @@ Related ADR: ADR-100 (Service Supervisor Pattern)
 
 import logging
 from decimal import Decimal
-from typing import ClassVar
+from typing import Any, ClassVar, cast
 
 from precog.api_connectors.kalshi_client import KalshiClient
 from precog.api_connectors.types import ProcessedMarketData, SeriesData
@@ -56,6 +56,7 @@ from precog.database.crud_operations import (
     update_market_with_versioning,
 )
 from precog.schedulers.base_poller import BasePoller
+from precog.validation.kalshi_validation import KalshiDataValidator
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -176,12 +177,30 @@ class KalshiMarketPoller(BasePoller):
         # Initialize Kalshi client (or use provided mock)
         self.kalshi_client = kalshi_client or KalshiClient(environment=environment)
 
+        # Initialize data validator (instance-level, NOT module-level singleton,
+        # because _anomaly_counts is stateful per-poller)
+        self._validator = KalshiDataValidator()
+
+        # Validation stats tracked separately from PollerStats TypedDict
+        # to avoid type contract violations. Merged in get_stats().
+        self._validation_stats: dict[str, int] = {
+            "validation_errors": 0,
+            "validation_warnings": 0,
+        }
+
         logger.info(
             "KalshiMarketPoller initialized: series=%s, poll_interval=%ds, env=%s",
             self.series_tickers,
             self.poll_interval,
             self.environment,
         )
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get stats including validation counters."""
+        with self._lock:
+            stats = dict(self._stats)
+            stats.update(self._validation_stats)
+            return stats
 
     def _get_job_name(self) -> str:
         """Return human-readable name for the polling job."""
@@ -527,6 +546,46 @@ class KalshiMarketPoller(BasePoller):
         all_markets = self.kalshi_client.fetch_all_markets(
             series_tickers=[series_ticker],
         )
+
+        # Validate fetched market data (soft validation — log issues, never block ingestion).
+        # Runs on raw API data before any DB mapping or filtering.
+        # Wrapped in try/except: a validator bug must NEVER prevent market syncing.
+        try:
+            validation_results = self._validator.validate_markets(
+                cast("list[dict[str, Any]]", all_markets)
+            )
+            error_count = sum(1 for r in validation_results if r.has_errors)
+            warning_count = sum(
+                1 for r in validation_results if r.has_warnings and not r.has_errors
+            )
+            valid_count = len(all_markets) - error_count
+
+            # Log individual issues at appropriate levels
+            for vr in validation_results:
+                if vr.has_errors or vr.has_warnings:
+                    vr.log_issues(logger)
+
+            # Summary log: INFO if errors exist, DEBUG otherwise
+            summary_log = logger.info if error_count else logger.debug
+            summary_log(
+                "Validation [%s]: %d markets checked, %d valid, %d errors, %d warnings",
+                series_ticker,
+                len(all_markets),
+                valid_count,
+                error_count,
+                warning_count,
+            )
+
+            # Track validation stats (separate dict, merged in get_stats)
+            with self._lock:
+                self._validation_stats["validation_errors"] += error_count
+                self._validation_stats["validation_warnings"] += warning_count
+        except Exception as e:
+            logger.error(
+                "Validation failed for series %s (ingestion continues): %s",
+                series_ticker,
+                e,
+            )
 
         markets_updated = 0
         markets_created = 0

--- a/src/precog/validation/kalshi_validation.py
+++ b/src/precog/validation/kalshi_validation.py
@@ -450,8 +450,25 @@ class KalshiDataValidator:
             result.add_error("ticker", "Missing or empty ticker")
 
         # Validate status
+        # Includes both database-mapped statuses (open, closed, settled, halted)
+        # and raw Kalshi API statuses (active, unopened, determined, finalized,
+        # initialized, inactive). The poller maps API statuses to DB statuses
+        # via STATUS_MAPPING, but validation runs on raw API data before mapping.
         status = market.get("status")
-        valid_statuses = {"open", "closed", "settled"}
+        valid_statuses = {
+            # Database-mapped statuses
+            "open",
+            "closed",
+            "settled",
+            "halted",
+            # Raw Kalshi API statuses (mapped to DB statuses by the poller)
+            "active",
+            "unopened",
+            "determined",
+            "finalized",
+            "initialized",
+            "inactive",
+        }
         if status and status not in valid_statuses:
             result.add_warning(
                 "status",

--- a/tests/unit/schedulers/test_kalshi_poller.py
+++ b/tests/unit/schedulers/test_kalshi_poller.py
@@ -509,3 +509,186 @@ class TestGetActiveMarketCount:
         """get_active_market_count returns 0 when no open markets exist."""
         mock_count.return_value = 0
         assert poller_with_mock_client.get_active_market_count() == 0
+
+
+# =============================================================================
+# Validation Integration Tests
+# =============================================================================
+
+
+class TestKalshiPollerValidation:
+    """Test validation integration in the polling pipeline."""
+
+    @pytest.mark.unit
+    def test_poller_has_validator_instance(self, poller_with_mock_client):
+        """Poller creates a KalshiDataValidator in __init__."""
+        from precog.validation.kalshi_validation import KalshiDataValidator
+
+        assert hasattr(poller_with_mock_client, "_validator")
+        assert isinstance(poller_with_mock_client._validator, KalshiDataValidator)
+
+    @pytest.mark.unit
+    def test_poll_series_calls_validator(self, poller_with_mock_client, mock_market_data_list):
+        """_poll_series calls validate_markets on fetched data."""
+        poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = mock_market_data_list
+
+        with (
+            patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None),
+            patch("precog.schedulers.kalshi_poller.get_or_create_event"),
+            patch("precog.schedulers.kalshi_poller.create_market"),
+            patch.object(
+                poller_with_mock_client._validator,
+                "validate_markets",
+                wraps=poller_with_mock_client._validator.validate_markets,
+            ) as mock_validate,
+        ):
+            poller_with_mock_client._poll_series("KXNFLGAME")
+
+            mock_validate.assert_called_once_with(mock_market_data_list)
+
+    @pytest.mark.unit
+    def test_validation_does_not_block_ingestion(self, poller_with_mock_client):
+        """Markets with validation errors are still synced to DB."""
+        # Market with invalid data (negative volume -> ERROR)
+        bad_market = {
+            "ticker": "KXNFLGAME-BAD",
+            "event_ticker": "KXNFLGAME-EVENT",
+            "title": "Bad Market",
+            "status": "active",
+            "yes_ask_dollars": Decimal("0.50"),
+            "no_ask_dollars": Decimal("0.50"),
+            "volume": -100,  # Invalid: negative volume triggers ERROR
+            "open_interest": 0,
+        }
+
+        poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = [bad_market]
+
+        with (
+            patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None),
+            patch("precog.schedulers.kalshi_poller.get_or_create_event"),
+            patch(
+                "precog.schedulers.kalshi_poller.create_market", return_value="MKT-1"
+            ) as mock_create,
+        ):
+            fetched, _updated, created = poller_with_mock_client._poll_series("KXNFLGAME")
+
+            # Market must still be persisted despite validation error
+            assert fetched == 1
+            assert created == 1
+            mock_create.assert_called_once()
+
+    @pytest.mark.unit
+    def test_validation_summary_logged_debug_when_clean(
+        self, poller_with_mock_client, mock_market_data_list, caplog
+    ):
+        """Validation summary uses DEBUG when no errors found."""
+        poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = mock_market_data_list
+
+        with (
+            patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None),
+            patch("precog.schedulers.kalshi_poller.get_or_create_event"),
+            patch("precog.schedulers.kalshi_poller.create_market"),
+        ):
+            import logging
+
+            with caplog.at_level(logging.DEBUG, logger="precog.schedulers.kalshi_poller"):
+                poller_with_mock_client._poll_series("KXNFLGAME")
+
+            assert "Validation [KXNFLGAME]" in caplog.text
+            assert "2 markets checked" in caplog.text
+
+    @pytest.mark.unit
+    def test_validation_summary_logged_info_when_errors(self, poller_with_mock_client, caplog):
+        """Validation summary uses INFO when errors found."""
+        bad_market = {
+            "ticker": "KXNFLGAME-BAD",
+            "event_ticker": "KXNFLGAME-EVENT",
+            "title": "Bad Market",
+            "status": "active",
+            "yes_ask_dollars": Decimal("0.50"),
+            "no_ask_dollars": Decimal("0.50"),
+            "volume": -100,  # Triggers validation ERROR
+            "open_interest": 0,
+        }
+        poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = [bad_market]
+
+        with (
+            patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None),
+            patch("precog.schedulers.kalshi_poller.get_or_create_event"),
+            patch("precog.schedulers.kalshi_poller.create_market"),
+        ):
+            import logging
+
+            with caplog.at_level(logging.DEBUG, logger="precog.schedulers.kalshi_poller"):
+                poller_with_mock_client._poll_series("KXNFLGAME")
+
+            assert "Validation [KXNFLGAME]" in caplog.text
+            assert "1 errors" in caplog.text
+
+    @pytest.mark.unit
+    def test_validation_stats_tracked(self, poller_with_mock_client):
+        """Validation errors and warnings are tracked in poller stats."""
+        bad_market = {
+            "ticker": "KXNFLGAME-BAD",
+            "event_ticker": "KXNFLGAME-EVENT",
+            "title": "Bad Market",
+            "status": "active",
+            "yes_ask_dollars": Decimal("0.50"),
+            "no_ask_dollars": Decimal("0.50"),
+            "volume": -100,  # Triggers validation ERROR
+            "open_interest": 0,
+        }
+        poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = [bad_market]
+
+        with (
+            patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None),
+            patch("precog.schedulers.kalshi_poller.get_or_create_event"),
+            patch("precog.schedulers.kalshi_poller.create_market"),
+        ):
+            poller_with_mock_client._poll_series("KXNFLGAME")
+
+        stats = poller_with_mock_client.get_stats()
+        assert stats["validation_errors"] == 1
+        assert stats["validation_warnings"] == 0
+
+    @pytest.mark.unit
+    def test_validation_exception_does_not_block_ingestion(self, poller_with_mock_client):
+        """If the validator itself throws, markets are still synced to DB."""
+        market = {
+            "ticker": "KXNFLGAME-25NOV29-NEBUF-B250",
+            "event_ticker": "KXNFLGAME-EVENT",
+            "title": "Test Market",
+            "status": "active",
+            "yes_ask_dollars": Decimal("0.50"),
+            "no_ask_dollars": Decimal("0.50"),
+            "volume": 100,
+            "open_interest": 50,
+        }
+        poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = [market]
+
+        # Force the validator to throw
+        with (
+            patch.object(
+                poller_with_mock_client._validator,
+                "validate_markets",
+                side_effect=RuntimeError("validator exploded"),
+            ),
+            patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None),
+            patch("precog.schedulers.kalshi_poller.get_or_create_event"),
+            patch(
+                "precog.schedulers.kalshi_poller.create_market", return_value="MKT-1"
+            ) as mock_create,
+        ):
+            fetched, _updated, created = poller_with_mock_client._poll_series("KXNFLGAME")
+
+            # Market MUST still be persisted despite validator crash
+            assert fetched == 1
+            assert created == 1
+            mock_create.assert_called_once()
+
+    @pytest.mark.unit
+    def test_validation_stats_initialized_before_first_poll(self, poller_with_mock_client):
+        """Validation stats keys exist immediately, before any poll runs."""
+        stats = poller_with_mock_client.get_stats()
+        assert stats["validation_errors"] == 0
+        assert stats["validation_warnings"] == 0

--- a/tests/unit/validation/test_kalshi_validation.py
+++ b/tests/unit/validation/test_kalshi_validation.py
@@ -316,12 +316,18 @@ class TestMarketDataValidation:
         assert result.has_warnings
 
     def test_valid_statuses_accepted(self, validator: KalshiDataValidator) -> None:
-        """Valid statuses (open, closed, settled) are accepted."""
-        for status in ["open", "closed", "settled"]:
+        """All valid statuses (DB-mapped and raw Kalshi API) are accepted."""
+        # Database-mapped statuses
+        db_statuses = ["open", "closed", "settled", "halted"]
+        # Raw Kalshi API statuses (mapped by poller before DB insert)
+        api_statuses = ["active", "unopened", "determined", "finalized", "initialized", "inactive"]
+        for status in db_statuses + api_statuses:
             market = {"ticker": "TEST", "status": status}
             result = validator.validate_market_data(market)
             # Should not have status-related warnings
-            assert not any("status" in w.field for w in result.warnings)
+            assert not any("status" in w.field for w in result.warnings), (
+                f"Status '{status}' should be accepted but generated a warning"
+            )
 
     def test_negative_volume_error(self, validator: KalshiDataValidator) -> None:
         """Negative volume generates error."""


### PR DESCRIPTION
## Summary
- Wire existing `KalshiDataValidator` (14 checks, previously dead code) into `_poll_series()` as soft validation
- Expand `valid_statuses` to include raw Kalshi API statuses (`active`, `unopened`, `determined`, etc.)
- Guard validation block with `try/except` — a validator bug can never block market ingestion
- Track validation stats via separate dict merged in overridden `get_stats()`
- Add 8 new tests covering: call verification, non-blocking guarantee, logging levels, stats tracking, exception safety, stats initialization

## Test plan
- [x] All 1,740 unit tests pass (0 failures)
- [x] All 933 pre-push tests pass (unit + integration + e2e + property + stress + race + chaos)
- [x] Ruff lint clean, mypy clean (0 errors)
- [x] Reviewed by Spock (Pragmatic Reviewer) — 1 blocker found and fixed (stats initialization)
- [x] QA by Ripley (Targeted Sentinel) — conditional pass, 2 warnings addressed (try/except guard, mypy compliance)

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)