### PR TITLE
feat: Migration 0023 — edges enrichment and lifecycle tracking

### DIFF
--- a/src/precog/database/alembic/versions/0023_edges_enrichment.py
+++ b/src/precog/database/alembic/versions/0023_edges_enrichment.py
@@ -1,0 +1,209 @@
+"""Enrich edges table with analytics-ready columns and lifecycle tracking.
+
+Adds 15 new columns to the edges table for full edge lifecycle tracking:
+detection -> recommendation -> execution -> settlement -> outcome.
+
+Also drops the dead probability_matrix_id FK column (the probability_matrices
+table itself is dropped later in migration 0030).
+
+New columns:
+  - actual_outcome: Settlement result ('yes', 'no', 'void', 'unresolved')
+  - settlement_value: Actual settlement price (DECIMAL(10,4))
+  - resolved_at: When the edge was resolved
+  - strategy_id: FK to strategies(strategy_id) for attribution
+  - edge_status: Lifecycle status ('detected' -> 'settled')
+  - yes_ask_price, no_ask_price: Kalshi ask price snapshots at detection
+  - spread, volume, open_interest, last_price, liquidity: Market microstructure
+  - category, subcategory: Market classification
+  - execution_environment: 'live', 'paper', 'backtest'
+
+New views:
+  - edge_lifecycle: Edges with computed realized_pnl and hours_to_resolution
+
+This is a CLEAN DB migration -- no production data to preserve.
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-03-21
+
+Related:
+- Issue #366: FK integrity
+- migration_batch_plan_v1.md: Migration 0023 spec
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0023"
+down_revision: str = "0022"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add analytics columns, drop probability_matrix_id, create edge_lifecycle view.
+
+    Steps:
+    1. Drop current_edges view (Pattern 38 -- view binds to columns)
+    2. Drop probability_matrix_id FK + column
+    3. Add 15 new columns
+    4. Add partial indexes for common query patterns
+    5. Recreate current_edges view
+    6. Create edge_lifecycle view with computed fields
+    """
+    # Step 1: Drop current_edges view (Pattern 38)
+    # SELECT * views bind to columns at creation time -- dropping a column
+    # that the view references will fail with DependentObjectsStillExist.
+    op.execute("DROP VIEW IF EXISTS current_edges")
+
+    # Step 2: Drop probability_matrix_id FK and column
+    op.execute("ALTER TABLE edges DROP CONSTRAINT IF EXISTS edges_probability_matrix_id_fkey")
+    op.execute("ALTER TABLE edges DROP COLUMN IF EXISTS probability_matrix_id")
+
+    # Step 3: Add new columns (all NULLABLE -- existing SCD versions get NULLs)
+    op.execute("""
+        ALTER TABLE edges ADD COLUMN IF NOT EXISTS actual_outcome VARCHAR(20)
+            CHECK (actual_outcome IN ('yes', 'no', 'void', 'unresolved'))
+    """)
+    op.execute("ALTER TABLE edges ADD COLUMN IF NOT EXISTS settlement_value DECIMAL(10,4)")
+    op.execute("ALTER TABLE edges ADD COLUMN IF NOT EXISTS resolved_at TIMESTAMP WITH TIME ZONE")
+    op.execute(
+        "ALTER TABLE edges ADD COLUMN IF NOT EXISTS strategy_id INTEGER "
+        "REFERENCES strategies(strategy_id) ON DELETE SET NULL"
+    )
+    op.execute("""
+        ALTER TABLE edges ADD COLUMN IF NOT EXISTS edge_status VARCHAR(30)
+            DEFAULT 'detected'
+            CHECK (edge_status IN (
+                'detected', 'recommended', 'acted_on',
+                'expired', 'settled', 'void'
+            ))
+    """)
+    op.execute("ALTER TABLE edges ADD COLUMN IF NOT EXISTS yes_ask_price DECIMAL(10,4)")
+    op.execute("ALTER TABLE edges ADD COLUMN IF NOT EXISTS no_ask_price DECIMAL(10,4)")
+    op.execute("ALTER TABLE edges ADD COLUMN IF NOT EXISTS spread DECIMAL(10,4)")
+    op.execute("ALTER TABLE edges ADD COLUMN IF NOT EXISTS volume INTEGER")
+    op.execute("ALTER TABLE edges ADD COLUMN IF NOT EXISTS open_interest INTEGER")
+    op.execute("ALTER TABLE edges ADD COLUMN IF NOT EXISTS last_price DECIMAL(10,4)")
+    op.execute("ALTER TABLE edges ADD COLUMN IF NOT EXISTS liquidity DECIMAL(10,4)")
+    op.execute("ALTER TABLE edges ADD COLUMN IF NOT EXISTS category VARCHAR(100)")
+    op.execute("ALTER TABLE edges ADD COLUMN IF NOT EXISTS subcategory VARCHAR(100)")
+    op.execute("""
+        ALTER TABLE edges ADD COLUMN IF NOT EXISTS execution_environment VARCHAR(20)
+            DEFAULT 'live'
+            CHECK (execution_environment IN ('live', 'paper', 'backtest'))
+    """)
+
+    # Step 4: Add partial indexes for common analytics queries
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_edges_strategy "
+        "ON edges(strategy_id) WHERE row_current_ind = TRUE"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_edges_status "
+        "ON edges(edge_status) WHERE row_current_ind = TRUE"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_edges_category "
+        "ON edges(category) WHERE row_current_ind = TRUE"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_edges_resolved "
+        "ON edges(resolved_at) WHERE resolved_at IS NOT NULL"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_edges_exec_env "
+        "ON edges(execution_environment) WHERE row_current_ind = TRUE"
+    )
+
+    # Step 5: Recreate current_edges view
+    op.execute(
+        "CREATE OR REPLACE VIEW current_edges AS SELECT * FROM edges WHERE row_current_ind = TRUE"
+    )
+
+    # Step 6: Create edge_lifecycle view with computed analytics fields
+    op.execute("""
+        CREATE OR REPLACE VIEW edge_lifecycle AS
+        SELECT
+            e.id,
+            e.edge_id,
+            e.market_internal_id,
+            e.model_id,
+            e.strategy_id,
+            e.expected_value,
+            e.true_win_probability,
+            e.market_implied_probability,
+            e.market_price,
+            e.yes_ask_price,
+            e.no_ask_price,
+            e.edge_status,
+            e.actual_outcome,
+            e.settlement_value,
+            e.confidence_level,
+            e.execution_environment,
+            e.created_at,
+            e.resolved_at,
+            -- P&L assumes YES-side position (edge detection = buy YES)
+            CASE
+                WHEN e.actual_outcome = 'yes' THEN e.settlement_value - e.market_price
+                WHEN e.actual_outcome = 'no' THEN e.market_price - e.settlement_value
+                ELSE NULL
+            END AS realized_pnl,
+            CASE
+                WHEN e.resolved_at IS NOT NULL AND e.created_at IS NOT NULL
+                THEN EXTRACT(EPOCH FROM (e.resolved_at - e.created_at)) / 3600.0
+                ELSE NULL
+            END AS hours_to_resolution
+        FROM edges e
+        WHERE e.row_current_ind = TRUE
+    """)
+
+
+def downgrade() -> None:
+    """Reverse: drop new columns/views, restore probability_matrix_id."""
+    # Drop views first
+    op.execute("DROP VIEW IF EXISTS edge_lifecycle")
+    op.execute("DROP VIEW IF EXISTS current_edges")
+
+    # Drop new indexes
+    for idx in [
+        "idx_edges_strategy",
+        "idx_edges_status",
+        "idx_edges_category",
+        "idx_edges_resolved",
+        "idx_edges_exec_env",
+    ]:
+        op.execute(f"DROP INDEX IF EXISTS {idx}")
+
+    # Drop new columns (reverse order of addition)
+    for col in [
+        "execution_environment",
+        "subcategory",
+        "category",
+        "liquidity",
+        "last_price",
+        "open_interest",
+        "volume",
+        "spread",
+        "no_ask_price",
+        "yes_ask_price",
+        "edge_status",
+        "strategy_id",
+        "resolved_at",
+        "settlement_value",
+        "actual_outcome",
+    ]:
+        op.execute(f"ALTER TABLE edges DROP COLUMN IF EXISTS {col}")
+
+    # Re-add probability_matrix_id
+    op.execute(
+        "ALTER TABLE edges ADD COLUMN probability_matrix_id INTEGER "
+        "REFERENCES probability_matrices(probability_id) ON DELETE SET NULL"
+    )
+
+    # Recreate current_edges view
+    op.execute(
+        "CREATE OR REPLACE VIEW current_edges AS SELECT * FROM edges WHERE row_current_ind = TRUE"
+    )

