### PR TITLE
feat: Migration 0025 — create orders table, simplify trades to pure fill records

### DIFF
--- a/src/precog/database/alembic/versions/0025_create_orders.py
+++ b/src/precog/database/alembic/versions/0025_create_orders.py
@@ -1,0 +1,259 @@
+"""Create orders table with attribution, simplify trades table.
+
+Orders capture the trading DECISION (what was requested, why, by which strategy/model).
+Trades capture execution EVENTS (what actually happened at the exchange). This clean
+separation eliminates attribution duplication and absorbs the planned portfolio_fills
+table (migration 0029 is now eliminated -- trades IS the fills table).
+
+Steps:
+    1. Drop dependent views on trades (Pattern 38)
+    2. CREATE TABLE orders with attribution, pricing, lifecycle columns
+    3. Add indexes on orders
+    4. Drop redundant columns from trades (attribution now on orders)
+    5. Add new columns to trades (order_id FK, is_taker)
+    6. Drop stale trades indexes for dropped columns
+    7. Recreate trade views with updated column set
+
+Revision ID: 0025
+Revises: 0024
+Create Date: 2026-03-21
+
+Related:
+- migration_batch_plan_v1.md: Migration 0025 spec
+- ADR-002: Decimal Precision for All Financial Data
+- issue336_council_findings.md: UNANIMOUS Option 2 (separate orders table)
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0025"
+down_revision: str = "0024"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create orders table, drop redundant trade columns, add order FK to trades.
+
+    Pattern 38 applied: Drop all views that reference trades before altering
+    columns, then recreate afterward. PostgreSQL views with SELECT * cache
+    column definitions at creation time -- column additions/removals silently
+    produce wrong results unless views are dropped and recreated.
+
+    Design intent:
+        - Orders own attribution (strategy, model, edge, position)
+        - Trades are pure fill/execution records linked via orders(id) FK
+        - portfolio_fills (migration 0029) is ELIMINATED -- trades IS fills
+    """
+    # ------------------------------------------------------------------
+    # Step 1: Drop ALL dependent views on trades (Pattern 38)
+    # ------------------------------------------------------------------
+    op.execute("DROP VIEW IF EXISTS live_trades")
+    op.execute("DROP VIEW IF EXISTS paper_trades")
+    op.execute("DROP VIEW IF EXISTS backtest_trades")
+    op.execute("DROP VIEW IF EXISTS training_data_trades")
+
+    # ------------------------------------------------------------------
+    # Step 2: CREATE TABLE orders
+    # ------------------------------------------------------------------
+    op.execute("""
+        CREATE TABLE orders (
+            id SERIAL PRIMARY KEY,
+
+            -- Platform + external identity
+            platform_id VARCHAR(50) NOT NULL
+                REFERENCES platforms(platform_id) ON DELETE CASCADE,
+            external_order_id VARCHAR(100) NOT NULL,
+            client_order_id VARCHAR(100),
+
+            -- Market reference
+            market_internal_id INTEGER NOT NULL
+                REFERENCES markets(id) ON DELETE CASCADE,
+
+            -- Attribution (the decision context -- lives HERE, not on trades)
+            strategy_id INTEGER REFERENCES strategies(strategy_id) ON DELETE SET NULL,
+            model_id INTEGER REFERENCES probability_models(model_id) ON DELETE SET NULL,
+            edge_id INTEGER REFERENCES edges(id) ON DELETE SET NULL,
+            position_id INTEGER REFERENCES positions(id) ON DELETE SET NULL,
+
+            -- Order intent
+            side VARCHAR(10) NOT NULL CHECK (side IN ('yes', 'no')),
+            action VARCHAR(10) NOT NULL CHECK (action IN ('buy', 'sell')),
+            order_type VARCHAR(20) NOT NULL DEFAULT 'market'
+                CHECK (order_type IN ('market', 'limit')),
+            time_in_force VARCHAR(30) DEFAULT 'good_till_canceled'
+                CHECK (time_in_force IN (
+                    'fill_or_kill', 'good_till_canceled', 'immediate_or_cancel'
+                )),
+
+            -- Pricing
+            requested_price DECIMAL(10,4) NOT NULL
+                CHECK (requested_price >= 0.0000 AND requested_price <= 1.0000),
+            requested_quantity INTEGER NOT NULL CHECK (requested_quantity > 0),
+
+            -- Fill tracking (mutable)
+            filled_quantity INTEGER NOT NULL DEFAULT 0 CHECK (filled_quantity >= 0),
+            remaining_quantity INTEGER NOT NULL CHECK (remaining_quantity >= 0),
+            average_fill_price DECIMAL(10,4),
+            total_fees DECIMAL(10,4) DEFAULT 0.0000,
+
+            -- Lifecycle status (mutable)
+            status VARCHAR(20) NOT NULL DEFAULT 'submitted'
+                CHECK (status IN (
+                    'submitted', 'resting', 'pending',
+                    'partial_fill', 'filled',
+                    'cancelled', 'expired'
+                )),
+
+            -- Execution context
+            execution_environment VARCHAR(20) NOT NULL DEFAULT 'live'
+                CHECK (execution_environment IN ('live', 'paper', 'backtest')),
+            trade_source VARCHAR(20) NOT NULL DEFAULT 'automated'
+                CHECK (trade_source IN ('automated', 'manual')),
+
+            -- Metadata
+            order_metadata JSONB,
+
+            -- Timestamps
+            created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            submitted_at TIMESTAMP WITH TIME ZONE,
+            filled_at TIMESTAMP WITH TIME ZONE,
+            cancelled_at TIMESTAMP WITH TIME ZONE,
+
+            CONSTRAINT uq_orders_platform_external
+                UNIQUE (platform_id, external_order_id)
+        )
+    """)
+
+    # ------------------------------------------------------------------
+    # Step 3: Add indexes on orders
+    # ------------------------------------------------------------------
+    op.execute("CREATE INDEX idx_orders_market ON orders(market_internal_id)")
+    op.execute("CREATE INDEX idx_orders_strategy ON orders(strategy_id)")
+    op.execute(
+        "CREATE INDEX idx_orders_status ON orders(status) "
+        "WHERE status IN ('submitted', 'resting', 'pending', 'partial_fill')"
+    )
+    op.execute("CREATE INDEX idx_orders_exec_env ON orders(execution_environment)")
+    op.execute("CREATE INDEX idx_orders_created ON orders(created_at)")
+
+    # ------------------------------------------------------------------
+    # Step 4: Drop redundant columns from trades
+    # Attribution now lives on orders; old VARCHAR order refs replaced by
+    # integer FK. Clean DB = no data loss.
+    # ------------------------------------------------------------------
+    op.execute("ALTER TABLE trades DROP COLUMN IF EXISTS order_id")
+    op.execute("ALTER TABLE trades DROP COLUMN IF EXISTS external_order_id")
+    op.execute("ALTER TABLE trades DROP COLUMN IF EXISTS strategy_id")
+    op.execute("ALTER TABLE trades DROP COLUMN IF EXISTS model_id")
+    op.execute("ALTER TABLE trades DROP COLUMN IF EXISTS edge_internal_id")
+    op.execute("ALTER TABLE trades DROP COLUMN IF EXISTS position_internal_id")
+    op.execute("ALTER TABLE trades DROP COLUMN IF EXISTS order_type")
+    op.execute("ALTER TABLE trades DROP COLUMN IF EXISTS trade_source")
+
+    # ------------------------------------------------------------------
+    # Step 5: Add new columns to trades
+    # ------------------------------------------------------------------
+    op.execute(
+        "ALTER TABLE trades ADD COLUMN order_id INTEGER REFERENCES orders(id) ON DELETE SET NULL"
+    )
+    op.execute("ALTER TABLE trades ADD COLUMN is_taker BOOLEAN")
+    op.execute("CREATE INDEX idx_trades_order ON trades(order_id)")
+
+    # ------------------------------------------------------------------
+    # Step 6: Drop stale trades indexes for dropped columns
+    # ------------------------------------------------------------------
+    op.execute("DROP INDEX IF EXISTS idx_trades_source")
+
+    # ------------------------------------------------------------------
+    # Step 7: Recreate trade views with updated column set
+    # ------------------------------------------------------------------
+    op.execute(
+        "CREATE OR REPLACE VIEW live_trades AS "
+        "SELECT * FROM trades WHERE execution_environment = 'live'"
+    )
+    op.execute(
+        "CREATE OR REPLACE VIEW paper_trades AS "
+        "SELECT * FROM trades WHERE execution_environment = 'paper'"
+    )
+    op.execute(
+        "CREATE OR REPLACE VIEW backtest_trades AS "
+        "SELECT * FROM trades WHERE execution_environment = 'backtest'"
+    )
+    op.execute(
+        "CREATE OR REPLACE VIEW training_data_trades AS "
+        "SELECT * FROM trades WHERE execution_environment IN ('paper', 'backtest')"
+    )
+
+
+def downgrade() -> None:
+    """Reverse: drop order FK from trades, re-add dropped columns, drop orders table."""
+    # Step 1: Drop trade views (column set is changing)
+    op.execute("DROP VIEW IF EXISTS live_trades")
+    op.execute("DROP VIEW IF EXISTS paper_trades")
+    op.execute("DROP VIEW IF EXISTS backtest_trades")
+    op.execute("DROP VIEW IF EXISTS training_data_trades")
+
+    # Step 2: Drop new columns/indexes from trades
+    op.execute("DROP INDEX IF EXISTS idx_trades_order")
+    op.execute("ALTER TABLE trades DROP COLUMN IF EXISTS is_taker")
+    op.execute("ALTER TABLE trades DROP COLUMN IF EXISTS order_id")
+
+    # Step 3: Re-add dropped columns to trades
+    op.execute("ALTER TABLE trades ADD COLUMN order_id VARCHAR(100)")
+    op.execute("ALTER TABLE trades ADD COLUMN external_order_id VARCHAR(100)")
+    op.execute(
+        "ALTER TABLE trades ADD COLUMN strategy_id INTEGER REFERENCES strategies(strategy_id)"
+    )
+    op.execute(
+        "ALTER TABLE trades ADD COLUMN model_id INTEGER REFERENCES probability_models(model_id)"
+    )
+    op.execute(
+        "ALTER TABLE trades ADD COLUMN edge_internal_id INTEGER "
+        "REFERENCES edges(id) ON DELETE SET NULL"
+    )
+    op.execute(
+        "ALTER TABLE trades ADD COLUMN position_internal_id INTEGER "
+        "REFERENCES positions(id) ON DELETE SET NULL"
+    )
+    op.execute(
+        "ALTER TABLE trades ADD COLUMN order_type VARCHAR(20) DEFAULT 'market' "
+        "CHECK (order_type IN ('market', 'limit', 'stop', 'stop_limit'))"
+    )
+    op.execute(
+        "ALTER TABLE trades ADD COLUMN trade_source VARCHAR(20) DEFAULT 'automated' "
+        "CHECK (trade_source IN ('automated', 'manual'))"
+    )
+
+    # Step 4: Re-add dropped indexes
+    op.execute("CREATE INDEX idx_trades_source ON trades(trade_source)")
+
+    # Step 5: Drop orders indexes and table
+    op.execute("DROP INDEX IF EXISTS idx_orders_created")
+    op.execute("DROP INDEX IF EXISTS idx_orders_exec_env")
+    op.execute("DROP INDEX IF EXISTS idx_orders_status")
+    op.execute("DROP INDEX IF EXISTS idx_orders_strategy")
+    op.execute("DROP INDEX IF EXISTS idx_orders_market")
+    op.execute("DROP TABLE IF EXISTS orders")
+
+    # Step 6: Recreate trade views with restored columns
+    op.execute(
+        "CREATE OR REPLACE VIEW live_trades AS "
+        "SELECT * FROM trades WHERE execution_environment = 'live'"
+    )
+    op.execute(
+        "CREATE OR REPLACE VIEW paper_trades AS "
+        "SELECT * FROM trades WHERE execution_environment = 'paper'"
+    )
+    op.execute(
+        "CREATE OR REPLACE VIEW backtest_trades AS "
+        "SELECT * FROM trades WHERE execution_environment = 'backtest'"
+    )
+    op.execute(
+        "CREATE OR REPLACE VIEW training_data_trades AS "
+        "SELECT * FROM trades WHERE execution_environment IN ('paper', 'backtest')"
+    )