--- a/src/precog/database/crud_operations.py
+++ b/src/precog/database/crud_operations.py
@@ -5775,3 +5775,413 @@ def get_active_breakers(breaker_type: str | None = None) -> list[dict[str, Any]]
         ORDER BY triggered_at DESC
     """
     return fetch_all(query)
+
+
+# =============================================================================
+# EDGE OPERATIONS
+# =============================================================================
+#
+# Migration 0023: edges table enriched with analytics-ready columns.
+#   - probability_matrix_id dropped (dead FK)
+#   - New columns: actual_outcome, settlement_value, resolved_at, strategy_id,
+#     edge_status, yes_ask_price, no_ask_price, spread, volume, open_interest,
+#     last_price, liquidity, category, subcategory, execution_environment
+#   - New views: current_edges (recreated), edge_lifecycle (computed P&L)
+#
+# SCD Type 2: edges use row_current_ind versioning.
+#   - create_edge: sets row_current_ind = TRUE
+#   - update_edge_outcome / update_edge_status: direct updates (lifecycle
+#     events, not version changes)
+# =============================================================================
+
+
+def create_edge(
+    market_internal_id: int,
+    model_id: int,
+    expected_value: Decimal,
+    true_win_probability: Decimal,
+    market_implied_probability: Decimal,
+    market_price: Decimal,
+    yes_ask_price: Decimal | None = None,
+    no_ask_price: Decimal | None = None,
+    spread: Decimal | None = None,
+    volume: int | None = None,
+    open_interest: int | None = None,
+    last_price: Decimal | None = None,
+    liquidity: Decimal | None = None,
+    strategy_id: int | None = None,
+    confidence_level: str | None = None,
+    confidence_metrics: dict | None = None,
+    recommended_action: str | None = None,
+    category: str | None = None,
+    subcategory: str | None = None,
+    execution_environment: ExecutionEnvironment = "live",
+) -> int:
+    """
+    Create a new edge record with SCD Type 2 row_current_ind = TRUE.
+
+    An edge represents a detected positive expected value opportunity: the
+    difference between the model's predicted probability and the market's
+    implied probability. This function captures the full market microstructure
+    snapshot at the moment of edge detection.
+
+    Args:
+        market_internal_id: Integer FK to markets(id) surrogate PK
+        model_id: FK to probability_models(model_id) that detected this edge
+        expected_value: Expected value of the edge as DECIMAL(10,4)
+        true_win_probability: Model's predicted probability [0, 1]
+        market_implied_probability: Market-implied probability [0, 1]
+        market_price: Market price at detection [0, 1]
+        yes_ask_price: Kalshi YES ask price snapshot at detection
+        no_ask_price: Kalshi NO ask price snapshot at detection
+        spread: Bid-ask spread as DECIMAL(10,4)
+        volume: Trading volume at detection
+        open_interest: Open interest at detection
+        last_price: Last traded price at detection
+        liquidity: Market liquidity metric
+        strategy_id: FK to strategies(strategy_id) for attribution
+        confidence_level: 'high', 'medium', or 'low'
+        confidence_metrics: Additional confidence data as JSONB
+        recommended_action: 'auto_execute', 'alert', or 'ignore'
+        category: Market category (e.g., 'sports', 'politics')
+        subcategory: Market subcategory (e.g., 'nfl', 'ncaaf')
+        execution_environment: 'live', 'paper', or 'backtest' (default 'live')
+
+    Returns:
+        Integer surrogate PK (edges.id) of the newly created edge.
+
+    Educational Note:
+        Dual-Key Structure (Migration 017):
+        - id SERIAL (surrogate key) - returned by this function
+        - edge_id VARCHAR (business key) - auto-generated as EDGE-{id}
+        - Enables SCD Type 2 versioning (multiple versions of same edge)
+
+        Edge Lifecycle (Migration 0023):
+        - Edges start as 'detected' and progress through:
+          detected -> recommended -> acted_on -> settled/expired/void
+        - Outcome tracking via actual_outcome + settlement_value
+        - P&L computed in edge_lifecycle view
+
+    Example:
+        >>> edge_pk = create_edge(
+        ...     market_internal_id=42,
+        ...     model_id=2,
+        ...     expected_value=Decimal("0.0500"),
+        ...     true_win_probability=Decimal("0.5700"),
+        ...     market_implied_probability=Decimal("0.5200"),
+        ...     market_price=Decimal("0.5200"),
+        ...     yes_ask_price=Decimal("0.5300"),
+        ...     no_ask_price=Decimal("0.4800"),
+        ...     strategy_id=1,
+        ...     confidence_level='high',
+        ...     execution_environment='paper',
+        ... )
+        >>> # Returns surrogate id (e.g., 1), edge_id auto-set to 'EDGE-1'
+
+    References:
+        - Migration 0023: edges enrichment and cleanup
+        - ADR-002: Decimal Precision for All Financial Data
+    """
+    # Runtime type validation (enforces Decimal precision)
+    expected_value = validate_decimal(expected_value, "expected_value")
+    true_win_probability = validate_decimal(true_win_probability, "true_win_probability")
+    market_implied_probability = validate_decimal(
+        market_implied_probability, "market_implied_probability"
+    )
+    market_price = validate_decimal(market_price, "market_price")
+
+    if yes_ask_price is not None:
+        yes_ask_price = validate_decimal(yes_ask_price, "yes_ask_price")
+    if no_ask_price is not None:
+        no_ask_price = validate_decimal(no_ask_price, "no_ask_price")
+    if spread is not None:
+        spread = validate_decimal(spread, "spread")
+    if last_price is not None:
+        last_price = validate_decimal(last_price, "last_price")
+    if liquidity is not None:
+        liquidity = validate_decimal(liquidity, "liquidity")
+
+    insert_query = """
+        INSERT INTO edges (
+            edge_id, market_internal_id, model_id,
+            expected_value, true_win_probability,
+            market_implied_probability, market_price,
+            yes_ask_price, no_ask_price, spread,
+            volume, open_interest, last_price, liquidity,
+            strategy_id, confidence_level, confidence_metrics,
+            recommended_action, category, subcategory,
+            execution_environment, edge_status,
+            row_current_ind, row_start_ts
+        )
+        VALUES (
+            'TEMP', %s, %s,
+            %s, %s, %s, %s,
+            %s, %s, %s,
+            %s, %s, %s, %s,
+            %s, %s, %s,
+            %s, %s, %s,
+            %s, 'detected',
+            TRUE, NOW()
+        )
+        RETURNING id
+    """
+
+    params = (
+        market_internal_id,
+        model_id,
+        expected_value,
+        true_win_probability,
+        market_implied_probability,
+        market_price,
+        yes_ask_price,
+        no_ask_price,
+        spread,
+        volume,
+        open_interest,
+        last_price,
+        liquidity,
+        strategy_id,
+        confidence_level,
+        json.dumps(confidence_metrics) if confidence_metrics is not None else None,
+        recommended_action,
+        category,
+        subcategory,
+        execution_environment,
+    )
+
+    with get_cursor(commit=True) as cur:
+        # Get surrogate id
+        cur.execute(insert_query, params)
+        result = cur.fetchone()
+        surrogate_id = cast("int", result["id"])
+
+        # Update to set correct edge_id (EDGE-{id} format)
+        cur.execute(
+            "UPDATE edges SET edge_id = %s WHERE id = %s",
+            (f"EDGE-{surrogate_id}", surrogate_id),
+        )
+
+        return surrogate_id
+
+
+def update_edge_outcome(
+    edge_pk: int,
+    actual_outcome: str,
+    settlement_value: Decimal,
+    resolved_at: datetime | None = None,
+) -> bool:
+    """
+    Record settlement outcome for an edge.
+
+    This is a lifecycle event (not an SCD version change), so we update
+    the current row directly rather than creating a new SCD version.
+    Also sets edge_status to 'settled'.
+
+    Args:
+        edge_pk: Surrogate PK (edges.id), NOT the edge_id business key
+        actual_outcome: Settlement result - 'yes', 'no', 'void', or 'unresolved'
+        settlement_value: Actual settlement price as DECIMAL(10,4)
+            (0.0000 or 1.0000 for binary markets)
+        resolved_at: Resolution timestamp (defaults to NOW())
+
+    Returns:
+        True if the edge was found and updated, False otherwise.
+
+    Educational Note:
+        Why direct update instead of SCD version?
+        Outcome resolution is a lifecycle event on an existing edge -- it
+        doesn't change the edge's identity or detection parameters. The
+        edge_lifecycle view computes realized_pnl from settlement_value
+        minus market_price, so we need these on the same row.
+
+    Example:
+        >>> success = update_edge_outcome(
+        ...     edge_pk=42,
+        ...     actual_outcome='yes',
+        ...     settlement_value=Decimal("1.0000"),
+        ... )
+        >>> # Edge 42 now has edge_status='settled', actual_outcome='yes'
+
+    References:
+        - Migration 0023: edges enrichment
+        - edge_lifecycle view: computes realized_pnl from outcome
+    """
+    settlement_value = validate_decimal(settlement_value, "settlement_value")
+
+    valid_outcomes = ("yes", "no", "void", "unresolved")
+    if actual_outcome not in valid_outcomes:
+        raise ValueError(f"actual_outcome must be one of {valid_outcomes}, got '{actual_outcome}'")
+
+    query = """
+        UPDATE edges
+        SET actual_outcome = %s,
+            settlement_value = %s,
+            resolved_at = COALESCE(%s, NOW()),
+            edge_status = 'settled'
+        WHERE id = %s AND row_current_ind = TRUE
+    """
+
+    with get_cursor(commit=True) as cur:
+        cur.execute(query, (actual_outcome, settlement_value, resolved_at, edge_pk))
+        return int(cur.rowcount or 0) > 0
+
+
+def update_edge_status(
+    edge_pk: int,
+    new_status: str,
+) -> bool:
+    """
+    Transition an edge's lifecycle status.
+
+    This is a direct update (not an SCD version change) because status
+    transitions track lifecycle progression, not identity changes.
+
+    Args:
+        edge_pk: Surrogate PK (edges.id), NOT the edge_id business key
+        new_status: New lifecycle status. Valid values:
+            'detected', 'recommended', 'acted_on', 'expired', 'settled', 'void'
+
+    Returns:
+        True if the edge was found and updated, False otherwise.
+
+    Example:
+        >>> success = update_edge_status(edge_pk=42, new_status='recommended')
+        >>> # Edge 42 status changed from 'detected' to 'recommended'
+
+    References:
+        - Migration 0023: edge_status column with CHECK constraint
+    """
+    valid_statuses = (
+        "detected",
+        "recommended",
+        "acted_on",
+        "expired",
+        "settled",
+        "void",
+    )
+    if new_status not in valid_statuses:
+        raise ValueError(f"new_status must be one of {valid_statuses}, got '{new_status}'")
+
+    query = """
+        UPDATE edges
+        SET edge_status = %s
+        WHERE id = %s AND row_current_ind = TRUE
+    """
+
+    with get_cursor(commit=True) as cur:
+        cur.execute(query, (new_status, edge_pk))
+        return int(cur.rowcount or 0) > 0
+
+
+def get_edges_by_strategy(
+    strategy_id: int,
+    edge_status: str | None = None,
+    execution_environment: str | None = None,
+    limit: int = 100,
+) -> list[dict]:
+    """
+    Query current edges for a specific strategy.
+
+    Only returns rows with row_current_ind = TRUE (SCD Type 2 pattern).
+
+    Args:
+        strategy_id: FK to strategies(strategy_id)
+        edge_status: Optional filter by lifecycle status
+            ('detected', 'recommended', 'acted_on', 'expired', 'settled', 'void')
+        execution_environment: Optional filter ('live', 'paper', 'backtest')
+        limit: Maximum rows to return (default 100)
+
+    Returns:
+        List of edge dictionaries, ordered by created_at DESC.
+
+    Example:
+        >>> edges = get_edges_by_strategy(strategy_id=1, edge_status='detected')
+        >>> for edge in edges:
+        ...     print(f"Edge {edge['edge_id']}: EV={edge['expected_value']}")
+
+    References:
+        - Migration 0023: strategy_id column + idx_edges_strategy index
+    """
+    query = """
+        SELECT id, edge_id, market_internal_id, model_id, strategy_id,
+               expected_value, true_win_probability, market_implied_probability,
+               market_price, yes_ask_price, no_ask_price, spread,
+               volume, open_interest, last_price, liquidity,
+               edge_status, actual_outcome, settlement_value,
+               confidence_level, recommended_action,
+               category, subcategory, execution_environment,
+               created_at, resolved_at
+        FROM edges
+        WHERE row_current_ind = TRUE AND strategy_id = %s
+    """
+    params: list = [strategy_id]
+
+    if edge_status is not None:
+        query += " AND edge_status = %s"
+        params.append(edge_status)
+
+    if execution_environment is not None:
+        query += " AND execution_environment = %s"
+        params.append(execution_environment)
+
+    query += " ORDER BY created_at DESC LIMIT %s"
+    params.append(limit)
+
+    return fetch_all(query, tuple(params))
+
+
+def get_edge_lifecycle(
+    market_internal_id: int | None = None,
+    strategy_id: int | None = None,
+    limit: int = 100,
+) -> list[dict]:
+    """
+    Query the edge_lifecycle view for analytics.
+
+    The view includes computed fields:
+    - realized_pnl: settlement_value - market_price (for 'yes' outcomes)
+      or market_price - settlement_value (for 'no' outcomes)
+    - hours_to_resolution: time from edge creation to resolution in hours
+
+    Args:
+        market_internal_id: Optional filter by market
+        strategy_id: Optional filter by strategy
+        limit: Maximum rows to return (default 100)
+
+    Returns:
+        List of edge lifecycle dictionaries with computed fields.
+
+    Example:
+        >>> lifecycle = get_edge_lifecycle(strategy_id=1)
+        >>> for edge in lifecycle:
+        ...     if edge['realized_pnl'] is not None:
+        ...         print(f"Edge {edge['edge_id']}: P&L={edge['realized_pnl']}")
+
+    References:
+        - Migration 0023: edge_lifecycle view definition
+    """
+    query = """
+        SELECT id, edge_id, market_internal_id, model_id, strategy_id,
+               expected_value, true_win_probability, market_implied_probability,
+               market_price, yes_ask_price, no_ask_price,
+               edge_status, actual_outcome, settlement_value,
+               confidence_level, execution_environment,
+               created_at, resolved_at,
+               realized_pnl, hours_to_resolution
+        FROM edge_lifecycle
+        WHERE 1=1
+    """
+    params: list = []
+
+    if market_internal_id is not None:
+        query += " AND market_internal_id = %s"
+        params.append(market_internal_id)
+
+    if strategy_id is not None:
+        query += " AND strategy_id = %s"
+        params.append(strategy_id)
+
+    query += " ORDER BY created_at DESC LIMIT %s"
+    params.append(limit)
+
+    return fetch_all(query, tuple(params))

--- a/tests/fixtures/testcontainers_fixtures.py
+++ b/tests/fixtures/testcontainers_fixtures.py
@@ -448,11 +448,11 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
     -- edges table (SCD Type 2 with dual-key structure per migration 017)
     -- id: Surrogate primary key (unique across all versions)
     -- edge_id: Business key (can repeat for SCD Type 2 versions)
+    -- Migration 0023: probability_matrix_id dropped, 15 analytics columns added
     CREATE TABLE IF NOT EXISTS edges (
         id SERIAL PRIMARY KEY,
         edge_id VARCHAR NOT NULL,
         market_internal_id INTEGER NOT NULL REFERENCES markets(id) ON DELETE CASCADE,
-        probability_matrix_id INTEGER REFERENCES probability_matrices(probability_id) ON DELETE SET NULL,
         model_id INTEGER REFERENCES probability_models(model_id) ON DELETE SET NULL,
         expected_value DECIMAL(10,4) NOT NULL,
         true_win_probability DECIMAL(10,4) NOT NULL CHECK (true_win_probability >= 0.0000 AND true_win_probability <= 1.0000),
@@ -461,6 +461,21 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
         confidence_level VARCHAR(20) CHECK (confidence_level IN ('high', 'medium', 'low')),
         confidence_metrics JSONB,
         recommended_action VARCHAR(50) CHECK (recommended_action IN ('auto_execute', 'alert', 'ignore')),
+        actual_outcome VARCHAR(20) CHECK (actual_outcome IN ('yes', 'no', 'void', 'unresolved')),
+        settlement_value DECIMAL(10,4),
+        resolved_at TIMESTAMP WITH TIME ZONE,
+        strategy_id INTEGER REFERENCES strategies(strategy_id) ON DELETE SET NULL,
+        edge_status VARCHAR(30) DEFAULT 'detected' CHECK (edge_status IN ('detected', 'recommended', 'acted_on', 'expired', 'settled', 'void')),
+        yes_ask_price DECIMAL(10,4),
+        no_ask_price DECIMAL(10,4),
+        spread DECIMAL(10,4),
+        volume INTEGER,
+        open_interest INTEGER,
+        last_price DECIMAL(10,4),
+        liquidity DECIMAL(10,4),
+        category VARCHAR(100),
+        subcategory VARCHAR(100),
+        execution_environment VARCHAR(20) DEFAULT 'live' CHECK (execution_environment IN ('live', 'paper', 'backtest')),
         created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
         row_start_ts TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
         row_end_ts TIMESTAMP WITH TIME ZONE,
@@ -471,6 +486,11 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
     CREATE INDEX IF NOT EXISTS idx_edges_current ON edges(row_current_ind) WHERE row_current_ind = TRUE;
     CREATE UNIQUE INDEX IF NOT EXISTS idx_edges_unique_current ON edges(edge_id) WHERE row_current_ind = TRUE;
     CREATE INDEX IF NOT EXISTS idx_edges_business_key ON edges(edge_id);
+    CREATE INDEX IF NOT EXISTS idx_edges_strategy ON edges(strategy_id) WHERE row_current_ind = TRUE;
+    CREATE INDEX IF NOT EXISTS idx_edges_status ON edges(edge_status) WHERE row_current_ind = TRUE;
+    CREATE INDEX IF NOT EXISTS idx_edges_category ON edges(category) WHERE row_current_ind = TRUE;
+    CREATE INDEX IF NOT EXISTS idx_edges_resolved ON edges(resolved_at) WHERE resolved_at IS NOT NULL;
+    CREATE INDEX IF NOT EXISTS idx_edges_exec_env ON edges(execution_environment) WHERE row_current_ind = TRUE;
 
     -- 7. TRADING & POSITIONS
     -- positions table (SCD Type 2 with dual-key structure per migration 015)
@@ -681,6 +701,28 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
     LEFT JOIN market_snapshots ms ON ms.market_id = m.id AND ms.row_current_ind = TRUE;
     CREATE OR REPLACE VIEW current_game_states AS SELECT * FROM game_states WHERE row_current_ind = TRUE;
     CREATE OR REPLACE VIEW current_edges AS SELECT * FROM edges WHERE row_current_ind = TRUE;
+    -- edge_lifecycle view (migration 0023: computed P&L and resolution time)
+    CREATE OR REPLACE VIEW edge_lifecycle AS
+    SELECT
+        e.id, e.edge_id, e.market_internal_id, e.model_id, e.strategy_id,
+        e.expected_value, e.true_win_probability, e.market_implied_probability,
+        e.market_price, e.yes_ask_price, e.no_ask_price,
+        e.edge_status, e.actual_outcome, e.settlement_value,
+        e.confidence_level, e.execution_environment,
+        e.created_at, e.resolved_at,
+        -- P&L assumes YES-side position (edge detection = buy YES)
+        CASE
+            WHEN e.actual_outcome = 'yes' THEN e.settlement_value - e.market_price
+            WHEN e.actual_outcome = 'no' THEN e.market_price - e.settlement_value
+            ELSE NULL
+        END AS realized_pnl,
+        CASE
+            WHEN e.resolved_at IS NOT NULL AND e.created_at IS NOT NULL
+            THEN EXTRACT(EPOCH FROM (e.resolved_at - e.created_at)) / 3600.0
+            ELSE NULL
+        END AS hours_to_resolution
+    FROM edges e
+    WHERE e.row_current_ind = TRUE;
     CREATE OR REPLACE VIEW open_positions AS SELECT * FROM positions WHERE row_current_ind = TRUE AND status = 'open';
     CREATE OR REPLACE VIEW current_balances AS SELECT * FROM account_balance WHERE row_current_ind = TRUE;
     CREATE OR REPLACE VIEW active_strategies AS SELECT * FROM strategies WHERE status = 'active';

--- a/tests/unit/database/test_edge_crud.py
+++ b/tests/unit/database/test_edge_crud.py
@@ -1,0 +1,537 @@
+"""
+Unit Tests for Edge CRUD Operations (Migration 0023).
+
+Tests the edge lifecycle CRUD functions: create, update outcome/status,
+query by strategy, and edge_lifecycle view queries.
+
+Related:
+- Migration 0023: edges enrichment and cleanup
+- ADR-002: Decimal Precision for All Financial Data
+- Pattern 2: Dual Versioning System (SCD Type 2)
+
+Usage:
+    pytest tests/unit/database/test_edge_crud.py -v
+    pytest tests/unit/database/test_edge_crud.py -v -m unit
+"""
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from precog.database.crud_operations import (
+    create_edge,
+    get_edge_lifecycle,
+    get_edges_by_strategy,
+    update_edge_outcome,
+    update_edge_status,
+)
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+
+def _mock_cursor_context(mock_get_cursor, mock_cursor=None):
+    """Set up mock_get_cursor to return a context manager yielding mock_cursor."""
+    if mock_cursor is None:
+        mock_cursor = MagicMock()
+    mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_cursor
+
+
+# =============================================================================
+# CREATE EDGE TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestCreateEdge:
+    """Unit tests for create_edge function."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_edge_returns_surrogate_id(self, mock_get_cursor):
+        """Test create_edge returns the integer surrogate PK."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 42}
+
+        result = create_edge(
+            market_internal_id=1,
+            model_id=2,
+            expected_value=Decimal("0.0500"),
+            true_win_probability=Decimal("0.5700"),
+            market_implied_probability=Decimal("0.5200"),
+            market_price=Decimal("0.5200"),
+        )
+
+        assert result == 42
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_edge_auto_generates_edge_id(self, mock_get_cursor):
+        """Test that edge_id is set to EDGE-{id} after insert."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 7}
+
+        create_edge(
+            market_internal_id=1,
+            model_id=2,
+            expected_value=Decimal("0.0500"),
+            true_win_probability=Decimal("0.5700"),
+            market_implied_probability=Decimal("0.5200"),
+            market_price=Decimal("0.5200"),
+        )
+
+        # Second execute call should be the UPDATE for edge_id
+        calls = mock_cursor.execute.call_args_list
+        assert len(calls) == 2
+        update_call = calls[1]
+        assert "EDGE-7" in str(update_call)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_edge_validates_decimal_fields(self, mock_get_cursor):
+        """Test that float values are rejected for Decimal fields."""
+        _mock_cursor_context(mock_get_cursor)
+
+        with pytest.raises(TypeError, match="expected_value must be Decimal"):
+            create_edge(
+                market_internal_id=1,
+                model_id=2,
+                expected_value=0.05,  # float -- should raise
+                true_win_probability=Decimal("0.5700"),
+                market_implied_probability=Decimal("0.5200"),
+                market_price=Decimal("0.5200"),
+            )
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_edge_validates_optional_decimal_fields(self, mock_get_cursor):
+        """Test that optional Decimal fields also reject floats."""
+        _mock_cursor_context(mock_get_cursor)
+
+        with pytest.raises(TypeError, match="yes_ask_price must be Decimal"):
+            create_edge(
+                market_internal_id=1,
+                model_id=2,
+                expected_value=Decimal("0.0500"),
+                true_win_probability=Decimal("0.5700"),
+                market_implied_probability=Decimal("0.5200"),
+                market_price=Decimal("0.5200"),
+                yes_ask_price=0.53,  # float -- should raise
+            )
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_edge_with_all_optional_fields(self, mock_get_cursor):
+        """Test create_edge with every optional parameter provided."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 99}
+
+        result = create_edge(
+            market_internal_id=1,
+            model_id=2,
+            expected_value=Decimal("0.0500"),
+            true_win_probability=Decimal("0.5700"),
+            market_implied_probability=Decimal("0.5200"),
+            market_price=Decimal("0.5200"),
+            yes_ask_price=Decimal("0.5300"),
+            no_ask_price=Decimal("0.4800"),
+            spread=Decimal("0.0100"),
+            volume=1500,
+            open_interest=3200,
+            last_price=Decimal("0.5250"),
+            liquidity=Decimal("50000.0000"),
+            strategy_id=1,
+            confidence_level="high",
+            confidence_metrics={"model_agreement": 0.95},
+            recommended_action="auto_execute",
+            category="sports",
+            subcategory="nfl",
+            execution_environment="paper",
+        )
+
+        assert result == 99
+        # Verify INSERT was called with confidence_metrics as JSON
+        insert_call = mock_cursor.execute.call_args_list[0]
+        insert_params = insert_call[0][1]
+        # confidence_metrics should be JSON-serialized (16th param, 0-indexed 15)
+        assert json.loads(insert_params[15]) == {"model_agreement": 0.95}
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_edge_sets_edge_status_detected(self, mock_get_cursor):
+        """Test that new edges default to edge_status='detected'."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        create_edge(
+            market_internal_id=1,
+            model_id=2,
+            expected_value=Decimal("0.0500"),
+            true_win_probability=Decimal("0.5700"),
+            market_implied_probability=Decimal("0.5200"),
+            market_price=Decimal("0.5200"),
+        )
+
+        insert_sql = mock_cursor.execute.call_args_list[0][0][0]
+        assert "'detected'" in insert_sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_edge_sets_row_current_ind_true(self, mock_get_cursor):
+        """Test that new edges have row_current_ind = TRUE."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        create_edge(
+            market_internal_id=1,
+            model_id=2,
+            expected_value=Decimal("0.0500"),
+            true_win_probability=Decimal("0.5700"),
+            market_implied_probability=Decimal("0.5200"),
+            market_price=Decimal("0.5200"),
+        )
+
+        insert_sql = mock_cursor.execute.call_args_list[0][0][0]
+        assert "TRUE" in insert_sql
+        assert "row_current_ind" in insert_sql
+
+
+# =============================================================================
+# UPDATE EDGE OUTCOME TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestUpdateEdgeOutcome:
+    """Unit tests for update_edge_outcome function."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_edge_outcome_success(self, mock_get_cursor):
+        """Test successful outcome update returns True."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        result = update_edge_outcome(
+            edge_pk=42,
+            actual_outcome="yes",
+            settlement_value=Decimal("1.0000"),
+        )
+
+        assert result is True
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_edge_outcome_not_found(self, mock_get_cursor):
+        """Test outcome update returns False when edge not found."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 0
+
+        result = update_edge_outcome(
+            edge_pk=999,
+            actual_outcome="no",
+            settlement_value=Decimal("0.0000"),
+        )
+
+        assert result is False
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_edge_outcome_sets_status_settled(self, mock_get_cursor):
+        """Test that outcome update sets edge_status to 'settled'."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        update_edge_outcome(
+            edge_pk=42,
+            actual_outcome="yes",
+            settlement_value=Decimal("1.0000"),
+        )
+
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "settled" in sql
+        assert "row_current_ind = TRUE" in sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_edge_outcome_validates_decimal(self, mock_get_cursor):
+        """Test that settlement_value rejects floats."""
+        _mock_cursor_context(mock_get_cursor)
+
+        with pytest.raises(TypeError, match="settlement_value must be Decimal"):
+            update_edge_outcome(
+                edge_pk=42,
+                actual_outcome="yes",
+                settlement_value=1.0,  # float -- should raise
+            )
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_edge_outcome_invalid_outcome(self, mock_get_cursor):
+        """Test that invalid outcome values are rejected."""
+        _mock_cursor_context(mock_get_cursor)
+
+        with pytest.raises(ValueError, match="actual_outcome must be one of"):
+            update_edge_outcome(
+                edge_pk=42,
+                actual_outcome="maybe",  # invalid
+                settlement_value=Decimal("1.0000"),
+            )
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_edge_outcome_with_resolved_at(self, mock_get_cursor):
+        """Test outcome update with explicit resolved_at timestamp."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        resolved = datetime(2026, 3, 21, 12, 0, 0, tzinfo=UTC)
+        update_edge_outcome(
+            edge_pk=42,
+            actual_outcome="void",
+            settlement_value=Decimal("0.0000"),
+            resolved_at=resolved,
+        )
+
+        params = mock_cursor.execute.call_args[0][1]
+        assert params[2] == resolved
+
+
+# =============================================================================
+# UPDATE EDGE STATUS TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestUpdateEdgeStatus:
+    """Unit tests for update_edge_status function."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_edge_status_success(self, mock_get_cursor):
+        """Test successful status transition returns True."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        result = update_edge_status(edge_pk=42, new_status="recommended")
+
+        assert result is True
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_edge_status_not_found(self, mock_get_cursor):
+        """Test status update returns False when edge not found."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 0
+
+        result = update_edge_status(edge_pk=999, new_status="recommended")
+
+        assert result is False
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_edge_status_invalid_status(self, mock_get_cursor):
+        """Test that invalid status values are rejected."""
+        _mock_cursor_context(mock_get_cursor)
+
+        with pytest.raises(ValueError, match="new_status must be one of"):
+            update_edge_status(edge_pk=42, new_status="invalid_status")
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_edge_status_all_valid_statuses(self, mock_get_cursor):
+        """Test that all valid statuses are accepted."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        valid_statuses = [
+            "detected",
+            "recommended",
+            "acted_on",
+            "expired",
+            "settled",
+            "void",
+        ]
+        for status in valid_statuses:
+            result = update_edge_status(edge_pk=42, new_status=status)
+            assert result is True
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_edge_status_filters_by_row_current_ind(self, mock_get_cursor):
+        """Test that status update only targets current SCD rows."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        update_edge_status(edge_pk=42, new_status="acted_on")
+
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "row_current_ind = TRUE" in sql
+
+
+# =============================================================================
+# GET EDGES BY STRATEGY TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetEdgesByStrategy:
+    """Unit tests for get_edges_by_strategy function."""
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_edges_by_strategy_basic(self, mock_fetch_all):
+        """Test basic query with only strategy_id."""
+        mock_fetch_all.return_value = [
+            {"id": 1, "edge_id": "EDGE-1", "strategy_id": 5},
+            {"id": 2, "edge_id": "EDGE-2", "strategy_id": 5},
+        ]
+
+        result = get_edges_by_strategy(strategy_id=5)
+
+        assert len(result) == 2
+        mock_fetch_all.assert_called_once()
+        call_args = mock_fetch_all.call_args
+        sql = call_args[0][0]
+        assert "row_current_ind = TRUE" in sql
+        assert "strategy_id = %s" in sql
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_edges_by_strategy_with_status_filter(self, mock_fetch_all):
+        """Test query with edge_status filter."""
+        mock_fetch_all.return_value = []
+
+        get_edges_by_strategy(strategy_id=5, edge_status="detected")
+
+        call_args = mock_fetch_all.call_args
+        sql = call_args[0][0]
+        params = call_args[0][1]
+        assert "edge_status = %s" in sql
+        assert "detected" in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_edges_by_strategy_with_exec_env_filter(self, mock_fetch_all):
+        """Test query with execution_environment filter."""
+        mock_fetch_all.return_value = []
+
+        get_edges_by_strategy(strategy_id=5, execution_environment="paper")
+
+        call_args = mock_fetch_all.call_args
+        sql = call_args[0][0]
+        params = call_args[0][1]
+        assert "execution_environment = %s" in sql
+        assert "paper" in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_edges_by_strategy_with_all_filters(self, mock_fetch_all):
+        """Test query with all optional filters."""
+        mock_fetch_all.return_value = []
+
+        get_edges_by_strategy(
+            strategy_id=5,
+            edge_status="settled",
+            execution_environment="live",
+            limit=50,
+        )
+
+        call_args = mock_fetch_all.call_args
+        params = call_args[0][1]
+        # Params: strategy_id, edge_status, execution_environment, limit
+        assert params == (5, "settled", "live", 50)
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_edges_by_strategy_default_limit(self, mock_fetch_all):
+        """Test that default limit is 100."""
+        mock_fetch_all.return_value = []
+
+        get_edges_by_strategy(strategy_id=5)
+
+        call_args = mock_fetch_all.call_args
+        params = call_args[0][1]
+        # Last param should be limit = 100
+        assert params[-1] == 100
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_edges_by_strategy_orders_by_created_at_desc(self, mock_fetch_all):
+        """Test that results are ordered by created_at DESC."""
+        mock_fetch_all.return_value = []
+
+        get_edges_by_strategy(strategy_id=5)
+
+        sql = mock_fetch_all.call_args[0][0]
+        assert "ORDER BY created_at DESC" in sql
+
+
+# =============================================================================
+# GET EDGE LIFECYCLE TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetEdgeLifecycle:
+    """Unit tests for get_edge_lifecycle function."""
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_edge_lifecycle_returns_computed_fields(self, mock_fetch_all):
+        """Test that query selects realized_pnl and hours_to_resolution."""
+        mock_fetch_all.return_value = [
+            {
+                "id": 1,
+                "edge_id": "EDGE-1",
+                "realized_pnl": Decimal("0.4800"),
+                "hours_to_resolution": 24.5,
+            }
+        ]
+
+        result = get_edge_lifecycle()
+
+        assert len(result) == 1
+        assert result[0]["realized_pnl"] == Decimal("0.4800")
+        assert result[0]["hours_to_resolution"] == 24.5
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_edge_lifecycle_queries_view(self, mock_fetch_all):
+        """Test that query uses the edge_lifecycle view."""
+        mock_fetch_all.return_value = []
+
+        get_edge_lifecycle()
+
+        sql = mock_fetch_all.call_args[0][0]
+        assert "edge_lifecycle" in sql
+        assert "realized_pnl" in sql
+        assert "hours_to_resolution" in sql
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_edge_lifecycle_filter_by_market(self, mock_fetch_all):
+        """Test filtering by market_internal_id."""
+        mock_fetch_all.return_value = []
+
+        get_edge_lifecycle(market_internal_id=42)
+
+        call_args = mock_fetch_all.call_args
+        sql = call_args[0][0]
+        params = call_args[0][1]
+        assert "market_internal_id = %s" in sql
+        assert 42 in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_edge_lifecycle_filter_by_strategy(self, mock_fetch_all):
+        """Test filtering by strategy_id."""
+        mock_fetch_all.return_value = []
+
+        get_edge_lifecycle(strategy_id=5)
+
+        call_args = mock_fetch_all.call_args
+        sql = call_args[0][0]
+        params = call_args[0][1]
+        assert "strategy_id = %s" in sql
+        assert 5 in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_edge_lifecycle_with_both_filters(self, mock_fetch_all):
+        """Test filtering by both market and strategy."""
+        mock_fetch_all.return_value = []
+
+        get_edge_lifecycle(market_internal_id=42, strategy_id=5, limit=25)
+
+        call_args = mock_fetch_all.call_args
+        params = call_args[0][1]
+        assert params == (42, 5, 25)
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_edge_lifecycle_default_limit(self, mock_fetch_all):
+        """Test that default limit is 100."""
+        mock_fetch_all.return_value = []
+
+        get_edge_lifecycle()
+
+        call_args = mock_fetch_all.call_args
+        params = call_args[0][1]
+        assert params[-1] == 100


### PR DESCRIPTION
## Summary
- Drop dead `probability_matrix_id` FK column from edges table (table dropped in 0030)
- Add 15 analytics-ready columns: outcome tracking, strategy attribution, market microstructure snapshots, lifecycle status, classification
- Create `edge_lifecycle` view with computed `realized_pnl` and `hours_to_resolution`
- Add 5 new CRUD functions: `create_edge`, `update_edge_outcome`, `update_edge_status`, `get_edges_by_strategy`, `get_edge_lifecycle`
- 30 unit tests for all new CRUD functions

Part of migration batch (0019-0032). 5th of 14 migrations.

## Test plan
- [x] 30 unit tests pass (test_edge_crud.py)
- [x] Full unit suite passes (1935 tests)
- [x] Integration + E2E pass (990 tests)
- [x] Stress + Chaos + Race pass (1057 tests)
- [x] Ruff lint clean
- [x] Mypy clean
- [x] Pre-commit hooks pass
- [x] Reviewer (Glokta): APPROVE — fixes applied for edge_pk naming, confidence_metrics None-check, P&L documentation
- [x] QA (Ripley): No blockers — blast radius contained, 0 remaining probability_matrix_id references

🤖 Generated with [Claude Code](https://claude.com/claude-code)