--- a/src/precog/database/crud_operations.py
+++ b/src/precog/database/crud_operations.py
@@ -2000,102 +2000,92 @@ def close_position(
 
 def create_trade(
     market_internal_id: int,
-    strategy_id: int,
-    model_id: int,
     side: str,
     quantity: int,
     price: Decimal,
-    position_id: int | None = None,
-    order_type: str = "market",
+    order_id: int | None = None,
+    is_taker: bool | None = None,
+    fees: Decimal | None = None,
     trade_metadata: dict | None = None,
-    # ⭐ ATTRIBUTION ARCHITECTURE (Migration 019) - NEW parameters
-    trade_source: str = "automated",
     calculated_probability: Decimal | None = None,
     market_price: Decimal | None = None,
-    # ⭐ EXECUTION ENVIRONMENT (Migration 0008, ADR-107) - NEW parameter
     execution_environment: ExecutionEnvironment = "live",
 ) -> int:
     """
-    Record executed trade with strategy and model attribution.
+    Record an executed trade (fill event).
+
+    Trades are IMMUTABLE fill records — one row per exchange execution event.
+    Attribution (strategy, model, edge, position) lives on the associated
+    order, not on the trade. Query attribution via JOIN to orders table.
 
     Args:
         market_internal_id: Integer foreign key to markets(id)
-        strategy_id: Strategy version that generated this trade
-        model_id: Model version used for probability
-        side: 'YES' or 'NO'
-        quantity: Number of contracts
-        price: Execution price as DECIMAL(10,4)
-        position_id: Associated position (if any)
-        order_type: Order type (default: 'market')
-        trade_metadata: Additional metadata
-        trade_source: Trade origin ('automated' or 'manual') - default 'automated'
-        calculated_probability: Model-predicted win probability at execution (0.0-1.0)
-        market_price: Kalshi market price at execution (0.0-1.0)
-        execution_environment: Execution context - 'live' (production), 'paper' (demo),
-            or 'backtest' (simulation). Default 'live'. See ADR-107.
+        side: Trade direction - 'buy' or 'sell'
+        quantity: Number of contracts filled
+        price: Execution price as DECIMAL(10,4) in [0, 1]
+        order_id: Integer FK to orders(id) — links fill to its order
+        is_taker: Whether this fill was a taker (True) or maker (False)
+        fees: Per-fill fees as DECIMAL(10,4)
+        trade_metadata: Additional metadata as JSONB
+        calculated_probability: Model-predicted probability at execution [0, 1]
+        market_price: Kalshi market price at execution [0, 1]
+        execution_environment: 'live', 'paper', or 'backtest' (default 'live')
 
     Returns:
         trade_id of newly created trade
 
     Educational Note:
-        Attribution Architecture (Migrations 018-019):
-        - trade_source distinguishes automated (app) vs manual (Kalshi UI) trades
-        - calculated_probability + market_price enable performance analytics:
-          * "Which model has highest ROI?"
-          * "Do high-edge trades correlate with profit?"
-        - edge_value automatically calculated: calculated_probability - market_price
-        - 20-100x faster than JSONB for analytics (B-tree index vs GIN index)
-
-    Validation:
-        - If calculated_probability provided, market_price should also be provided
-        - Both must be in range [0.0, 1.0] (enforced by CHECK constraints)
-        - trade_source must be 'automated' or 'manual' (enforced by ENUM type)
+        Migration 0025 Redesign:
+        - Attribution (strategy_id, model_id, edge_id, position_id) moved to orders
+        - Trades are pure execution records (what actually happened at the exchange)
+        - edge_value auto-calculated: calculated_probability - market_price
+        - Query attribution: SELECT o.strategy_id FROM orders o JOIN trades t ON t.order_id = o.id
 
     Example:
         >>> trade_id = create_trade(
         ...     market_internal_id=42,
-        ...     strategy_id=1,
-        ...     model_id=2,
-        ...     side='YES',
-        ...     quantity=100,
+        ...     side='buy',
+        ...     quantity=10,
         ...     price=Decimal("0.5200"),
-        ...     position_id=123,
-        ...     trade_source='automated',
-        ...     calculated_probability=Decimal("0.6500"),
-        ...     market_price=Decimal("0.5800"),
-        ...     execution_environment='paper'  # Demo API testing
+        ...     order_id=7,
+        ...     is_taker=True,
+        ...     fees=Decimal("0.0100"),
+        ...     execution_environment='paper',
         ... )
-        >>> # edge_value automatically calculated: 0.6500 - 0.5800 = 0.0700
+
+    References:
+        - Migration 0025: orders/trades redesign
+        - Issue #336: council-approved separation of orders and trades
     """
     # Calculate edge_value if both probability and price provided
     edge_value: Decimal | None = None
     if calculated_probability is not None and market_price is not None:
         edge_value = calculated_probability - market_price
 
+    if fees is not None:
+        fees = validate_decimal(fees, "fees")
+
     query = """
         INSERT INTO trades (
-            market_internal_id, strategy_id, model_id,
-            side, quantity, price,
-            position_internal_id, order_type,
+            market_internal_id, side, quantity, price,
+            order_id, is_taker, fees,
             trade_metadata, execution_time,
-            trade_source, calculated_probability, market_price, edge_value,
+            calculated_probability, market_price, edge_value,
             execution_environment
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, NOW(), %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, NOW(), %s, %s, %s, %s)
         RETURNING trade_id
     """
 
     params = (
         market_internal_id,
-        strategy_id,
-        model_id,
         side,
         quantity,
         price,
-        position_id,
-        order_type,
+        order_id,
+        is_taker,
+        fees,
         trade_metadata,
-        trade_source,
         calculated_probability,
         market_price,
         edge_value,
@@ -2175,19 +2165,22 @@ def get_recent_trades(
         >>> # Pagination: get page 2 (trades 100-199)
         >>> page2 = get_recent_trades(limit=100, offset=100)
     """
-    # Migration 0021: markets is dimension (no SCD, no row_current_ind filter needed).
+    # Migration 0025: attribution lives on orders, joined through t.order_id.
     query = """
-        SELECT t.*, m.ticker, s.strategy_name, pm.model_name
+        SELECT t.*, m.ticker,
+               o.strategy_id, o.model_id,
+               s.strategy_name, pm.model_name
         FROM trades t
         JOIN markets m ON t.market_internal_id = m.id
-        JOIN strategies s ON t.strategy_id = s.strategy_id
-        JOIN probability_models pm ON t.model_id = pm.model_id
+        LEFT JOIN orders o ON t.order_id = o.id
+        LEFT JOIN strategies s ON o.strategy_id = s.strategy_id
+        LEFT JOIN probability_models pm ON o.model_id = pm.model_id
         WHERE 1=1
     """
     params: list[int | str] = []
 
     if strategy_id:
-        query += " AND t.strategy_id = %s"
+        query += " AND o.strategy_id = %s"
         params.append(strategy_id)
 
     if execution_environment is not None:
@@ -2884,13 +2877,16 @@ def get_trade_by_id(trade_id: int) -> dict[str, Any] | None:
         - ADR-091: Explicit Columns vs JSONB for Trade Attribution
         - Pattern 15: Trade/Position Attribution Architecture
     """
-    # Migration 0022: markets is dimension (no SCD, no row_current_ind filter needed).
+    # Migration 0025: attribution on orders, joined through t.order_id.
     query = """
-        SELECT t.*, m.ticker, s.strategy_name, pm.model_name
+        SELECT t.*, m.ticker,
+               o.strategy_id, o.model_id,
+               s.strategy_name, pm.model_name
         FROM trades t
         JOIN markets m ON t.market_internal_id = m.id
-        JOIN strategies s ON t.strategy_id = s.strategy_id
-        LEFT JOIN probability_models pm ON t.model_id = pm.model_id
+        LEFT JOIN orders o ON t.order_id = o.id
+        LEFT JOIN strategies s ON o.strategy_id = s.strategy_id
+        LEFT JOIN probability_models pm ON o.model_id = pm.model_id
         WHERE t.trade_id = %s
     """
     return fetch_one(query, (trade_id,))
@@ -6180,6 +6176,509 @@ def get_edge_lifecycle(
     if strategy_id is not None:
         query += " AND strategy_id = %s"
         params.append(strategy_id)
+
+    query += " ORDER BY created_at DESC LIMIT %s"
+    params.append(limit)
+
+    return fetch_all(query, tuple(params))
+
+
+# =============================================================================
+# ORDER OPERATIONS
+# =============================================================================
+#
+# Migration 0025: orders table with attribution, simplified trades table.
+#   - Orders capture the trading DECISION (what, why, which strategy/model)
+#   - Trades capture EXECUTION EVENTS (fills at the exchange)
+#   - Attribution (strategy_id, model_id, edge_id, position_id) lives on
+#     orders, NOT on trades. Trades inherit via FK JOIN.
+#   - Orders are MUTABLE (status, fill quantities change). NOT SCD.
+#   - Terminal state guard: filled/cancelled/expired cannot be resurrected.
+#
+# Kalshi API Status Mapping:
+#   Kalshi uses "executed" (we use "filled") and "canceled" (we use "cancelled").
+#   Use KALSHI_STATUS_MAP to translate before calling update_order_status().
+# =============================================================================
+
+# Kalshi API uses different status names than our internal model.
+# Apply this mapping when ingesting order data from the Kalshi API:
+#   kalshi_status = KALSHI_STATUS_MAP.get(api_status, api_status)
+KALSHI_STATUS_MAP: dict[str, str] = {
+    "executed": "filled",
+    "canceled": "cancelled",
+}
+
+# Valid values for order enum-like fields (used in runtime validation)
+_VALID_ORDER_SIDES = {"yes", "no"}
+_VALID_ORDER_ACTIONS = {"buy", "sell"}
+_VALID_ORDER_TYPES = {"market", "limit"}
+_VALID_TIME_IN_FORCE = {"fill_or_kill", "good_till_canceled", "immediate_or_cancel"}
+_VALID_EXEC_ENVS = {"live", "paper", "backtest"}
+_VALID_TRADE_SOURCES = {"automated", "manual"}
+_VALID_ORDER_STATUSES = {
+    "submitted",
+    "resting",
+    "pending",
+    "partial_fill",
+    "filled",
+    "cancelled",
+    "expired",
+}
+_TERMINAL_ORDER_STATUSES = {"filled", "cancelled", "expired"}
+
+
+def create_order(
+    platform_id: str,
+    external_order_id: str,
+    market_internal_id: int,
+    side: str,
+    action: str,
+    requested_price: Decimal,
+    requested_quantity: int,
+    order_type: str = "market",
+    time_in_force: str = "good_till_canceled",
+    strategy_id: int | None = None,
+    model_id: int | None = None,
+    edge_id: int | None = None,
+    position_id: int | None = None,
+    client_order_id: str | None = None,
+    execution_environment: ExecutionEnvironment = "live",
+    trade_source: str = "automated",
+    order_metadata: dict | None = None,
+) -> int:
+    """
+    Create a new order record.
+
+    An order represents a trading DECISION: what was requested, why (attribution),
+    and the current fill state. Orders are mutable -- status and fill quantities
+    update as the exchange processes them.
+
+    Args:
+        platform_id: FK to platforms(platform_id), e.g. 'kalshi'
+        external_order_id: Exchange-assigned order ID (unique per platform)
+        market_internal_id: Integer FK to markets(id) surrogate PK
+        side: 'yes' or 'no' (which outcome is being bet on)
+        action: 'buy' or 'sell' (entering or exiting a position)
+        requested_price: Limit price as DECIMAL(10,4) in [0, 1]
+        requested_quantity: Number of contracts requested (> 0)
+        order_type: 'market' or 'limit' (default 'market')
+        time_in_force: 'fill_or_kill', 'good_till_canceled', or 'immediate_or_cancel'
+        strategy_id: FK to strategies(strategy_id) for attribution
+        model_id: FK to probability_models(model_id) for attribution
+        edge_id: FK to edges(id) for attribution
+        position_id: FK to positions(id) for attribution
+        client_order_id: User-provided tracking ID
+        execution_environment: 'live', 'paper', or 'backtest'
+        trade_source: 'automated' or 'manual'
+        order_metadata: Additional data stored as JSONB
+
+    Returns:
+        Integer surrogate PK (orders.id) of the newly created order.
+
+    Raises:
+        TypeError: If requested_price is not Decimal
+        ValueError: If side, action, order_type, time_in_force,
+            execution_environment, or trade_source has invalid value
+
+    Educational Note:
+        Kalshi Status Mapping:
+            Kalshi API uses "executed" (we use "filled") and "canceled"
+            (we use "cancelled" with double-l). When ingesting from Kalshi,
+            translate via KALSHI_STATUS_MAP before calling:
+                internal = KALSHI_STATUS_MAP.get(kalshi_status, kalshi_status)
+
+        Attribution Design:
+            Attribution lives on orders, not trades. To get a trade's strategy,
+            JOIN trades.order_id -> orders.id -> orders.strategy_id. This avoids
+            duplicating attribution across every fill event.
+
+    Example:
+        >>> order_pk = create_order(
+        ...     platform_id='kalshi',
+        ...     external_order_id='abc-123',
+        ...     market_internal_id=42,
+        ...     side='yes',
+        ...     action='buy',
+        ...     requested_price=Decimal("0.5500"),
+        ...     requested_quantity=10,
+        ...     strategy_id=1,
+        ...     execution_environment='paper',
+        ... )
+        >>> # Returns surrogate id (e.g., 1)
+
+    References:
+        - Migration 0025: create_orders
+        - issue336_council_findings.md: UNANIMOUS Option 2
+    """
+    # Runtime type validation (enforces Decimal precision)
+    requested_price = validate_decimal(requested_price, "requested_price")
+
+    # Runtime enum-like validation (Glokta finding #5)
+    if side not in _VALID_ORDER_SIDES:
+        raise ValueError(f"side must be one of {_VALID_ORDER_SIDES}, got '{side}'")
+    if action not in _VALID_ORDER_ACTIONS:
+        raise ValueError(f"action must be one of {_VALID_ORDER_ACTIONS}, got '{action}'")
+    if order_type not in _VALID_ORDER_TYPES:
+        raise ValueError(f"order_type must be one of {_VALID_ORDER_TYPES}, got '{order_type}'")
+    if time_in_force not in _VALID_TIME_IN_FORCE:
+        raise ValueError(
+            f"time_in_force must be one of {_VALID_TIME_IN_FORCE}, got '{time_in_force}'"
+        )
+    if execution_environment not in _VALID_EXEC_ENVS:
+        raise ValueError(
+            f"execution_environment must be one of {_VALID_EXEC_ENVS}, "
+            f"got '{execution_environment}'"
+        )
+    if trade_source not in _VALID_TRADE_SOURCES:
+        raise ValueError(
+            f"trade_source must be one of {_VALID_TRADE_SOURCES}, got '{trade_source}'"
+        )
+
+    insert_query = """
+        INSERT INTO orders (
+            platform_id, external_order_id, client_order_id,
+            market_internal_id,
+            strategy_id, model_id, edge_id, position_id,
+            side, action, order_type, time_in_force,
+            requested_price, requested_quantity,
+            remaining_quantity, status,
+            execution_environment, trade_source,
+            order_metadata
+        )
+        VALUES (
+            %s, %s, %s,
+            %s,
+            %s, %s, %s, %s,
+            %s, %s, %s, %s,
+            %s, %s,
+            %s, 'submitted',
+            %s, %s,
+            %s
+        )
+        RETURNING id
+    """
+
+    params = (
+        platform_id,
+        external_order_id,
+        client_order_id,
+        market_internal_id,
+        strategy_id,
+        model_id,
+        edge_id,
+        position_id,
+        side,
+        action,
+        order_type,
+        time_in_force,
+        requested_price,
+        requested_quantity,
+        requested_quantity,  # remaining_quantity = requested_quantity initially
+        execution_environment,
+        trade_source,
+        json.dumps(order_metadata) if order_metadata is not None else None,
+    )
+
+    with get_cursor(commit=True) as cur:
+        cur.execute(insert_query, params)
+        result = cur.fetchone()
+        return cast("int", result["id"])
+
+
+def get_order_by_id(order_pk: int) -> dict | None:
+    """
+    Retrieve an order by its surrogate primary key.
+
+    Args:
+        order_pk: Integer PK of the order (orders.id)
+
+    Returns:
+        Dictionary of column:value pairs, or None if not found.
+
+    Example:
+        >>> order = get_order_by_id(42)
+        >>> if order:
+        ...     print(order['status'], order['filled_quantity'])
+
+    References:
+        - Migration 0025: create_orders
+    """
+    return fetch_one("SELECT * FROM orders WHERE id = %s", (order_pk,))
+
+
+def get_order_by_external_id(platform_id: str, external_order_id: str) -> dict | None:
+    """
+    Retrieve an order by its platform + external order ID (unique pair).
+
+    This is the primary lookup path when processing order updates from the
+    exchange API, since the exchange provides its own order ID.
+
+    Args:
+        platform_id: Platform identifier (e.g. 'kalshi')
+        external_order_id: Exchange-assigned order ID
+
+    Returns:
+        Dictionary of column:value pairs, or None if not found.
+
+    Example:
+        >>> order = get_order_by_external_id('kalshi', 'abc-123')
+
+    References:
+        - Migration 0025: UNIQUE(platform_id, external_order_id)
+    """
+    return fetch_one(
+        "SELECT * FROM orders WHERE platform_id = %s AND external_order_id = %s",
+        (platform_id, external_order_id),
+    )
+
+
+def update_order_status(order_pk: int, new_status: str) -> bool:
+    """
+    Update an order's lifecycle status with terminal state guard.
+
+    TERMINAL STATE GUARD (Glokta finding #1): Orders in terminal states
+    (filled, cancelled, expired) CANNOT be updated. The WHERE clause rejects
+    any attempt to resurrect a terminal order, preventing data corruption.
+
+    Timestamp behavior:
+        - filled -> sets filled_at = NOW()
+        - cancelled -> sets cancelled_at = NOW()
+        - expired -> sets cancelled_at = NOW() (Glokta finding #2: expiration
+          is a cancellation variant)
+        - All transitions -> sets updated_at = NOW()
+
+    Kalshi Status Mapping:
+        Kalshi API uses "executed" (= our "filled") and "canceled" (= our
+        "cancelled"). Translate via KALSHI_STATUS_MAP before calling:
+            internal = KALSHI_STATUS_MAP.get(kalshi_status, kalshi_status)
+            update_order_status(pk, internal)
+
+    Args:
+        order_pk: Integer PK of the order
+        new_status: Target status (must be in _VALID_ORDER_STATUSES)
+
+    Returns:
+        True if the order was updated, False if not found or in terminal state.
+
+    Raises:
+        ValueError: If new_status is not a valid order status
+
+    Example:
+        >>> success = update_order_status(42, 'resting')
+        >>> # Terminal orders silently reject updates:
+        >>> update_order_status(42, 'filled')  # True
+        >>> update_order_status(42, 'resting')  # False (already terminal)
+
+    References:
+        - Migration 0025: create_orders
+        - Glokta findings #1, #2, #4
+    """
+    if new_status not in _VALID_ORDER_STATUSES:
+        raise ValueError(f"new_status must be one of {_VALID_ORDER_STATUSES}, got '{new_status}'")
+
+    # Build timestamp updates based on target status
+    extra_sets = ""
+    if new_status == "filled":
+        extra_sets = ", filled_at = NOW()"
+    elif new_status in ("cancelled", "expired"):
+        # Expired is a cancellation variant (Glokta finding #2)
+        extra_sets = ", cancelled_at = NOW()"
+
+    query = f"""
+        UPDATE orders
+        SET status = %s,
+            updated_at = NOW(){extra_sets}
+        WHERE id = %s
+          AND status NOT IN ('filled', 'cancelled', 'expired')
+    """  # noqa: S608 -- extra_sets is built from hardcoded literals, not user input
+
+    with get_cursor(commit=True) as cur:
+        cur.execute(query, (new_status, order_pk))
+        return int(cur.rowcount or 0) > 0
+
+
+def update_order_fill(
+    order_pk: int,
+    fill_quantity: int,
+    fill_price: Decimal,
+    fees: Decimal = Decimal("0.0000"),
+) -> bool:
+    """
+    Record a fill event on an order (atomic quantity/price/fee update).
+
+    Performs an atomic SQL update that:
+    1. Increments filled_quantity by fill_quantity
+    2. Decrements remaining_quantity by fill_quantity
+    3. Computes weighted average fill price across all fills
+    4. Accumulates total_fees
+    5. Auto-sets status to 'partial_fill' or 'filled' based on remaining
+
+    Overfill protection: WHERE remaining_quantity >= fill_quantity prevents
+    recording more fills than the order requested.
+
+    Terminal state guard: WHERE status NOT IN ('filled', 'cancelled', 'expired')
+    prevents fills on already-terminal orders.
+
+    Args:
+        order_pk: Integer PK of the order
+        fill_quantity: Number of contracts filled in this event (must be > 0)
+        fill_price: Execution price as DECIMAL(10,4) in [0, 1]
+        fees: Fees for this fill as DECIMAL(10,4) (default 0)
+
+    Returns:
+        True if the fill was recorded, False if order not found, already
+        terminal, or fill_quantity exceeds remaining.
+
+    Raises:
+        TypeError: If fill_price or fees is not Decimal
+        ValueError: If fill_quantity <= 0
+
+    Educational Note:
+        Weighted Average Price Formula:
+            new_avg = (old_avg * old_filled + fill_price * fill_qty) /
+                      (old_filled + fill_qty)
+        The COALESCE handles the first fill where average_fill_price is NULL.
+
+    Example:
+        >>> # First fill: 5 of 10 contracts at 0.55
+        >>> update_order_fill(42, 5, Decimal("0.5500"), Decimal("0.0100"))
+        >>> # Second fill: remaining 5 at 0.56
+        >>> update_order_fill(42, 5, Decimal("0.5600"), Decimal("0.0100"))
+        >>> # Order is now 'filled' with average_fill_price ~= 0.5550
+
+    References:
+        - Migration 0025: create_orders
+        - Glokta finding #3: fill_quantity validation
+    """
+    # Validate fill_quantity > 0 (Glokta finding #3)
+    if fill_quantity <= 0:
+        raise ValueError(f"fill_quantity must be > 0, got {fill_quantity}")
+
+    # Runtime type validation (enforces Decimal precision)
+    fill_price = validate_decimal(fill_price, "fill_price")
+    fees = validate_decimal(fees, "fees")
+
+    query = """
+        UPDATE orders
+        SET filled_quantity = filled_quantity + %s,
+            remaining_quantity = remaining_quantity - %s,
+            average_fill_price = (
+                COALESCE(average_fill_price, 0) * filled_quantity + %s * %s
+            ) / (filled_quantity + %s),
+            total_fees = COALESCE(total_fees, 0) + %s,
+            status = CASE
+                WHEN remaining_quantity - %s = 0 THEN 'filled'
+                ELSE 'partial_fill'
+            END,
+            filled_at = CASE
+                WHEN remaining_quantity - %s = 0 THEN NOW()
+                ELSE filled_at
+            END,
+            updated_at = NOW()
+        WHERE id = %s
+          AND remaining_quantity >= %s
+          AND status NOT IN ('filled', 'cancelled', 'expired')
+    """
+
+    params = (
+        fill_quantity,  # filled_quantity + %s
+        fill_quantity,  # remaining_quantity - %s
+        fill_price,  # average_fill_price numerator: fill_price * fill_qty
+        fill_quantity,  # average_fill_price numerator: fill_price * fill_qty
+        fill_quantity,  # average_fill_price denominator
+        fees,  # total_fees + %s
+        fill_quantity,  # CASE remaining - %s = 0 (status)
+        fill_quantity,  # CASE remaining - %s = 0 (filled_at)
+        order_pk,  # WHERE id = %s
+        fill_quantity,  # WHERE remaining_quantity >= %s
+    )
+
+    with get_cursor(commit=True) as cur:
+        cur.execute(query, params)
+        return int(cur.rowcount or 0) > 0
+
+
+def cancel_order(order_pk: int) -> bool:
+    """
+    Cancel an order if it is still in a cancellable state.
+
+    Only orders with status IN ('submitted', 'resting', 'pending', 'partial_fill')
+    can be cancelled. Already-filled, already-cancelled, and expired orders
+    are silently rejected (returns False).
+
+    Args:
+        order_pk: Integer PK of the order
+
+    Returns:
+        True if the order was cancelled, False if not found or not cancellable.
+
+    Example:
+        >>> cancel_order(42)  # True if order was open
+        >>> cancel_order(42)  # False (already cancelled)
+
+    References:
+        - Migration 0025: create_orders
+    """
+    query = """
+        UPDATE orders
+        SET status = 'cancelled',
+            cancelled_at = NOW(),
+            updated_at = NOW()
+        WHERE id = %s
+          AND status IN ('submitted', 'resting', 'pending', 'partial_fill')
+    """
+
+    with get_cursor(commit=True) as cur:
+        cur.execute(query, (order_pk,))
+        return int(cur.rowcount or 0) > 0
+
+
+def get_open_orders(
+    strategy_id: int | None = None,
+    execution_environment: ExecutionEnvironment | None = None,
+    market_internal_id: int | None = None,
+    limit: int = 100,
+) -> list[dict]:
+    """
+    Query orders in active (non-terminal) statuses.
+
+    Active statuses: submitted, resting, pending, partial_fill.
+    Terminal statuses (excluded): filled, cancelled, expired.
+
+    Args:
+        strategy_id: Optional filter by strategy FK
+        execution_environment: Optional filter by 'live', 'paper', or 'backtest'
+        market_internal_id: Optional filter by market FK
+        limit: Maximum rows to return (default 100)
+
+    Returns:
+        List of dictionaries, one per open order, ordered by created_at DESC.
+
+    Example:
+        >>> orders = get_open_orders(strategy_id=1, execution_environment='paper')
+        >>> for o in orders:
+        ...     print(o['external_order_id'], o['status'], o['remaining_quantity'])
+
+    References:
+        - Migration 0025: create_orders
+    """
+    query = """
+        SELECT * FROM orders
+        WHERE status IN ('submitted', 'resting', 'pending', 'partial_fill')
+    """
+    params: list = []
+
+    if strategy_id is not None:
+        query += " AND strategy_id = %s"
+        params.append(strategy_id)
+
+    if execution_environment is not None:
+        query += " AND execution_environment = %s"
+        params.append(execution_environment)
+
+    if market_internal_id is not None:
+        query += " AND market_internal_id = %s"
+        params.append(market_internal_id)
 
     query += " ORDER BY created_at DESC LIMIT %s"
     params.append(limit)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -414,12 +414,10 @@ def sample_trade_data():
     Uses high IDs (99901) to match fixture data and avoid SERIAL collision.
     """
     return {
-        "strategy_id": 99901,
-        "model_id": 99901,
         "side": "buy",  # trades use 'buy'/'sell', not 'yes'/'no'
         "quantity": 100,
         "price": Decimal("0.5200"),
-        "order_type": "market",
+        # Attribution (strategy_id, model_id) lives on orders, not trades (migration 0025)
     }
 
 

--- a/tests/fixtures/testcontainers_fixtures.py
+++ b/tests/fixtures/testcontainers_fixtures.py
@@ -542,24 +542,57 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
     -- Historical query index (migration 024)
     CREATE INDEX IF NOT EXISTS idx_positions_history ON positions(row_current_ind, created_at DESC);
 
-    -- trades table (per migration 015/017: References surrogate IDs, not business keys)
-    -- trade_source converted from ENUM to VARCHAR + CHECK in migration 0024
+    -- orders table (migration 0025: attribution lives here, not on trades)
+    -- Orders capture the trading DECISION; trades capture EXECUTION EVENTS.
+    CREATE TABLE IF NOT EXISTS orders (
+        id SERIAL PRIMARY KEY,
+        platform_id VARCHAR(50) NOT NULL REFERENCES platforms(platform_id) ON DELETE CASCADE,
+        external_order_id VARCHAR(100) NOT NULL,
+        client_order_id VARCHAR(100),
+        market_internal_id INTEGER NOT NULL REFERENCES markets(id) ON DELETE CASCADE,
+        strategy_id INTEGER REFERENCES strategies(strategy_id) ON DELETE SET NULL,
+        model_id INTEGER REFERENCES probability_models(model_id) ON DELETE SET NULL,
+        edge_id INTEGER REFERENCES edges(id) ON DELETE SET NULL,
+        position_id INTEGER REFERENCES positions(id) ON DELETE SET NULL,
+        side VARCHAR(10) NOT NULL CHECK (side IN ('yes', 'no')),
+        action VARCHAR(10) NOT NULL CHECK (action IN ('buy', 'sell')),
+        order_type VARCHAR(20) NOT NULL DEFAULT 'market' CHECK (order_type IN ('market', 'limit')),
+        time_in_force VARCHAR(30) DEFAULT 'good_till_canceled' CHECK (time_in_force IN ('fill_or_kill', 'good_till_canceled', 'immediate_or_cancel')),
+        requested_price DECIMAL(10,4) NOT NULL CHECK (requested_price >= 0.0000 AND requested_price <= 1.0000),
+        requested_quantity INTEGER NOT NULL CHECK (requested_quantity > 0),
+        filled_quantity INTEGER NOT NULL DEFAULT 0 CHECK (filled_quantity >= 0),
+        remaining_quantity INTEGER NOT NULL CHECK (remaining_quantity >= 0),
+        average_fill_price DECIMAL(10,4),
+        total_fees DECIMAL(10,4) DEFAULT 0.0000,
+        status VARCHAR(20) NOT NULL DEFAULT 'submitted' CHECK (status IN ('submitted', 'resting', 'pending', 'partial_fill', 'filled', 'cancelled', 'expired')),
+        execution_environment VARCHAR(20) NOT NULL DEFAULT 'live' CHECK (execution_environment IN ('live', 'paper', 'backtest')),
+        trade_source VARCHAR(20) NOT NULL DEFAULT 'automated' CHECK (trade_source IN ('automated', 'manual')),
+        order_metadata JSONB,
+        created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+        updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+        submitted_at TIMESTAMP WITH TIME ZONE,
+        filled_at TIMESTAMP WITH TIME ZONE,
+        cancelled_at TIMESTAMP WITH TIME ZONE,
+        CONSTRAINT uq_orders_platform_external UNIQUE (platform_id, external_order_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_orders_market ON orders(market_internal_id);
+    CREATE INDEX IF NOT EXISTS idx_orders_strategy ON orders(strategy_id);
+    CREATE INDEX IF NOT EXISTS idx_orders_status ON orders(status) WHERE status IN ('submitted', 'resting', 'pending', 'partial_fill');
+    CREATE INDEX IF NOT EXISTS idx_orders_exec_env ON orders(execution_environment);
+    CREATE INDEX IF NOT EXISTS idx_orders_created ON orders(created_at);
+
+    -- trades table (migration 0025: attribution columns removed, order_id FK added)
+    -- Trades are pure fill/execution records. Attribution lives on orders.
     CREATE TABLE IF NOT EXISTS trades (
         trade_id SERIAL PRIMARY KEY,
         market_internal_id INTEGER NOT NULL REFERENCES markets(id) ON DELETE CASCADE,
         platform_id VARCHAR(50) REFERENCES platforms(platform_id) ON DELETE CASCADE,
-        position_internal_id INTEGER REFERENCES positions(id) ON DELETE SET NULL,
-        edge_internal_id INTEGER REFERENCES edges(id) ON DELETE SET NULL,
-        strategy_id INTEGER REFERENCES strategies(strategy_id),
-        model_id INTEGER REFERENCES probability_models(model_id),
-        order_id VARCHAR(100),
-        external_order_id VARCHAR(100),
+        order_id INTEGER REFERENCES orders(id) ON DELETE SET NULL,
         side VARCHAR(10) NOT NULL CHECK (side IN ('buy', 'sell')),
         price DECIMAL(10,4) NOT NULL CHECK (price >= 0.0000 AND price <= 1.0000),
         quantity INTEGER NOT NULL CHECK (quantity > 0),
         fees DECIMAL(10,4) CHECK (fees IS NULL OR fees >= 0.0000),
-        trade_source VARCHAR(20) DEFAULT 'automated' CHECK (trade_source IN ('automated', 'manual')),
-        order_type VARCHAR(20) DEFAULT 'market' CHECK (order_type IN ('market', 'limit', 'stop', 'stop_limit')),
+        is_taker BOOLEAN,
         execution_time TIMESTAMP WITH TIME ZONE,
         calculated_probability DECIMAL(10,4) CHECK (calculated_probability IS NULL OR (calculated_probability >= 0.0000 AND calculated_probability <= 1.0000)),
         market_price DECIMAL(10,4) CHECK (market_price IS NULL OR (market_price >= 0.0000 AND market_price <= 1.0000)),
@@ -574,9 +607,8 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
     );
     CREATE INDEX IF NOT EXISTS idx_trades_market_internal ON trades(market_internal_id);
     CREATE INDEX IF NOT EXISTS idx_trades_platform ON trades(platform_id);
-    CREATE INDEX IF NOT EXISTS idx_trades_position ON trades(position_internal_id);
+    CREATE INDEX IF NOT EXISTS idx_trades_order ON trades(order_id);
     CREATE INDEX IF NOT EXISTS idx_trades_created ON trades(created_at);
-    CREATE INDEX IF NOT EXISTS idx_trades_source ON trades(trade_source);
 
     CREATE TABLE IF NOT EXISTS settlements (
         settlement_id SERIAL PRIMARY KEY,
@@ -758,7 +790,7 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
     CREATE INDEX IF NOT EXISTS idx_historical_elo_season ON historical_elo(season);
 
     -- Track migration version
-    INSERT INTO alembic_version (version_num) VALUES ('0022')
+    INSERT INTO alembic_version (version_num) VALUES ('0025')
     ON CONFLICT (version_num) DO NOTHING;
     """
 

--- a/tests/unit/database/test_order_crud.py
+++ b/tests/unit/database/test_order_crud.py
@@ -1,0 +1,646 @@
+"""
+Unit Tests for Order CRUD Operations (Migration 0025).
+
+Tests the order lifecycle CRUD functions: create, get, update status,
+record fills, cancel, and query open orders. Validates terminal state
+guard, overfill protection, Decimal enforcement, and enum validation.
+
+Related:
+- Migration 0025: create_orders
+- ADR-002: Decimal Precision for All Financial Data
+- issue336_council_findings.md: UNANIMOUS Option 2 (separate orders table)
+- Glokta findings #1-#5
+
+Usage:
+    pytest tests/unit/database/test_order_crud.py -v
+    pytest tests/unit/database/test_order_crud.py -v -m unit
+"""
+
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from precog.database.crud_operations import (
+    KALSHI_STATUS_MAP,
+    cancel_order,
+    create_order,
+    get_open_orders,
+    get_order_by_external_id,
+    get_order_by_id,
+    update_order_fill,
+    update_order_status,
+)
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+
+def _mock_cursor_context(mock_get_cursor, mock_cursor=None):
+    """Set up mock_get_cursor to return a context manager yielding mock_cursor."""
+    if mock_cursor is None:
+        mock_cursor = MagicMock()
+    mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_cursor
+
+
+def _default_order_kwargs():
+    """Return minimal valid kwargs for create_order."""
+    return {
+        "platform_id": "kalshi",
+        "external_order_id": "abc-123",
+        "market_internal_id": 42,
+        "side": "yes",
+        "action": "buy",
+        "requested_price": Decimal("0.5500"),
+        "requested_quantity": 10,
+    }
+
+
+# =============================================================================
+# CREATE ORDER TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestCreateOrder:
+    """Unit tests for create_order function."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_order_returns_surrogate_id(self, mock_get_cursor):
+        """Test create_order returns the integer surrogate PK."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 7}
+
+        result = create_order(**_default_order_kwargs())
+
+        assert result == 7
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_order_sets_remaining_equals_requested(self, mock_get_cursor):
+        """Test that remaining_quantity is set to requested_quantity on insert."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        create_order(**_default_order_kwargs())
+
+        insert_call = mock_cursor.execute.call_args_list[0]
+        insert_params = insert_call[0][1]
+        # requested_quantity=10 should appear twice: once for requested, once for remaining
+        # Find the requested_quantity and remaining_quantity positions
+        # In params tuple: index 13 = requested_quantity, index 14 = remaining_quantity
+        assert insert_params[13] == 10  # requested_quantity
+        assert insert_params[14] == 10  # remaining_quantity = requested_quantity
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_order_sets_status_submitted(self, mock_get_cursor):
+        """Test that new orders default to status='submitted'."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        create_order(**_default_order_kwargs())
+
+        insert_sql = mock_cursor.execute.call_args_list[0][0][0]
+        assert "'submitted'" in insert_sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_order_validates_decimal_price(self, mock_get_cursor):
+        """Test that float values are rejected for requested_price."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_order_kwargs()
+        kwargs["requested_price"] = 0.55  # float -- should raise
+
+        with pytest.raises(TypeError, match="requested_price must be Decimal"):
+            create_order(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_order_validates_side(self, mock_get_cursor):
+        """Test that invalid side values are rejected."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_order_kwargs()
+        kwargs["side"] = "maybe"
+
+        with pytest.raises(ValueError, match="side must be one of"):
+            create_order(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_order_validates_action(self, mock_get_cursor):
+        """Test that invalid action values are rejected."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_order_kwargs()
+        kwargs["action"] = "hold"
+
+        with pytest.raises(ValueError, match="action must be one of"):
+            create_order(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_order_validates_order_type(self, mock_get_cursor):
+        """Test that invalid order_type values are rejected."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_order_kwargs()
+        kwargs["order_type"] = "stop_limit"
+
+        with pytest.raises(ValueError, match="order_type must be one of"):
+            create_order(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_order_validates_time_in_force(self, mock_get_cursor):
+        """Test that invalid time_in_force values are rejected."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_order_kwargs()
+        kwargs["time_in_force"] = "day"
+
+        with pytest.raises(ValueError, match="time_in_force must be one of"):
+            create_order(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_order_validates_execution_environment(self, mock_get_cursor):
+        """Test that invalid execution_environment values are rejected (Glokta #5)."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_order_kwargs()
+        kwargs["execution_environment"] = "staging"
+
+        with pytest.raises(ValueError, match="execution_environment must be one of"):
+            create_order(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_order_validates_trade_source(self, mock_get_cursor):
+        """Test that invalid trade_source values are rejected (Glokta #5)."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_order_kwargs()
+        kwargs["trade_source"] = "bot"
+
+        with pytest.raises(ValueError, match="trade_source must be one of"):
+            create_order(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_order_with_all_optional_fields(self, mock_get_cursor):
+        """Test create_order with every optional parameter provided."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 99}
+
+        result = create_order(
+            platform_id="kalshi",
+            external_order_id="xyz-789",
+            market_internal_id=42,
+            side="no",
+            action="sell",
+            requested_price=Decimal("0.4500"),
+            requested_quantity=5,
+            order_type="limit",
+            time_in_force="fill_or_kill",
+            strategy_id=1,
+            model_id=2,
+            edge_id=3,
+            position_id=4,
+            client_order_id="my-tracking-id",
+            execution_environment="paper",
+            trade_source="manual",
+            order_metadata={"source": "test"},
+        )
+
+        assert result == 99
+
+
+# =============================================================================
+# GET ORDER BY ID TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetOrderById:
+    """Unit tests for get_order_by_id function."""
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_get_order_by_id_found(self, mock_fetch_one):
+        """Test retrieving an existing order by PK."""
+        mock_fetch_one.return_value = {"id": 42, "status": "submitted"}
+
+        result = get_order_by_id(42)
+
+        assert result is not None
+        assert result["id"] == 42
+        mock_fetch_one.assert_called_once()
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_get_order_by_id_not_found(self, mock_fetch_one):
+        """Test retrieving a non-existent order returns None."""
+        mock_fetch_one.return_value = None
+
+        result = get_order_by_id(999)
+
+        assert result is None
+
+
+# =============================================================================
+# GET ORDER BY EXTERNAL ID TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetOrderByExternalId:
+    """Unit tests for get_order_by_external_id function."""
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_get_order_by_external_id_found(self, mock_fetch_one):
+        """Test retrieving an order by platform + external_order_id."""
+        mock_fetch_one.return_value = {"id": 42, "external_order_id": "abc-123"}
+
+        result = get_order_by_external_id("kalshi", "abc-123")
+
+        assert result is not None
+        assert result["external_order_id"] == "abc-123"
+        mock_fetch_one.assert_called_once()
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_get_order_by_external_id_not_found(self, mock_fetch_one):
+        """Test retrieving a non-existent external order returns None."""
+        mock_fetch_one.return_value = None
+
+        result = get_order_by_external_id("kalshi", "nonexistent")
+
+        assert result is None
+
+
+# =============================================================================
+# UPDATE ORDER STATUS TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestUpdateOrderStatus:
+    """Unit tests for update_order_status function."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_status_valid_transition(self, mock_get_cursor):
+        """Test a valid status transition returns True."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        result = update_order_status(42, "resting")
+
+        assert result is True
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_status_terminal_guard_filled(self, mock_get_cursor):
+        """Test that filled orders cannot be updated (Glokta #1)."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 0  # WHERE clause rejects terminal status
+
+        result = update_order_status(42, "resting")
+
+        assert result is False
+        # Verify WHERE clause includes terminal state guard
+        execute_sql = mock_cursor.execute.call_args[0][0]
+        assert "NOT IN ('filled', 'cancelled', 'expired')" in execute_sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_status_terminal_guard_cancelled(self, mock_get_cursor):
+        """Test that cancelled orders cannot be updated (Glokta #1)."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 0
+
+        result = update_order_status(42, "submitted")
+
+        assert result is False
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_status_terminal_guard_expired(self, mock_get_cursor):
+        """Test that expired orders cannot be updated (Glokta #1)."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 0
+
+        result = update_order_status(42, "submitted")
+
+        assert result is False
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_status_sets_filled_at(self, mock_get_cursor):
+        """Test that transitioning to 'filled' sets filled_at = NOW()."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        update_order_status(42, "filled")
+
+        execute_sql = mock_cursor.execute.call_args[0][0]
+        assert "filled_at = NOW()" in execute_sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_status_sets_cancelled_at_for_cancelled(self, mock_get_cursor):
+        """Test that transitioning to 'cancelled' sets cancelled_at = NOW()."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        update_order_status(42, "cancelled")
+
+        execute_sql = mock_cursor.execute.call_args[0][0]
+        assert "cancelled_at = NOW()" in execute_sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_status_sets_cancelled_at_for_expired(self, mock_get_cursor):
+        """Test that transitioning to 'expired' sets cancelled_at (Glokta #2)."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        update_order_status(42, "expired")
+
+        execute_sql = mock_cursor.execute.call_args[0][0]
+        assert "cancelled_at = NOW()" in execute_sql
+
+    def test_update_status_rejects_invalid_status(self):
+        """Test that invalid status values raise ValueError."""
+        with pytest.raises(ValueError, match="new_status must be one of"):
+            update_order_status(42, "unknown_status")
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_status_always_sets_updated_at(self, mock_get_cursor):
+        """Test that updated_at = NOW() is always set."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        update_order_status(42, "resting")
+
+        execute_sql = mock_cursor.execute.call_args[0][0]
+        assert "updated_at = NOW()" in execute_sql
+
+
+# =============================================================================
+# UPDATE ORDER FILL TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestUpdateOrderFill:
+    """Unit tests for update_order_fill function."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_fill_increments_quantities(self, mock_get_cursor):
+        """Test that fill SQL increments filled and decrements remaining."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        result = update_order_fill(42, 5, Decimal("0.5500"))
+
+        assert result is True
+        execute_sql = mock_cursor.execute.call_args[0][0]
+        assert "filled_quantity = filled_quantity +" in execute_sql
+        assert "remaining_quantity = remaining_quantity -" in execute_sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_fill_sets_partial_fill_or_filled_status(self, mock_get_cursor):
+        """Test that fill SQL uses CASE to set partial_fill or filled."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        update_order_fill(42, 5, Decimal("0.5500"))
+
+        execute_sql = mock_cursor.execute.call_args[0][0]
+        assert "'partial_fill'" in execute_sql
+        assert "'filled'" in execute_sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_fill_computes_weighted_average_price(self, mock_get_cursor):
+        """Test that fill SQL computes weighted average fill price."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        update_order_fill(42, 5, Decimal("0.5500"))
+
+        execute_sql = mock_cursor.execute.call_args[0][0]
+        assert "average_fill_price" in execute_sql
+        assert "COALESCE" in execute_sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_fill_overfill_protection(self, mock_get_cursor):
+        """Test that WHERE clause prevents overfilling."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 0  # WHERE remaining >= fill_qty fails
+
+        result = update_order_fill(42, 100, Decimal("0.5500"))
+
+        assert result is False
+        execute_sql = mock_cursor.execute.call_args[0][0]
+        assert "remaining_quantity >=" in execute_sql
+
+    def test_fill_validates_fill_quantity_positive(self):
+        """Test that fill_quantity <= 0 raises ValueError (Glokta #3)."""
+        with pytest.raises(ValueError, match="fill_quantity must be > 0"):
+            update_order_fill(42, 0, Decimal("0.5500"))
+
+    def test_fill_validates_fill_quantity_negative(self):
+        """Test that negative fill_quantity raises ValueError."""
+        with pytest.raises(ValueError, match="fill_quantity must be > 0"):
+            update_order_fill(42, -1, Decimal("0.5500"))
+
+    def test_fill_validates_decimal_price(self):
+        """Test that float fill_price is rejected."""
+        with pytest.raises(TypeError, match="fill_price must be Decimal"):
+            update_order_fill(42, 5, 0.55)
+
+    def test_fill_validates_decimal_fees(self):
+        """Test that float fees are rejected."""
+        with pytest.raises(TypeError, match="fees must be Decimal"):
+            update_order_fill(42, 5, Decimal("0.5500"), 0.01)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_fill_terminal_state_guard(self, mock_get_cursor):
+        """Test that fills on terminal orders are rejected."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        update_order_fill(42, 5, Decimal("0.5500"))
+
+        execute_sql = mock_cursor.execute.call_args[0][0]
+        assert "NOT IN ('filled', 'cancelled', 'expired')" in execute_sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_fill_sets_filled_at_when_fully_filled(self, mock_get_cursor):
+        """Test that filled_at is set when remaining reaches zero."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        update_order_fill(42, 10, Decimal("0.5500"))
+
+        execute_sql = mock_cursor.execute.call_args[0][0]
+        assert "filled_at" in execute_sql
+
+
+# =============================================================================
+# CANCEL ORDER TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestCancelOrder:
+    """Unit tests for cancel_order function."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_cancel_success(self, mock_get_cursor):
+        """Test cancelling an open order returns True."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        result = cancel_order(42)
+
+        assert result is True
+        execute_sql = mock_cursor.execute.call_args[0][0]
+        assert "'cancelled'" in execute_sql
+        assert "cancelled_at = NOW()" in execute_sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_cancel_rejects_already_filled(self, mock_get_cursor):
+        """Test that already-filled orders cannot be cancelled."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 0
+
+        result = cancel_order(42)
+
+        assert result is False
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_cancel_rejects_already_cancelled(self, mock_get_cursor):
+        """Test that already-cancelled orders return False."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 0
+
+        result = cancel_order(42)
+
+        assert result is False
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_cancel_only_allows_active_statuses(self, mock_get_cursor):
+        """Test that WHERE clause only targets cancellable statuses."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        cancel_order(42)
+
+        execute_sql = mock_cursor.execute.call_args[0][0]
+        assert "'submitted'" in execute_sql
+        assert "'resting'" in execute_sql
+        assert "'pending'" in execute_sql
+        assert "'partial_fill'" in execute_sql
+
+
+# =============================================================================
+# GET OPEN ORDERS TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetOpenOrders:
+    """Unit tests for get_open_orders function."""
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_open_orders_filters_active_statuses(self, mock_fetch_all):
+        """Test that query filters for active statuses only."""
+        mock_fetch_all.return_value = []
+
+        get_open_orders()
+
+        query = mock_fetch_all.call_args[0][0]
+        assert "'submitted'" in query
+        assert "'resting'" in query
+        assert "'pending'" in query
+        assert "'partial_fill'" in query
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_open_orders_strategy_filter(self, mock_fetch_all):
+        """Test filtering by strategy_id."""
+        mock_fetch_all.return_value = []
+
+        get_open_orders(strategy_id=1)
+
+        query = mock_fetch_all.call_args[0][0]
+        params = mock_fetch_all.call_args[0][1]
+        assert "strategy_id = %s" in query
+        assert 1 in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_open_orders_environment_filter(self, mock_fetch_all):
+        """Test filtering by execution_environment."""
+        mock_fetch_all.return_value = []
+
+        get_open_orders(execution_environment="paper")
+
+        query = mock_fetch_all.call_args[0][0]
+        params = mock_fetch_all.call_args[0][1]
+        assert "execution_environment = %s" in query
+        assert "paper" in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_open_orders_market_filter(self, mock_fetch_all):
+        """Test filtering by market_internal_id."""
+        mock_fetch_all.return_value = []
+
+        get_open_orders(market_internal_id=42)
+
+        query = mock_fetch_all.call_args[0][0]
+        params = mock_fetch_all.call_args[0][1]
+        assert "market_internal_id = %s" in query
+        assert 42 in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_open_orders_default_limit(self, mock_fetch_all):
+        """Test that default limit of 100 is applied."""
+        mock_fetch_all.return_value = []
+
+        get_open_orders()
+
+        params = mock_fetch_all.call_args[0][1]
+        assert 100 in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_open_orders_custom_limit(self, mock_fetch_all):
+        """Test passing a custom limit."""
+        mock_fetch_all.return_value = []
+
+        get_open_orders(limit=25)
+
+        params = mock_fetch_all.call_args[0][1]
+        assert 25 in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_open_orders_returns_list(self, mock_fetch_all):
+        """Test that result is a list of dicts."""
+        mock_fetch_all.return_value = [
+            {"id": 1, "status": "submitted"},
+            {"id": 2, "status": "resting"},
+        ]
+
+        result = get_open_orders()
+
+        assert len(result) == 2
+        assert result[0]["id"] == 1
+
+
+# =============================================================================
+# KALSHI STATUS MAP TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestKalshiStatusMap:
+    """Unit tests for the KALSHI_STATUS_MAP constant (Glokta #4)."""
+
+    def test_executed_maps_to_filled(self):
+        """Test Kalshi 'executed' maps to our 'filled'."""
+        assert KALSHI_STATUS_MAP["executed"] == "filled"
+
+    def test_canceled_maps_to_cancelled(self):
+        """Test Kalshi 'canceled' (one l) maps to our 'cancelled' (two l's)."""
+        assert KALSHI_STATUS_MAP["canceled"] == "cancelled"
+
+    def test_unknown_status_passthrough(self):
+        """Test that unknown statuses pass through with .get() default."""
+        result = KALSHI_STATUS_MAP.get("resting", "resting")
+        assert result == "resting"


### PR DESCRIPTION
## Summary
- **CREATE TABLE orders** with full attribution (strategy_id, model_id, edge_id, position_id), mutable lifecycle, terminal state guard, Kalshi status mapping
- **Simplify trades** to pure fill records: drop 8 redundant columns (strategy_id, model_id, edge_internal_id, position_internal_id, order_id VARCHAR, external_order_id VARCHAR, order_type, trade_source), add `order_id INTEGER FK` + `is_taker BOOLEAN`
- **Absorbs migration 0029** (portfolio_fills) — trades IS the fills table, 13 migrations remain
- Update `create_trade()`, `get_recent_trades()`, `get_trade_by_id()` for orders-based attribution JOIN
- 48 unit tests, 7 CRUD functions, KALSHI_STATUS_MAP constant

Redesigned in session 16 based on architectural review: attribution belongs on orders (the decision), not trades (the execution). Clean DB = no backward compat for old VARCHAR columns.

Closes #333, Closes #336

## Test plan
- [x] 48 unit tests pass (test_order_crud.py)
- [x] Full unit suite passes (1983 tests)
- [x] Ruff lint + format clean
- [x] Mypy clean
- [x] Pre-commit hooks pass
- [x] Pre-push hooks pass (unit + integration + stress/chaos/race)
- [x] Glokta review findings incorporated (terminal state guard, fill_quantity validation, expired timestamp, Kalshi status mapping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)