### PR TITLE
feat: Migrations 0026-0028 — account_ledger, temporal_alignment, market_trades

### DIFF
--- a/src/precog/database/alembic/versions/0026_account_ledger.py
+++ b/src/precog/database/alembic/versions/0026_account_ledger.py
@@ -1,0 +1,109 @@
+"""Create account_ledger table for append-only transaction log.
+
+The account_balance table uses SCD Type 2 to track balance snapshots, but does
+not explain WHY the balance changed. The account_ledger table provides an
+append-only transaction log that links balance changes to their causes
+(deposits, withdrawals, trade P&L, fees, rebates).
+
+Steps:
+    1. CREATE TABLE account_ledger with financials, reference, and order FK
+    2. Add indexes for common query patterns
+
+Revision ID: 0026
+Revises: 0025
+Create Date: 2026-03-21
+
+Related:
+- migration_batch_plan_v1.md: Migration 0026 spec
+- ADR-002: Decimal Precision for All Financial Data
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0026"
+down_revision: str = "0025"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create account_ledger table for tracking balance change causation.
+
+    Design intent:
+        - Append-only: rows are never updated or deleted
+        - Links to orders via FK for trade-related entries
+        - Polymorphic reference_type + reference_id for flexible sourcing
+        - amount CAN be negative (withdrawals, fees)
+        - running_balance cannot go below zero
+    """
+    # ------------------------------------------------------------------
+    # Step 1: CREATE TABLE account_ledger
+    # ------------------------------------------------------------------
+    op.execute("""
+        CREATE TABLE account_ledger (
+            id SERIAL PRIMARY KEY,
+
+            -- Platform identity
+            platform_id VARCHAR(50) NOT NULL
+                REFERENCES platforms(platform_id) ON DELETE CASCADE,
+
+            -- Transaction classification
+            transaction_type VARCHAR(20) NOT NULL
+                CHECK (transaction_type IN (
+                    'deposit', 'withdrawal', 'trade_pnl', 'fee', 'rebate', 'adjustment'
+                )),
+
+            -- Financials (DECIMAL only, never float)
+            amount DECIMAL(10,4) NOT NULL,
+            running_balance DECIMAL(10,4) NOT NULL
+                CHECK (running_balance >= 0.0000),
+            currency VARCHAR(10) NOT NULL DEFAULT 'USD',
+
+            -- Reference to source entity (polymorphic)
+            reference_type VARCHAR(20)
+                CHECK (reference_type IS NULL OR reference_type IN (
+                    'order', 'settlement', 'trade', 'manual', 'system'
+                )),
+            reference_id INTEGER,
+
+            -- Direct order FK for trade-related entries
+            order_id INTEGER REFERENCES orders(id) ON DELETE SET NULL,
+
+            -- Human-readable description
+            description TEXT,
+
+            -- Immutable timestamp (append-only, no updates)
+            created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+        )
+    """)
+
+    # ------------------------------------------------------------------
+    # Step 2: Add indexes for common query patterns
+    # ------------------------------------------------------------------
+    # idx_ledger_platform_date covers platform_id-only queries via leading column
+    op.execute(
+        "CREATE INDEX idx_ledger_platform_date ON account_ledger(platform_id, created_at DESC)"
+    )
+    op.execute("CREATE INDEX idx_ledger_type ON account_ledger(transaction_type)")
+    op.execute(
+        "CREATE INDEX idx_ledger_order ON account_ledger(order_id) WHERE order_id IS NOT NULL"
+    )
+    op.execute(
+        "CREATE INDEX idx_ledger_reference ON account_ledger(reference_type, reference_id) "
+        "WHERE reference_type IS NOT NULL"
+    )
+
+
+def downgrade() -> None:
+    """Reverse: drop indexes and account_ledger table."""
+    # Step 1: Drop indexes
+    op.execute("DROP INDEX IF EXISTS idx_ledger_reference")
+    op.execute("DROP INDEX IF EXISTS idx_ledger_order")
+    op.execute("DROP INDEX IF EXISTS idx_ledger_type")
+    op.execute("DROP INDEX IF EXISTS idx_ledger_platform_date")
+
+    # Step 2: Drop table
+    op.execute("DROP TABLE IF EXISTS account_ledger")

--- a/src/precog/database/alembic/versions/0027_temporal_alignment.py
+++ b/src/precog/database/alembic/versions/0027_temporal_alignment.py
@@ -1,0 +1,113 @@
+"""Create temporal_alignment table linking market snapshots to game states.
+
+Kalshi polls every 15s, ESPN every 30s. There is no cross-reference between
+price updates and game state updates. The temporal_alignment table links a
+specific market_snapshot row to a specific game_state row by timestamp
+proximity, enabling queries like "what was the market price when the score
+changed?" Critical for Phase 4 backtesting accuracy.
+
+Steps:
+    1. CREATE TABLE temporal_alignment with FKs, alignment metadata, denormalized fields
+    2. Add indexes for common query patterns
+
+Revision ID: 0027
+Revises: 0026
+Create Date: 2026-03-21
+
+Related:
+- migration_batch_plan_v1.md: Migration 0027 spec
+- Issue #375: Add temporal alignment table linking Kalshi polls to ESPN game states
+- ADR-002: Decimal Precision for All Financial Data
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0027"
+down_revision: str = "0026"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create temporal_alignment table for cross-source timestamp linking.
+
+    Design intent:
+        - Links a SPECIFIC market_snapshot to a SPECIFIC game_state by time proximity
+        - Denormalizes key fields for query convenience (avoids joins for common reads)
+        - alignment_quality categorizes time delta: exact/good/fair/poor/stale
+        - Unique constraint prevents duplicate snapshot-to-game-state pairings
+        - Append-only: rows are never updated once created
+    """
+    # ------------------------------------------------------------------
+    # Step 1: CREATE TABLE temporal_alignment
+    # ------------------------------------------------------------------
+    op.execute("""
+        CREATE TABLE temporal_alignment (
+            id SERIAL PRIMARY KEY,
+
+            -- Market reference
+            market_id INTEGER NOT NULL
+                REFERENCES markets(id) ON DELETE CASCADE,
+            market_snapshot_id INTEGER NOT NULL
+                REFERENCES market_snapshots(id) ON DELETE CASCADE,
+
+            -- Game state reference
+            game_state_id INTEGER NOT NULL
+                REFERENCES game_states(id) ON DELETE CASCADE,
+
+            -- Alignment metadata
+            snapshot_time TIMESTAMP WITH TIME ZONE NOT NULL,
+            game_state_time TIMESTAMP WITH TIME ZONE NOT NULL,
+            time_delta_seconds DECIMAL(10,2) NOT NULL,
+            alignment_quality VARCHAR(20) NOT NULL DEFAULT 'good'
+                CHECK (alignment_quality IN ('exact', 'good', 'fair', 'poor', 'stale')),
+
+            -- Denormalized snapshot values for query convenience
+            yes_ask_price DECIMAL(10,4),
+            no_ask_price DECIMAL(10,4),
+            spread DECIMAL(10,4),
+            volume INTEGER,
+
+            -- Denormalized game state values
+            game_status VARCHAR(50),
+            home_score INTEGER,
+            away_score INTEGER,
+            period VARCHAR(20),
+            clock VARCHAR(20),
+
+            -- Audit
+            created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+            -- Prevent duplicate alignments
+            CONSTRAINT uq_alignment_snapshot_game
+                UNIQUE (market_snapshot_id, game_state_id)
+        )
+    """)
+
+    # ------------------------------------------------------------------
+    # Step 2: Add indexes for common query patterns
+    # ------------------------------------------------------------------
+    op.execute("CREATE INDEX idx_alignment_market ON temporal_alignment(market_id)")
+    op.execute(
+        "CREATE INDEX idx_alignment_market_time ON temporal_alignment(market_id, snapshot_time DESC)"
+    )
+    op.execute(
+        "CREATE INDEX idx_alignment_quality ON temporal_alignment(alignment_quality) "
+        "WHERE alignment_quality IN ('poor', 'stale')"
+    )
+    op.execute("CREATE INDEX idx_alignment_game_state ON temporal_alignment(game_state_id)")
+
+
+def downgrade() -> None:
+    """Reverse: drop indexes and temporal_alignment table."""
+    # Step 1: Drop indexes
+    op.execute("DROP INDEX IF EXISTS idx_alignment_game_state")
+    op.execute("DROP INDEX IF EXISTS idx_alignment_quality")
+    op.execute("DROP INDEX IF EXISTS idx_alignment_market_time")
+    op.execute("DROP INDEX IF EXISTS idx_alignment_market")
+
+    # Step 2: Drop table
+    op.execute("DROP TABLE IF EXISTS temporal_alignment")

--- a/src/precog/database/alembic/versions/0028_market_trades.py
+++ b/src/precog/database/alembic/versions/0028_market_trades.py
@@ -1,0 +1,98 @@
+"""Create market_trades table for public trade tape data.
+
+Kalshi exposes a public trade tape (all fills on a market, not just ours).
+This data reveals volume patterns, price discovery, and liquidity -- critical
+signals for ML models in Phase 4+. Distinct from the trades table which
+stores only our portfolio fills.
+
+Steps:
+    1. CREATE TABLE market_trades with FKs, dedup constraint, CHECK constraints
+    2. Add indexes for common query patterns (market lookup, time-series, dedup)
+
+Revision ID: 0028
+Revises: 0027
+Create Date: 2026-03-21
+
+Related:
+- migration_batch_plan_v1.md: Migration 0028 spec
+- Issue #402: Add market_trades table for public trade tape
+- ADR-002: Decimal Precision for All Financial Data
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0028"
+down_revision: str = "0027"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create market_trades table for public trade tape persistence.
+
+    Design intent:
+        - Stores ALL public trades on a market (the tape), not just our fills
+        - Append-only: rows are never updated once created
+        - Dedup via UNIQUE(platform_id, external_trade_id) + ON CONFLICT DO NOTHING
+        - yes_price/no_price are EXECUTED trade prices (not order book quotes),
+          hence named without _ask_ suffix
+        - taker_side reveals aggressor direction (market signal for ML)
+        - count is Kalshi's aggregated contract count per trade record
+    """
+    # ------------------------------------------------------------------
+    # Step 1: CREATE TABLE market_trades
+    # ------------------------------------------------------------------
+    op.execute("""
+        CREATE TABLE market_trades (
+            id SERIAL PRIMARY KEY,
+
+            -- Platform + external identity (Kalshi's trade UUID)
+            platform_id VARCHAR(50) NOT NULL
+                REFERENCES platforms(platform_id) ON DELETE CASCADE,
+            external_trade_id VARCHAR(100) NOT NULL,
+
+            -- Market reference (integer FK per surrogate PK pattern)
+            market_internal_id INTEGER NOT NULL
+                REFERENCES markets(id) ON DELETE CASCADE,
+
+            -- Trade data
+            count INTEGER NOT NULL CHECK (count > 0),
+            yes_price DECIMAL(10,4)
+                CHECK (yes_price IS NULL OR (yes_price >= 0.0000 AND yes_price <= 1.0000)),
+            no_price DECIMAL(10,4)
+                CHECK (no_price IS NULL OR (no_price >= 0.0000 AND no_price <= 1.0000)),
+            taker_side VARCHAR(10)
+                CHECK (taker_side IS NULL OR taker_side IN ('yes', 'no')),
+
+            -- Timestamps
+            trade_time TIMESTAMP WITH TIME ZONE NOT NULL,
+            collected_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+
+            -- Dedup
+            CONSTRAINT uq_market_trades_platform_external
+                UNIQUE (platform_id, external_trade_id)
+        )
+    """)
+
+    # ------------------------------------------------------------------
+    # Step 2: Add indexes for common query patterns
+    # ------------------------------------------------------------------
+    op.execute("CREATE INDEX idx_market_trades_market ON market_trades(market_internal_id)")
+    op.execute(
+        "CREATE INDEX idx_market_trades_market_time ON market_trades(market_internal_id, trade_time DESC)"
+    )
+    op.execute("CREATE INDEX idx_market_trades_time ON market_trades(trade_time DESC)")
+
+
+def downgrade() -> None:
+    """Reverse: drop indexes and market_trades table."""
+    # Step 1: Drop indexes
+    op.execute("DROP INDEX IF EXISTS idx_market_trades_time")
+    op.execute("DROP INDEX IF EXISTS idx_market_trades_market_time")
+    op.execute("DROP INDEX IF EXISTS idx_market_trades_market")
+
+    # Step 2: Drop table
+    op.execute("DROP TABLE IF EXISTS market_trades")

--- a/src/precog/database/crud_operations.py
+++ b/src/precog/database/crud_operations.py
@@ -6684,3 +6684,859 @@ def get_open_orders(
     params.append(limit)
 
     return fetch_all(query, tuple(params))
+
+
+# =============================================================================
+# ACCOUNT LEDGER OPERATIONS (Append-Only)
+# =============================================================================
+#
+# Migration 0026: account_ledger table for transaction-level balance tracking.
+#   - Append-only: rows are never updated or deleted.
+#   - Links balance changes to their causes (deposits, withdrawals, P&L, fees).
+#   - amount CAN be negative (withdrawals, fees deducted).
+#   - running_balance cannot go below zero (CHECK constraint in DDL).
+#   - Polymorphic reference: reference_type + reference_id point to the source
+#     entity (order, settlement, trade, manual, system).
+#   - Direct order FK for trade-related entries.
+# =============================================================================
+
+_VALID_TRANSACTION_TYPES = frozenset(
+    {
+        "deposit",
+        "withdrawal",
+        "trade_pnl",
+        "fee",
+        "rebate",
+        "adjustment",
+    }
+)
+
+_VALID_REFERENCE_TYPES = frozenset(
+    {
+        "order",
+        "settlement",
+        "trade",
+        "manual",
+        "system",
+    }
+)
+
+
+def create_ledger_entry(
+    platform_id: str,
+    transaction_type: str,
+    amount: Decimal,
+    running_balance: Decimal,
+    currency: str = "USD",
+    reference_type: str | None = None,
+    reference_id: int | None = None,
+    order_id: int | None = None,
+    description: str | None = None,
+) -> int:
+    """
+    Create an append-only ledger entry recording a balance change.
+
+    The account_ledger explains WHY the balance changed, complementing the
+    account_balance SCD Type 2 snapshots that record WHAT the balance is.
+
+    Args:
+        platform_id: FK to platforms(platform_id), e.g. 'kalshi'
+        transaction_type: One of 'deposit', 'withdrawal', 'trade_pnl',
+            'fee', 'rebate', 'adjustment'
+        amount: Change amount as DECIMAL(10,4). Can be negative
+            (withdrawals, fees).
+        running_balance: Balance after this transaction as DECIMAL(10,4).
+            Must be >= 0.
+        currency: ISO currency code (default 'USD')
+        reference_type: Optional polymorphic source type -- one of
+            'order', 'settlement', 'trade', 'manual', 'system'
+        reference_id: Optional FK to the referenced entity (not enforced)
+        order_id: Optional FK to orders(id) for trade-related entries
+        description: Optional human-readable description
+
+    Returns:
+        Integer surrogate PK (account_ledger.id) of the newly created entry.
+
+    Raises:
+        TypeError: If amount or running_balance is not Decimal
+        ValueError: If transaction_type or reference_type is invalid
+
+    Educational Note:
+        Append-Only vs SCD Type 2:
+            account_balance uses SCD Type 2 (versioned snapshots of WHAT
+            the balance is). account_ledger is append-only (immutable log
+            of WHY it changed). Together they form a complete audit trail:
+            - Ledger: "Deposit of $500 at 10:00 AM"
+            - Balance snapshot: "Balance is now $1500 at 10:00 AM"
+
+        Why running_balance on every row?
+            Avoids expensive SUM(amount) aggregations. The latest row's
+            running_balance IS the current balance. O(1) lookup instead
+            of O(n) aggregation.
+
+    Example:
+        >>> entry_id = create_ledger_entry(
+        ...     platform_id='kalshi',
+        ...     transaction_type='deposit',
+        ...     amount=Decimal("500.0000"),
+        ...     running_balance=Decimal("1500.0000"),
+        ...     description="Initial deposit via ACH",
+        ... )
+        >>> # Returns surrogate id (e.g., 1)
+
+        >>> # Fee deduction (negative amount)
+        >>> entry_id = create_ledger_entry(
+        ...     platform_id='kalshi',
+        ...     transaction_type='fee',
+        ...     amount=Decimal("-0.0200"),
+        ...     running_balance=Decimal("1499.9800"),
+        ...     reference_type='order',
+        ...     reference_id=42,
+        ...     order_id=42,
+        ... )
+
+    References:
+        - Migration 0026: account_ledger
+        - migration_batch_plan_v1.md: Migration 0026 spec
+    """
+    # Runtime type validation (enforces Decimal precision)
+    amount = validate_decimal(amount, "amount")
+    running_balance = validate_decimal(running_balance, "running_balance")
+
+    # Domain constraint validation (mirrors DB CHECK constraint)
+    if running_balance < Decimal("0"):
+        raise ValueError(f"running_balance must be >= 0, got {running_balance}")
+
+    # Runtime enum-like validation
+    if transaction_type not in _VALID_TRANSACTION_TYPES:
+        raise ValueError(
+            f"transaction_type must be one of {_VALID_TRANSACTION_TYPES}, got '{transaction_type}'"
+        )
+    if reference_type is not None and reference_type not in _VALID_REFERENCE_TYPES:
+        raise ValueError(
+            f"reference_type must be one of {_VALID_REFERENCE_TYPES}, got '{reference_type}'"
+        )
+
+    insert_query = """
+        INSERT INTO account_ledger (
+            platform_id, transaction_type,
+            amount, running_balance, currency,
+            reference_type, reference_id,
+            order_id, description
+        )
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+        RETURNING id
+    """
+
+    params = (
+        platform_id,
+        transaction_type,
+        amount,
+        running_balance,
+        currency,
+        reference_type,
+        reference_id,
+        order_id,
+        description,
+    )
+
+    with get_cursor(commit=True) as cur:
+        cur.execute(insert_query, params)
+        result = cur.fetchone()
+        return cast("int", result["id"])
+
+
+def get_ledger_entries(
+    platform_id: str,
+    transaction_type: str | None = None,
+    limit: int = 100,
+    since: datetime | None = None,
+) -> list[dict]:
+    """
+    Retrieve ledger entries for a platform, ordered by created_at DESC.
+
+    Args:
+        platform_id: FK to platforms(platform_id)
+        transaction_type: Optional filter -- one of _VALID_TRANSACTION_TYPES
+        limit: Maximum rows to return (default 100)
+        since: Optional datetime filter -- only entries created after this time
+
+    Returns:
+        List of dictionaries, one per ledger entry, ordered by created_at DESC.
+
+    Example:
+        >>> entries = get_ledger_entries('kalshi', transaction_type='fee', limit=50)
+        >>> for e in entries:
+        ...     print(e['transaction_type'], e['amount'], e['running_balance'])
+
+        >>> # Get entries from the last hour
+        >>> from datetime import datetime, timedelta, timezone
+        >>> cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+        >>> recent = get_ledger_entries('kalshi', since=cutoff)
+
+    References:
+        - Migration 0026: account_ledger
+    """
+    query = "SELECT * FROM account_ledger WHERE platform_id = %s"
+    params: list = [platform_id]
+
+    if transaction_type is not None:
+        if transaction_type not in _VALID_TRANSACTION_TYPES:
+            raise ValueError(
+                f"transaction_type must be one of {_VALID_TRANSACTION_TYPES}, "
+                f"got '{transaction_type}'"
+            )
+        query += " AND transaction_type = %s"
+        params.append(transaction_type)
+
+    if since is not None:
+        query += " AND created_at >= %s"
+        params.append(since)
+
+    query += " ORDER BY created_at DESC, id DESC LIMIT %s"
+    params.append(limit)
+
+    return fetch_all(query, tuple(params))
+
+
+def get_running_balance(platform_id: str) -> Decimal | None:
+    """
+    Return the running_balance from the most recent ledger entry.
+
+    This is an O(1) lookup -- no aggregation needed because every ledger
+    entry stores the running balance at that point in time.
+
+    Args:
+        platform_id: FK to platforms(platform_id)
+
+    Returns:
+        Decimal running_balance from the latest entry, or None if no entries exist.
+
+    Example:
+        >>> balance = get_running_balance('kalshi')
+        >>> if balance is not None:
+        ...     print(f"Current balance: ${balance}")
+        ... else:
+        ...     print("No ledger entries yet")
+
+    References:
+        - Migration 0026: account_ledger
+    """
+    query = """
+        SELECT running_balance FROM account_ledger
+        WHERE platform_id = %s
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1
+    """
+
+    result = fetch_one(query, (platform_id,))
+    if result is None:
+        return None
+    return cast("Decimal", result["running_balance"])
+
+
+# =============================================================================
+# TEMPORAL ALIGNMENT CRUD
+# =============================================================================
+#
+# Migration 0027: temporal_alignment
+# Links market snapshots to game state snapshots by timestamp proximity.
+# Enables cross-source queries like "what was the market price when the score
+# changed?" Critical for Phase 4 backtesting accuracy.
+#
+# Design:
+#   - Append-only: rows are never updated once created.
+#   - Denormalizes key snapshot/game-state fields for query convenience.
+#   - alignment_quality categorizes the time delta between the two sources.
+# =============================================================================
+
+_VALID_ALIGNMENT_QUALITIES = frozenset({"exact", "good", "fair", "poor", "stale"})
+
+# Quality ordering for filtering (higher index = better)
+_ALIGNMENT_QUALITY_ORDER = ["stale", "poor", "fair", "good", "exact"]
+
+
+def insert_temporal_alignment(
+    market_id: int,
+    market_snapshot_id: int,
+    game_state_id: int,
+    snapshot_time: datetime,
+    game_state_time: datetime,
+    time_delta_seconds: Decimal,
+    alignment_quality: str = "good",
+    yes_ask_price: Decimal | None = None,
+    no_ask_price: Decimal | None = None,
+    spread: Decimal | None = None,
+    volume: int | None = None,
+    game_status: str | None = None,
+    home_score: int | None = None,
+    away_score: int | None = None,
+    period: str | None = None,
+    clock: str | None = None,
+) -> int:
+    """
+    Insert a temporal alignment linking a market snapshot to a game state.
+
+    The temporal_alignment table bridges Kalshi price polls (every 15s) and
+    ESPN game-state polls (every 30s) by matching them on timestamp proximity.
+    Each row records a SPECIFIC market_snapshot <-> game_state pairing with
+    the time delta and denormalized values for query convenience.
+
+    Args:
+        market_id: FK to markets(id)
+        market_snapshot_id: FK to market_snapshots(id) -- the specific snapshot row
+        game_state_id: FK to game_states(id) -- the specific game state row
+        snapshot_time: Timestamp of the market snapshot
+        game_state_time: Timestamp of the game state
+        time_delta_seconds: Absolute time difference as DECIMAL(10,2)
+        alignment_quality: One of 'exact', 'good', 'fair', 'poor', 'stale'
+            (default 'good')
+        yes_ask_price: Denormalized YES ask price as DECIMAL(10,4)
+        no_ask_price: Denormalized NO ask price as DECIMAL(10,4)
+        spread: Denormalized bid-ask spread as DECIMAL(10,4)
+        volume: Denormalized trade volume
+        game_status: Denormalized game status string
+        home_score: Denormalized home team score
+        away_score: Denormalized away team score
+        period: Denormalized game period (e.g., '1st', '2nd', 'OT')
+        clock: Denormalized game clock (e.g., '12:00', '05:32')
+
+    Returns:
+        Integer surrogate PK (temporal_alignment.id) of the newly created row.
+
+    Raises:
+        TypeError: If Decimal fields are not Decimal type
+        ValueError: If alignment_quality is not a valid value
+
+    Example:
+        >>> alignment_id = insert_temporal_alignment(
+        ...     market_id=42,
+        ...     market_snapshot_id=1001,
+        ...     game_state_id=501,
+        ...     snapshot_time=datetime(2026, 1, 15, 20, 30, 0, tzinfo=UTC),
+        ...     game_state_time=datetime(2026, 1, 15, 20, 30, 5, tzinfo=UTC),
+        ...     time_delta_seconds=Decimal("5.00"),
+        ...     alignment_quality='good',
+        ...     yes_ask_price=Decimal("0.5500"),
+        ...     no_ask_price=Decimal("0.4500"),
+        ... )
+
+    References:
+        - Migration 0027: temporal_alignment
+        - Issue #375: Temporal alignment table
+        - migration_batch_plan_v1.md: Migration 0027 spec
+    """
+    # Runtime type validation (enforces Decimal precision)
+    time_delta_seconds = validate_decimal(time_delta_seconds, "time_delta_seconds")
+    if yes_ask_price is not None:
+        yes_ask_price = validate_decimal(yes_ask_price, "yes_ask_price")
+    if no_ask_price is not None:
+        no_ask_price = validate_decimal(no_ask_price, "no_ask_price")
+    if spread is not None:
+        spread = validate_decimal(spread, "spread")
+
+    # Runtime enum-like validation
+    if alignment_quality not in _VALID_ALIGNMENT_QUALITIES:
+        raise ValueError(
+            f"alignment_quality must be one of {_VALID_ALIGNMENT_QUALITIES}, "
+            f"got '{alignment_quality}'"
+        )
+
+    insert_query = """
+        INSERT INTO temporal_alignment (
+            market_id, market_snapshot_id, game_state_id,
+            snapshot_time, game_state_time, time_delta_seconds,
+            alignment_quality,
+            yes_ask_price, no_ask_price, spread, volume,
+            game_status, home_score, away_score, period, clock
+        )
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        RETURNING id
+    """
+
+    params = (
+        market_id,
+        market_snapshot_id,
+        game_state_id,
+        snapshot_time,
+        game_state_time,
+        time_delta_seconds,
+        alignment_quality,
+        yes_ask_price,
+        no_ask_price,
+        spread,
+        volume,
+        game_status,
+        home_score,
+        away_score,
+        period,
+        clock,
+    )
+
+    with get_cursor(commit=True) as cur:
+        cur.execute(insert_query, params)
+        result = cur.fetchone()
+        return cast("int", result["id"])
+
+
+def insert_temporal_alignment_batch(alignments: list[dict]) -> int:
+    """
+    Bulk insert temporal alignment rows.
+
+    Accepts a list of dictionaries, each with the same keys as
+    insert_temporal_alignment parameters. Uses executemany for efficiency.
+
+    Args:
+        alignments: List of dicts, each containing:
+            - market_id (int, required)
+            - market_snapshot_id (int, required)
+            - game_state_id (int, required)
+            - snapshot_time (datetime, required)
+            - game_state_time (datetime, required)
+            - time_delta_seconds (Decimal, required)
+            - alignment_quality (str, default 'good')
+            - yes_ask_price (Decimal | None)
+            - no_ask_price (Decimal | None)
+            - spread (Decimal | None)
+            - volume (int | None)
+            - game_status (str | None)
+            - home_score (int | None)
+            - away_score (int | None)
+            - period (str | None)
+            - clock (str | None)
+
+    Returns:
+        Count of rows inserted.
+
+    Raises:
+        TypeError: If Decimal fields are not Decimal type
+        ValueError: If alignment_quality is not a valid value
+
+    Example:
+        >>> rows = [
+        ...     {
+        ...         "market_id": 42,
+        ...         "market_snapshot_id": 1001,
+        ...         "game_state_id": 501,
+        ...         "snapshot_time": datetime(2026, 1, 15, 20, 30, 0, tzinfo=UTC),
+        ...         "game_state_time": datetime(2026, 1, 15, 20, 30, 5, tzinfo=UTC),
+        ...         "time_delta_seconds": Decimal("5.00"),
+        ...     },
+        ...     {
+        ...         "market_id": 42,
+        ...         "market_snapshot_id": 1002,
+        ...         "game_state_id": 502,
+        ...         "snapshot_time": datetime(2026, 1, 15, 20, 30, 15, tzinfo=UTC),
+        ...         "game_state_time": datetime(2026, 1, 15, 20, 30, 10, tzinfo=UTC),
+        ...         "time_delta_seconds": Decimal("5.00"),
+        ...     },
+        ... ]
+        >>> count = insert_temporal_alignment_batch(rows)
+        >>> # count == 2
+
+    References:
+        - Migration 0027: temporal_alignment
+        - migration_batch_plan_v1.md: Migration 0027 spec
+    """
+    if not alignments:
+        return 0
+
+    # Validate all rows before inserting any
+    validated_params = []
+    for i, row in enumerate(alignments):
+        time_delta = validate_decimal(
+            row["time_delta_seconds"], f"alignments[{i}].time_delta_seconds"
+        )
+
+        yes_price = row.get("yes_ask_price")
+        if yes_price is not None:
+            yes_price = validate_decimal(yes_price, f"alignments[{i}].yes_ask_price")
+
+        no_price = row.get("no_ask_price")
+        if no_price is not None:
+            no_price = validate_decimal(no_price, f"alignments[{i}].no_ask_price")
+
+        sprd = row.get("spread")
+        if sprd is not None:
+            sprd = validate_decimal(sprd, f"alignments[{i}].spread")
+
+        quality = row.get("alignment_quality", "good")
+        if quality not in _VALID_ALIGNMENT_QUALITIES:
+            raise ValueError(
+                f"alignment_quality must be one of {_VALID_ALIGNMENT_QUALITIES}, "
+                f"got '{quality}' in alignments[{i}]"
+            )
+
+        validated_params.append(
+            (
+                row["market_id"],
+                row["market_snapshot_id"],
+                row["game_state_id"],
+                row["snapshot_time"],
+                row["game_state_time"],
+                time_delta,
+                quality,
+                yes_price,
+                no_price,
+                sprd,
+                row.get("volume"),
+                row.get("game_status"),
+                row.get("home_score"),
+                row.get("away_score"),
+                row.get("period"),
+                row.get("clock"),
+            )
+        )
+
+    insert_query = """
+        INSERT INTO temporal_alignment (
+            market_id, market_snapshot_id, game_state_id,
+            snapshot_time, game_state_time, time_delta_seconds,
+            alignment_quality,
+            yes_ask_price, no_ask_price, spread, volume,
+            game_status, home_score, away_score, period, clock
+        )
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+    """
+
+    with get_cursor(commit=True) as cur:
+        cur.executemany(insert_query, validated_params)
+        return len(validated_params)
+
+
+def get_alignments_by_market(
+    market_id: int,
+    limit: int = 100,
+    min_quality: str | None = None,
+) -> list[dict]:
+    """
+    Retrieve temporal alignments for a market, ordered by snapshot_time DESC.
+
+    Args:
+        market_id: FK to markets(id)
+        limit: Maximum rows to return (default 100)
+        min_quality: Optional minimum quality filter. Returns entries at this
+            quality level or better. Quality ordering (worst to best):
+            stale < poor < fair < good < exact
+
+    Returns:
+        List of dictionaries, one per alignment row, ordered by
+        snapshot_time DESC, id DESC.
+
+    Raises:
+        ValueError: If min_quality is not a valid alignment quality value
+
+    Example:
+        >>> # Get all alignments for market 42
+        >>> alignments = get_alignments_by_market(42)
+
+        >>> # Get only good or better alignments
+        >>> good_alignments = get_alignments_by_market(42, min_quality='good')
+
+        >>> # Get latest 10 alignments
+        >>> recent = get_alignments_by_market(42, limit=10)
+
+    References:
+        - Migration 0027: temporal_alignment
+        - migration_batch_plan_v1.md: Migration 0027 spec
+    """
+    query = "SELECT * FROM temporal_alignment WHERE market_id = %s"
+    params: list = [market_id]
+
+    if min_quality is not None:
+        if min_quality not in _VALID_ALIGNMENT_QUALITIES:
+            raise ValueError(
+                f"min_quality must be one of {_VALID_ALIGNMENT_QUALITIES}, got '{min_quality}'"
+            )
+        # Filter to entries at min_quality or better
+        quality_index = _ALIGNMENT_QUALITY_ORDER.index(min_quality)
+        acceptable = _ALIGNMENT_QUALITY_ORDER[quality_index:]
+        placeholders = ", ".join(["%s"] * len(acceptable))
+        query += f" AND alignment_quality IN ({placeholders})"
+        params.extend(acceptable)
+
+    query += " ORDER BY snapshot_time DESC, id DESC LIMIT %s"
+    params.append(limit)
+
+    return fetch_all(query, tuple(params))
+
+
+# =============================================================================
+# MARKET TRADES CRUD
+# =============================================================================
+#
+# Migration 0028: market_trades
+# Stores Kalshi's public trade tape (all fills on a market, not just ours).
+# Reveals volume patterns, price discovery, and liquidity -- critical ML signals.
+#
+# Design:
+#   - Append-only: rows are never updated once created.
+#   - Dedup via UNIQUE(platform_id, external_trade_id) + ON CONFLICT DO NOTHING.
+#   - yes_price/no_price are executed trade prices (not order book quotes).
+#   - taker_side reveals aggressor direction.
+# =============================================================================
+
+_VALID_TAKER_SIDES = frozenset({"yes", "no"})
+
+
+def upsert_market_trade(
+    platform_id: str,
+    external_trade_id: str,
+    market_internal_id: int,
+    count: int,
+    trade_time: datetime,
+    yes_price: Decimal | None = None,
+    no_price: Decimal | None = None,
+    taker_side: str | None = None,
+) -> int | None:
+    """
+    Insert a public market trade, skipping if it already exists (idempotent).
+
+    Uses INSERT ... ON CONFLICT (platform_id, external_trade_id) DO NOTHING
+    to safely handle duplicate ingestion from the Kalshi trade tape API.
+
+    Args:
+        platform_id: FK to platforms(platform_id), e.g. 'kalshi'
+        external_trade_id: Kalshi's trade UUID (unique per platform)
+        market_internal_id: FK to markets(id) -- integer surrogate PK
+        count: Number of contracts in this trade (must be > 0)
+        trade_time: When the trade was executed on the exchange
+        yes_price: Executed yes-side price as DECIMAL(10,4), or None
+        no_price: Executed no-side price as DECIMAL(10,4), or None
+        taker_side: Aggressor side -- 'yes' or 'no', or None if unknown
+
+    Returns:
+        Integer surrogate PK (market_trades.id) if inserted,
+        None if the trade already existed (conflict).
+
+    Raises:
+        TypeError: If yes_price or no_price is not Decimal (when not None)
+        ValueError: If taker_side is not in {'yes', 'no'} (when not None)
+
+    Example:
+        >>> trade_id = upsert_market_trade(
+        ...     platform_id='kalshi',
+        ...     external_trade_id='abc-123-def',
+        ...     market_internal_id=42,
+        ...     count=10,
+        ...     trade_time=datetime(2026, 1, 15, 20, 30, 0, tzinfo=UTC),
+        ...     yes_price=Decimal("0.5500"),
+        ...     taker_side='yes',
+        ... )
+        >>> # Returns id (e.g., 1) or None if duplicate
+
+    References:
+        - Migration 0028: market_trades
+        - Issue #402: Add market_trades table for public trade tape
+    """
+    # Runtime type validation for Decimal fields
+    if yes_price is not None:
+        yes_price = validate_decimal(yes_price, "yes_price")
+    if no_price is not None:
+        no_price = validate_decimal(no_price, "no_price")
+
+    # Runtime enum validation for taker_side
+    if taker_side is not None and taker_side not in _VALID_TAKER_SIDES:
+        raise ValueError(f"taker_side must be one of {_VALID_TAKER_SIDES}, got '{taker_side}'")
+
+    insert_query = """
+        INSERT INTO market_trades (
+            platform_id, external_trade_id, market_internal_id,
+            count, yes_price, no_price, taker_side,
+            trade_time
+        )
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (platform_id, external_trade_id) DO NOTHING
+        RETURNING id
+    """
+
+    params = (
+        platform_id,
+        external_trade_id,
+        market_internal_id,
+        count,
+        yes_price,
+        no_price,
+        taker_side,
+        trade_time,
+    )
+
+    with get_cursor(commit=True) as cur:
+        cur.execute(insert_query, params)
+        result = cur.fetchone()
+        if result is None:
+            return None
+        return cast("int", result["id"])
+
+
+def upsert_market_trades_batch(trades: list[dict]) -> int:
+    """
+    Bulk insert public market trades, skipping duplicates (idempotent).
+
+    Validates all rows before inserting any. Uses executemany with
+    ON CONFLICT DO NOTHING for safe bulk ingestion.
+
+    Args:
+        trades: List of dicts, each with keys:
+            - platform_id (str): FK to platforms(platform_id)
+            - external_trade_id (str): Kalshi's trade UUID
+            - market_internal_id (int): FK to markets(id)
+            - count (int): Number of contracts (must be > 0)
+            - trade_time (datetime): When trade was executed
+            - yes_price (Decimal | None): Optional executed yes price
+            - no_price (Decimal | None): Optional executed no price
+            - taker_side (str | None): Optional 'yes' or 'no'
+
+    Returns:
+        Count of rows actually inserted (not skipped by ON CONFLICT).
+
+    Raises:
+        TypeError: If Decimal fields are not Decimal type
+        ValueError: If taker_side is not a valid value
+
+    Example:
+        >>> trades = [
+        ...     {
+        ...         "platform_id": "kalshi",
+        ...         "external_trade_id": "abc-123",
+        ...         "market_internal_id": 42,
+        ...         "count": 10,
+        ...         "trade_time": datetime(2026, 1, 15, 20, 30, 0, tzinfo=UTC),
+        ...         "yes_price": Decimal("0.5500"),
+        ...         "taker_side": "yes",
+        ...     },
+        ... ]
+        >>> inserted = upsert_market_trades_batch(trades)
+        >>> # inserted == 1 (or 0 if all were duplicates)
+
+    References:
+        - Migration 0028: market_trades
+        - Issue #402: Add market_trades table for public trade tape
+    """
+    if not trades:
+        return 0
+
+    # Validate all rows before inserting any
+    validated_params = []
+    for i, row in enumerate(trades):
+        yes_price = row.get("yes_price")
+        if yes_price is not None:
+            yes_price = validate_decimal(yes_price, f"trades[{i}].yes_price")
+
+        no_price = row.get("no_price")
+        if no_price is not None:
+            no_price = validate_decimal(no_price, f"trades[{i}].no_price")
+
+        taker_side = row.get("taker_side")
+        if taker_side is not None and taker_side not in _VALID_TAKER_SIDES:
+            raise ValueError(
+                f"taker_side must be one of {_VALID_TAKER_SIDES}, got '{taker_side}' in trades[{i}]"
+            )
+
+        validated_params.append(
+            (
+                row["platform_id"],
+                row["external_trade_id"],
+                row["market_internal_id"],
+                row["count"],
+                yes_price,
+                no_price,
+                taker_side,
+                row["trade_time"],
+            )
+        )
+
+    insert_query = """
+        INSERT INTO market_trades (
+            platform_id, external_trade_id, market_internal_id,
+            count, yes_price, no_price, taker_side,
+            trade_time
+        )
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (platform_id, external_trade_id) DO NOTHING
+    """
+
+    with get_cursor(commit=True) as cur:
+        cur.executemany(insert_query, validated_params)
+        return cast("int", cur.rowcount)
+
+
+def get_market_trades(
+    market_internal_id: int,
+    limit: int = 100,
+    since: datetime | None = None,
+) -> list[dict]:
+    """
+    Retrieve public market trades for a market, ordered by trade_time DESC.
+
+    Args:
+        market_internal_id: FK to markets(id)
+        limit: Maximum rows to return (default 100)
+        since: Optional datetime filter -- only trades after this time
+
+    Returns:
+        List of dictionaries, one per trade, ordered by trade_time DESC, id DESC.
+
+    Example:
+        >>> trades = get_market_trades(42, limit=50)
+        >>> for t in trades:
+        ...     print(t['yes_price'], t['count'], t['taker_side'])
+
+        >>> # Get trades from the last hour
+        >>> from datetime import datetime, timedelta, timezone
+        >>> cutoff = datetime.now(timezone.utc) - timedelta(hours=1)
+        >>> recent = get_market_trades(42, since=cutoff)
+
+    References:
+        - Migration 0028: market_trades
+        - Issue #402: Add market_trades table for public trade tape
+    """
+    query = "SELECT * FROM market_trades WHERE market_internal_id = %s"
+    params: list = [market_internal_id]
+
+    if since is not None:
+        query += " AND trade_time >= %s"
+        params.append(since)
+
+    query += " ORDER BY trade_time DESC, id DESC LIMIT %s"
+    params.append(limit)
+
+    return fetch_all(query, tuple(params))
+
+
+def get_latest_trade_time(market_internal_id: int) -> datetime | None:
+    """
+    Return trade_time from the most recent public trade for a market.
+
+    Used as a high-water mark for incremental polling -- the poller asks
+    Kalshi for trades newer than this timestamp, avoiding re-fetching the
+    entire tape on every poll cycle.
+
+    Args:
+        market_internal_id: FK to markets(id)
+
+    Returns:
+        datetime of the latest trade, or None if no trades exist for this market.
+
+    Example:
+        >>> hwm = get_latest_trade_time(42)
+        >>> if hwm is not None:
+        ...     new_trades = kalshi_client.get_trades(market_id, min_ts=hwm)
+        ... else:
+        ...     new_trades = kalshi_client.get_trades(market_id)  # full fetch
+
+    References:
+        - Migration 0028: market_trades
+        - Issue #402: Add market_trades table for public trade tape
+    """
+    query = """
+        SELECT trade_time FROM market_trades
+        WHERE market_internal_id = %s
+        ORDER BY trade_time DESC, id DESC
+        LIMIT 1
+    """
+
+    result = fetch_one(query, (market_internal_id,))
+    if result is None:
+        return None
+    return cast("datetime", result["trade_time"])

--- a/tests/unit/database/test_account_ledger_crud.py
+++ b/tests/unit/database/test_account_ledger_crud.py
@@ -1,0 +1,371 @@
+"""
+Unit Tests for Account Ledger CRUD Operations (Migration 0026).
+
+Tests the append-only ledger functions: create_ledger_entry, get_ledger_entries,
+and get_running_balance. Validates Decimal enforcement, enum validation, optional
+parameter handling, filtering, and ordering.
+
+Related:
+- Migration 0026: account_ledger
+- ADR-002: Decimal Precision for All Financial Data
+- migration_batch_plan_v1.md: Migration 0026 spec
+
+Usage:
+    pytest tests/unit/database/test_account_ledger_crud.py -v
+    pytest tests/unit/database/test_account_ledger_crud.py -v -m unit
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from precog.database.crud_operations import (
+    _VALID_REFERENCE_TYPES,
+    _VALID_TRANSACTION_TYPES,
+    create_ledger_entry,
+    get_ledger_entries,
+    get_running_balance,
+)
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+
+def _mock_cursor_context(mock_get_cursor, mock_cursor=None):
+    """Set up mock_get_cursor to return a context manager yielding mock_cursor."""
+    if mock_cursor is None:
+        mock_cursor = MagicMock()
+    mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_cursor
+
+
+def _default_ledger_kwargs():
+    """Return minimal valid kwargs for create_ledger_entry."""
+    return {
+        "platform_id": "kalshi",
+        "transaction_type": "deposit",
+        "amount": Decimal("500.0000"),
+        "running_balance": Decimal("1500.0000"),
+    }
+
+
+# =============================================================================
+# CREATE LEDGER ENTRY TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestCreateLedgerEntry:
+    """Unit tests for create_ledger_entry function."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_ledger_entry_returns_surrogate_id(self, mock_get_cursor):
+        """Test create_ledger_entry returns the integer surrogate PK."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        result = create_ledger_entry(**_default_ledger_kwargs())
+
+        assert result == 1
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_ledger_entry_validates_decimal_amount(self, mock_get_cursor):
+        """Test that float values are rejected for amount."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_ledger_kwargs()
+        kwargs["amount"] = 500.0  # float -- should raise
+
+        with pytest.raises(TypeError, match="amount must be Decimal"):
+            create_ledger_entry(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_ledger_entry_validates_decimal_running_balance(self, mock_get_cursor):
+        """Test that float values are rejected for running_balance."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_ledger_kwargs()
+        kwargs["running_balance"] = 1500.0  # float -- should raise
+
+        with pytest.raises(TypeError, match="running_balance must be Decimal"):
+            create_ledger_entry(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_ledger_entry_validates_transaction_type(self, mock_get_cursor):
+        """Test that invalid transaction_type values are rejected."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_ledger_kwargs()
+        kwargs["transaction_type"] = "refund"
+
+        with pytest.raises(ValueError, match="transaction_type must be one of"):
+            create_ledger_entry(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_ledger_entry_validates_reference_type(self, mock_get_cursor):
+        """Test that invalid reference_type values are rejected."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_ledger_kwargs()
+        kwargs["reference_type"] = "external"
+
+        with pytest.raises(ValueError, match="reference_type must be one of"):
+            create_ledger_entry(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_ledger_entry_allows_none_reference_type(self, mock_get_cursor):
+        """Test that reference_type=None is accepted (not validated)."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 2}
+
+        kwargs = _default_ledger_kwargs()
+        kwargs["reference_type"] = None
+
+        result = create_ledger_entry(**kwargs)
+
+        assert result == 2
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_ledger_entry_validates_running_balance_non_negative(self, mock_get_cursor):
+        """Test that negative running_balance is rejected."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_ledger_kwargs()
+        kwargs["running_balance"] = Decimal("-1.0000")
+
+        with pytest.raises(ValueError, match="running_balance must be >= 0"):
+            create_ledger_entry(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_ledger_entry_allows_zero_running_balance(self, mock_get_cursor):
+        """Test that running_balance=0 is accepted (boundary value)."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 10}
+
+        kwargs = _default_ledger_kwargs()
+        kwargs["running_balance"] = Decimal("0.0000")
+        kwargs["transaction_type"] = "withdrawal"
+        kwargs["amount"] = Decimal("-1500.0000")
+
+        result = create_ledger_entry(**kwargs)
+
+        assert result == 10
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_ledger_entry_allows_negative_amount(self, mock_get_cursor):
+        """Test that negative amounts are allowed (withdrawals, fees)."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 3}
+
+        kwargs = _default_ledger_kwargs()
+        kwargs["amount"] = Decimal("-25.0000")
+        kwargs["transaction_type"] = "fee"
+
+        result = create_ledger_entry(**kwargs)
+
+        assert result == 3
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_ledger_entry_with_all_optional_fields(self, mock_get_cursor):
+        """Test create_ledger_entry with every optional parameter provided."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 99}
+
+        result = create_ledger_entry(
+            platform_id="kalshi",
+            transaction_type="trade_pnl",
+            amount=Decimal("50.0000"),
+            running_balance=Decimal("1550.0000"),
+            currency="USD",
+            reference_type="order",
+            reference_id=42,
+            order_id=42,
+            description="Profit from YES contract fill",
+        )
+
+        assert result == 99
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_ledger_entry_accepts_all_valid_transaction_types(self, mock_get_cursor):
+        """Test that every valid transaction_type is accepted."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        for txn_type in _VALID_TRANSACTION_TYPES:
+            kwargs = _default_ledger_kwargs()
+            kwargs["transaction_type"] = txn_type
+            result = create_ledger_entry(**kwargs)
+            assert result == 1
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_ledger_entry_accepts_all_valid_reference_types(self, mock_get_cursor):
+        """Test that every valid reference_type is accepted."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        for ref_type in _VALID_REFERENCE_TYPES:
+            kwargs = _default_ledger_kwargs()
+            kwargs["reference_type"] = ref_type
+            kwargs["reference_id"] = 1
+            result = create_ledger_entry(**kwargs)
+            assert result == 1
+
+
+# =============================================================================
+# GET LEDGER ENTRIES TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetLedgerEntries:
+    """Unit tests for get_ledger_entries function."""
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_ledger_entries_returns_empty_list(self, mock_fetch_all):
+        """Test that empty result set returns empty list."""
+        mock_fetch_all.return_value = []
+
+        result = get_ledger_entries("kalshi")
+
+        assert result == []
+
+    def test_get_ledger_entries_validates_transaction_type(self):
+        """Test that invalid transaction_type is rejected."""
+        with pytest.raises(ValueError, match="transaction_type must be one of"):
+            get_ledger_entries("kalshi", transaction_type="refund")
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_ledger_entries_returns_list(self, mock_fetch_all):
+        """Test that result is a list of dicts."""
+        mock_fetch_all.return_value = [
+            {"id": 1, "transaction_type": "deposit", "amount": Decimal("500.0000")},
+            {"id": 2, "transaction_type": "fee", "amount": Decimal("-0.0200")},
+        ]
+
+        result = get_ledger_entries("kalshi")
+
+        assert len(result) == 2
+        assert result[0]["id"] == 1
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_ledger_entries_filters_by_type(self, mock_fetch_all):
+        """Test filtering by transaction_type."""
+        mock_fetch_all.return_value = []
+
+        get_ledger_entries("kalshi", transaction_type="fee")
+
+        query = mock_fetch_all.call_args[0][0]
+        params = mock_fetch_all.call_args[0][1]
+        assert "transaction_type = %s" in query
+        assert "fee" in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_ledger_entries_filters_by_since(self, mock_fetch_all):
+        """Test filtering by since datetime."""
+        mock_fetch_all.return_value = []
+        cutoff = datetime(2026, 3, 21, 12, 0, 0, tzinfo=UTC)
+
+        get_ledger_entries("kalshi", since=cutoff)
+
+        query = mock_fetch_all.call_args[0][0]
+        params = mock_fetch_all.call_args[0][1]
+        assert "created_at >= %s" in query
+        assert cutoff in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_ledger_entries_respects_limit(self, mock_fetch_all):
+        """Test that custom limit is applied."""
+        mock_fetch_all.return_value = []
+
+        get_ledger_entries("kalshi", limit=25)
+
+        params = mock_fetch_all.call_args[0][1]
+        assert 25 in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_ledger_entries_default_limit(self, mock_fetch_all):
+        """Test that default limit of 100 is applied."""
+        mock_fetch_all.return_value = []
+
+        get_ledger_entries("kalshi")
+
+        params = mock_fetch_all.call_args[0][1]
+        assert 100 in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_ledger_entries_orders_by_created_at_desc(self, mock_fetch_all):
+        """Test that query orders by created_at DESC."""
+        mock_fetch_all.return_value = []
+
+        get_ledger_entries("kalshi")
+
+        query = mock_fetch_all.call_args[0][0]
+        assert "ORDER BY created_at DESC, id DESC" in query
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_ledger_entries_combines_filters(self, mock_fetch_all):
+        """Test combining transaction_type and since filters."""
+        mock_fetch_all.return_value = []
+        cutoff = datetime(2026, 3, 21, 12, 0, 0, tzinfo=UTC)
+
+        get_ledger_entries("kalshi", transaction_type="deposit", since=cutoff)
+
+        query = mock_fetch_all.call_args[0][0]
+        assert "transaction_type = %s" in query
+        assert "created_at >= %s" in query
+
+
+# =============================================================================
+# GET RUNNING BALANCE TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetRunningBalance:
+    """Unit tests for get_running_balance function."""
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_get_running_balance_returns_decimal(self, mock_fetch_one):
+        """Test that running_balance is returned as Decimal from latest entry."""
+        mock_fetch_one.return_value = {"running_balance": Decimal("1500.0000")}
+
+        result = get_running_balance("kalshi")
+
+        assert result == Decimal("1500.0000")
+        assert isinstance(result, Decimal)
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_get_running_balance_returns_none_when_empty(self, mock_fetch_one):
+        """Test that None is returned when no ledger entries exist."""
+        mock_fetch_one.return_value = None
+
+        result = get_running_balance("kalshi")
+
+        assert result is None
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_get_running_balance_queries_latest_entry(self, mock_fetch_one):
+        """Test that query orders by created_at DESC LIMIT 1."""
+        mock_fetch_one.return_value = {"running_balance": Decimal("1000.0000")}
+
+        get_running_balance("kalshi")
+
+        query = mock_fetch_one.call_args[0][0]
+        assert "ORDER BY created_at DESC, id DESC" in query
+        assert "LIMIT 1" in query
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_get_running_balance_filters_by_platform(self, mock_fetch_one):
+        """Test that query filters by platform_id."""
+        mock_fetch_one.return_value = {"running_balance": Decimal("1000.0000")}
+
+        get_running_balance("kalshi")
+
+        query = mock_fetch_one.call_args[0][0]
+        params = mock_fetch_one.call_args[0][1]
+        assert "platform_id = %s" in query
+        assert "kalshi" in params

--- a/tests/unit/database/test_market_trades_crud.py
+++ b/tests/unit/database/test_market_trades_crud.py
@@ -1,0 +1,446 @@
+"""
+Unit Tests for Market Trades CRUD Operations (Migration 0028).
+
+Tests the market trades functions: upsert_market_trade, upsert_market_trades_batch,
+get_market_trades, and get_latest_trade_time. Validates Decimal enforcement,
+enum validation, optional parameter handling, batch operations, ON CONFLICT
+idempotency, since filtering, and ordering.
+
+Related:
+- Migration 0028: market_trades
+- Issue #402: Add market_trades table for public trade tape
+- migration_batch_plan_v1.md: Migration 0028 spec
+
+Usage:
+    pytest tests/unit/database/test_market_trades_crud.py -v
+    pytest tests/unit/database/test_market_trades_crud.py -v -m unit
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from precog.database.crud_operations import (
+    _VALID_TAKER_SIDES,
+    get_latest_trade_time,
+    get_market_trades,
+    upsert_market_trade,
+    upsert_market_trades_batch,
+)
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+
+def _mock_cursor_context(mock_get_cursor, mock_cursor=None):
+    """Set up mock_get_cursor to return a context manager yielding mock_cursor."""
+    if mock_cursor is None:
+        mock_cursor = MagicMock()
+    mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_cursor
+
+
+def _default_trade_kwargs():
+    """Return minimal valid kwargs for upsert_market_trade."""
+    return {
+        "platform_id": "kalshi",
+        "external_trade_id": "abc-123-def",
+        "market_internal_id": 42,
+        "count": 10,
+        "trade_time": datetime(2026, 1, 15, 20, 30, 0, tzinfo=UTC),
+    }
+
+
+def _default_trade_dict():
+    """Return minimal valid dict for upsert_market_trades_batch."""
+    return {
+        "platform_id": "kalshi",
+        "external_trade_id": "abc-123-def",
+        "market_internal_id": 42,
+        "count": 10,
+        "trade_time": datetime(2026, 1, 15, 20, 30, 0, tzinfo=UTC),
+    }
+
+
+# =============================================================================
+# UPSERT MARKET TRADE TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestUpsertMarketTrade:
+    """Unit tests for upsert_market_trade function."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_upsert_returns_surrogate_id(self, mock_get_cursor):
+        """Test upsert_market_trade returns the integer surrogate PK on insert."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        result = upsert_market_trade(**_default_trade_kwargs())
+
+        assert result == 1
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_upsert_returns_none_on_conflict(self, mock_get_cursor):
+        """Test upsert returns None when trade already exists (ON CONFLICT DO NOTHING)."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = None
+
+        result = upsert_market_trade(**_default_trade_kwargs())
+
+        assert result is None
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_upsert_validates_decimal_yes_price(self, mock_get_cursor):
+        """Test that float values are rejected for yes_price."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_trade_kwargs()
+        kwargs["yes_price"] = 0.55  # float -- should raise
+
+        with pytest.raises(TypeError, match="yes_price must be Decimal"):
+            upsert_market_trade(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_upsert_validates_decimal_no_price(self, mock_get_cursor):
+        """Test that float values are rejected for no_price."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_trade_kwargs()
+        kwargs["no_price"] = 0.45  # float -- should raise
+
+        with pytest.raises(TypeError, match="no_price must be Decimal"):
+            upsert_market_trade(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_upsert_validates_taker_side(self, mock_get_cursor):
+        """Test that invalid taker_side values are rejected."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_trade_kwargs()
+        kwargs["taker_side"] = "buy"  # invalid -- should raise
+
+        with pytest.raises(ValueError, match="taker_side must be one of"):
+            upsert_market_trade(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_upsert_allows_none_optional_fields(self, mock_get_cursor):
+        """Test that all optional fields accept None (default behavior)."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 2}
+
+        # Only required fields -- yes_price, no_price, taker_side default to None
+        result = upsert_market_trade(**_default_trade_kwargs())
+
+        assert result == 2
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_upsert_with_all_optional_fields(self, mock_get_cursor):
+        """Test upsert_market_trade with every optional parameter provided."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 99}
+
+        result = upsert_market_trade(
+            platform_id="kalshi",
+            external_trade_id="abc-123-def",
+            market_internal_id=42,
+            count=10,
+            trade_time=datetime(2026, 1, 15, 20, 30, 0, tzinfo=UTC),
+            yes_price=Decimal("0.5500"),
+            no_price=Decimal("0.4500"),
+            taker_side="yes",
+        )
+
+        assert result == 99
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_upsert_accepts_all_valid_taker_sides(self, mock_get_cursor):
+        """Test that every valid taker_side is accepted."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        for side in _VALID_TAKER_SIDES:
+            kwargs = _default_trade_kwargs()
+            kwargs["taker_side"] = side
+            result = upsert_market_trade(**kwargs)
+            assert result == 1
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_upsert_sql_contains_on_conflict(self, mock_get_cursor):
+        """Test that the SQL uses ON CONFLICT DO NOTHING for idempotency."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        upsert_market_trade(**_default_trade_kwargs())
+
+        call_args = mock_cursor.execute.call_args
+        sql = call_args[0][0]
+        assert "ON CONFLICT" in sql
+        assert "DO NOTHING" in sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_upsert_sql_contains_returning_id(self, mock_get_cursor):
+        """Test that the SQL uses RETURNING id to get the surrogate PK."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        upsert_market_trade(**_default_trade_kwargs())
+
+        call_args = mock_cursor.execute.call_args
+        sql = call_args[0][0]
+        assert "RETURNING id" in sql
+
+
+# =============================================================================
+# UPSERT MARKET TRADES BATCH TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestUpsertMarketTradesBatch:
+    """Unit tests for upsert_market_trades_batch function."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_batch_returns_rowcount(self, mock_get_cursor):
+        """Test batch insert returns cur.rowcount (actual inserts, not skipped)."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 2
+
+        rows = [_default_trade_dict(), _default_trade_dict()]
+        rows[1]["external_trade_id"] = "xyz-456-ghi"
+
+        result = upsert_market_trades_batch(rows)
+
+        assert result == 2
+
+    def test_batch_empty_list_returns_zero(self):
+        """Test that empty list returns 0 without DB interaction."""
+        result = upsert_market_trades_batch([])
+
+        assert result == 0
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_batch_validates_decimal_yes_price(self, mock_get_cursor):
+        """Test that float yes_price is rejected in batch."""
+        _mock_cursor_context(mock_get_cursor)
+
+        row = _default_trade_dict()
+        row["yes_price"] = 0.55  # float -- should raise
+
+        with pytest.raises(TypeError, match="yes_price must be Decimal"):
+            upsert_market_trades_batch([row])
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_batch_validates_decimal_no_price(self, mock_get_cursor):
+        """Test that float no_price is rejected in batch."""
+        _mock_cursor_context(mock_get_cursor)
+
+        row = _default_trade_dict()
+        row["no_price"] = 0.45  # float -- should raise
+
+        with pytest.raises(TypeError, match="no_price must be Decimal"):
+            upsert_market_trades_batch([row])
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_batch_validates_taker_side(self, mock_get_cursor):
+        """Test that invalid taker_side is rejected in batch."""
+        _mock_cursor_context(mock_get_cursor)
+
+        row = _default_trade_dict()
+        row["taker_side"] = "sell"
+
+        with pytest.raises(ValueError, match="taker_side must be one of"):
+            upsert_market_trades_batch([row])
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_batch_calls_executemany(self, mock_get_cursor):
+        """Test that batch insert uses executemany for efficiency."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        rows = [_default_trade_dict()]
+        upsert_market_trades_batch(rows)
+
+        mock_cursor.executemany.assert_called_once()
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_batch_sql_contains_on_conflict(self, mock_get_cursor):
+        """Test that batch SQL uses ON CONFLICT DO NOTHING."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        upsert_market_trades_batch([_default_trade_dict()])
+
+        call_args = mock_cursor.executemany.call_args
+        sql = call_args[0][0]
+        assert "ON CONFLICT" in sql
+        assert "DO NOTHING" in sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_batch_allows_none_optional_fields(self, mock_get_cursor):
+        """Test that batch rows without optional fields work fine."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        # Only required fields
+        row = _default_trade_dict()
+        upsert_market_trades_batch([row])
+
+        call_args = mock_cursor.executemany.call_args
+        params_list = call_args[0][1]
+        # yes_price (index 4), no_price (index 5), taker_side (index 6) should be None
+        assert params_list[0][4] is None
+        assert params_list[0][5] is None
+        assert params_list[0][6] is None
+
+
+# =============================================================================
+# GET MARKET TRADES TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetMarketTrades:
+    """Unit tests for get_market_trades function."""
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_returns_empty_list(self, mock_fetch_all):
+        """Test that empty result set returns empty list."""
+        mock_fetch_all.return_value = []
+
+        result = get_market_trades(42)
+
+        assert result == []
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_returns_list_of_dicts(self, mock_fetch_all):
+        """Test that result is a list of dicts."""
+        mock_fetch_all.return_value = [
+            {"id": 1, "market_internal_id": 42, "count": 10},
+            {"id": 2, "market_internal_id": 42, "count": 5},
+        ]
+
+        result = get_market_trades(42)
+
+        assert len(result) == 2
+        assert result[0]["id"] == 1
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_filters_by_since(self, mock_fetch_all):
+        """Test that since parameter adds trade_time filter."""
+        mock_fetch_all.return_value = []
+        cutoff = datetime(2026, 1, 15, 20, 0, 0, tzinfo=UTC)
+
+        get_market_trades(42, since=cutoff)
+
+        query = mock_fetch_all.call_args[0][0]
+        params = mock_fetch_all.call_args[0][1]
+        assert "trade_time >= %s" in query
+        assert cutoff in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_respects_limit(self, mock_fetch_all):
+        """Test that custom limit is applied."""
+        mock_fetch_all.return_value = []
+
+        get_market_trades(42, limit=25)
+
+        params = mock_fetch_all.call_args[0][1]
+        assert 25 in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_default_limit(self, mock_fetch_all):
+        """Test that default limit of 100 is applied."""
+        mock_fetch_all.return_value = []
+
+        get_market_trades(42)
+
+        params = mock_fetch_all.call_args[0][1]
+        assert 100 in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_orders_by_trade_time_desc(self, mock_fetch_all):
+        """Test that query orders by trade_time DESC, id DESC."""
+        mock_fetch_all.return_value = []
+
+        get_market_trades(42)
+
+        query = mock_fetch_all.call_args[0][0]
+        assert "ORDER BY trade_time DESC, id DESC" in query
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_filters_by_market_internal_id(self, mock_fetch_all):
+        """Test that query filters by market_internal_id."""
+        mock_fetch_all.return_value = []
+
+        get_market_trades(42)
+
+        query = mock_fetch_all.call_args[0][0]
+        params = mock_fetch_all.call_args[0][1]
+        assert "market_internal_id = %s" in query
+        assert 42 in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_no_since_omits_time_filter(self, mock_fetch_all):
+        """Test that omitting since does not add time filter."""
+        mock_fetch_all.return_value = []
+
+        get_market_trades(42)
+
+        query = mock_fetch_all.call_args[0][0]
+        assert "trade_time >= %s" not in query
+
+
+# =============================================================================
+# GET LATEST TRADE TIME TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetLatestTradeTime:
+    """Unit tests for get_latest_trade_time function."""
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_returns_datetime_from_latest(self, mock_fetch_one):
+        """Test that function returns trade_time from the most recent trade."""
+        expected = datetime(2026, 1, 15, 20, 30, 0, tzinfo=UTC)
+        mock_fetch_one.return_value = {"trade_time": expected}
+
+        result = get_latest_trade_time(42)
+
+        assert result == expected
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_returns_none_when_empty(self, mock_fetch_one):
+        """Test that function returns None when no trades exist for this market."""
+        mock_fetch_one.return_value = None
+
+        result = get_latest_trade_time(42)
+
+        assert result is None
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_queries_correct_market(self, mock_fetch_one):
+        """Test that query filters by the given market_internal_id."""
+        mock_fetch_one.return_value = None
+
+        get_latest_trade_time(99)
+
+        params = mock_fetch_one.call_args[0][1]
+        assert 99 in params
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_orders_by_trade_time_desc(self, mock_fetch_one):
+        """Test that query orders by trade_time DESC, id DESC with LIMIT 1."""
+        mock_fetch_one.return_value = None
+
+        get_latest_trade_time(42)
+
+        query = mock_fetch_one.call_args[0][0]
+        assert "ORDER BY trade_time DESC, id DESC" in query
+        assert "LIMIT 1" in query

--- a/tests/unit/database/test_temporal_alignment_crud.py
+++ b/tests/unit/database/test_temporal_alignment_crud.py
@@ -1,0 +1,427 @@
+"""
+Unit Tests for Temporal Alignment CRUD Operations (Migration 0027).
+
+Tests the temporal alignment functions: insert_temporal_alignment,
+insert_temporal_alignment_batch, and get_alignments_by_market. Validates
+Decimal enforcement, enum validation, optional parameter handling, batch
+operations, quality filtering, and ordering.
+
+Related:
+- Migration 0027: temporal_alignment
+- Issue #375: Add temporal alignment table linking Kalshi polls to ESPN game states
+- migration_batch_plan_v1.md: Migration 0027 spec
+
+Usage:
+    pytest tests/unit/database/test_temporal_alignment_crud.py -v
+    pytest tests/unit/database/test_temporal_alignment_crud.py -v -m unit
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from precog.database.crud_operations import (
+    _VALID_ALIGNMENT_QUALITIES,
+    get_alignments_by_market,
+    insert_temporal_alignment,
+    insert_temporal_alignment_batch,
+)
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+
+def _mock_cursor_context(mock_get_cursor, mock_cursor=None):
+    """Set up mock_get_cursor to return a context manager yielding mock_cursor."""
+    if mock_cursor is None:
+        mock_cursor = MagicMock()
+    mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_cursor
+
+
+def _default_alignment_kwargs():
+    """Return minimal valid kwargs for insert_temporal_alignment."""
+    return {
+        "market_id": 42,
+        "market_snapshot_id": 1001,
+        "game_state_id": 501,
+        "snapshot_time": datetime(2026, 1, 15, 20, 30, 0, tzinfo=UTC),
+        "game_state_time": datetime(2026, 1, 15, 20, 30, 5, tzinfo=UTC),
+        "time_delta_seconds": Decimal("5.00"),
+    }
+
+
+def _default_alignment_dict():
+    """Return minimal valid dict for insert_temporal_alignment_batch."""
+    return {
+        "market_id": 42,
+        "market_snapshot_id": 1001,
+        "game_state_id": 501,
+        "snapshot_time": datetime(2026, 1, 15, 20, 30, 0, tzinfo=UTC),
+        "game_state_time": datetime(2026, 1, 15, 20, 30, 5, tzinfo=UTC),
+        "time_delta_seconds": Decimal("5.00"),
+    }
+
+
+# =============================================================================
+# INSERT TEMPORAL ALIGNMENT TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestInsertTemporalAlignment:
+    """Unit tests for insert_temporal_alignment function."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_insert_returns_surrogate_id(self, mock_get_cursor):
+        """Test insert_temporal_alignment returns the integer surrogate PK."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        result = insert_temporal_alignment(**_default_alignment_kwargs())
+
+        assert result == 1
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_insert_validates_decimal_time_delta(self, mock_get_cursor):
+        """Test that float values are rejected for time_delta_seconds."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_alignment_kwargs()
+        kwargs["time_delta_seconds"] = 5.0  # float -- should raise
+
+        with pytest.raises(TypeError, match="time_delta_seconds must be Decimal"):
+            insert_temporal_alignment(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_insert_validates_decimal_yes_ask_price(self, mock_get_cursor):
+        """Test that float values are rejected for yes_ask_price."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_alignment_kwargs()
+        kwargs["yes_ask_price"] = 0.55  # float -- should raise
+
+        with pytest.raises(TypeError, match="yes_ask_price must be Decimal"):
+            insert_temporal_alignment(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_insert_validates_decimal_no_ask_price(self, mock_get_cursor):
+        """Test that float values are rejected for no_ask_price."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_alignment_kwargs()
+        kwargs["no_ask_price"] = 0.45  # float -- should raise
+
+        with pytest.raises(TypeError, match="no_ask_price must be Decimal"):
+            insert_temporal_alignment(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_insert_validates_decimal_spread(self, mock_get_cursor):
+        """Test that float values are rejected for spread."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_alignment_kwargs()
+        kwargs["spread"] = 0.10  # float -- should raise
+
+        with pytest.raises(TypeError, match="spread must be Decimal"):
+            insert_temporal_alignment(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_insert_validates_alignment_quality(self, mock_get_cursor):
+        """Test that invalid alignment_quality values are rejected."""
+        _mock_cursor_context(mock_get_cursor)
+
+        kwargs = _default_alignment_kwargs()
+        kwargs["alignment_quality"] = "excellent"
+
+        with pytest.raises(ValueError, match="alignment_quality must be one of"):
+            insert_temporal_alignment(**kwargs)
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_insert_allows_none_optional_fields(self, mock_get_cursor):
+        """Test that all optional fields accept None (default behavior)."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 2}
+
+        # Only required fields -- all optional fields default to None
+        result = insert_temporal_alignment(**_default_alignment_kwargs())
+
+        assert result == 2
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_insert_with_all_optional_fields(self, mock_get_cursor):
+        """Test insert_temporal_alignment with every optional parameter provided."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 99}
+
+        result = insert_temporal_alignment(
+            market_id=42,
+            market_snapshot_id=1001,
+            game_state_id=501,
+            snapshot_time=datetime(2026, 1, 15, 20, 30, 0, tzinfo=UTC),
+            game_state_time=datetime(2026, 1, 15, 20, 30, 5, tzinfo=UTC),
+            time_delta_seconds=Decimal("5.00"),
+            alignment_quality="exact",
+            yes_ask_price=Decimal("0.5500"),
+            no_ask_price=Decimal("0.4500"),
+            spread=Decimal("0.1000"),
+            volume=150,
+            game_status="in_progress",
+            home_score=21,
+            away_score=14,
+            period="3rd",
+            clock="08:42",
+        )
+
+        assert result == 99
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_insert_accepts_all_valid_alignment_qualities(self, mock_get_cursor):
+        """Test that every valid alignment_quality is accepted."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        for quality in _VALID_ALIGNMENT_QUALITIES:
+            kwargs = _default_alignment_kwargs()
+            kwargs["alignment_quality"] = quality
+            result = insert_temporal_alignment(**kwargs)
+            assert result == 1
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_insert_default_alignment_quality_is_good(self, mock_get_cursor):
+        """Test that default alignment_quality is 'good' when not specified."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 5}
+
+        kwargs = _default_alignment_kwargs()
+        # Do NOT set alignment_quality -- should default to 'good'
+        insert_temporal_alignment(**kwargs)
+
+        # Verify the SQL params include 'good' in the alignment_quality position
+        call_args = mock_cursor.execute.call_args
+        params = call_args[0][1]
+        # alignment_quality is the 7th param (index 6)
+        assert params[6] == "good"
+
+
+# =============================================================================
+# INSERT TEMPORAL ALIGNMENT BATCH TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestInsertTemporalAlignmentBatch:
+    """Unit tests for insert_temporal_alignment_batch function."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_batch_insert_returns_count(self, mock_get_cursor):
+        """Test batch insert returns count of rows inserted."""
+        _mock_cursor_context(mock_get_cursor)
+
+        rows = [_default_alignment_dict(), _default_alignment_dict()]
+        rows[1]["market_snapshot_id"] = 1002
+        rows[1]["game_state_id"] = 502
+
+        result = insert_temporal_alignment_batch(rows)
+
+        assert result == 2
+
+    def test_batch_insert_empty_list_returns_zero(self):
+        """Test that empty list returns 0 without DB interaction."""
+        result = insert_temporal_alignment_batch([])
+
+        assert result == 0
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_batch_insert_validates_decimal_time_delta(self, mock_get_cursor):
+        """Test that float time_delta_seconds is rejected in batch."""
+        _mock_cursor_context(mock_get_cursor)
+
+        row = _default_alignment_dict()
+        row["time_delta_seconds"] = 5.0  # float -- should raise
+
+        with pytest.raises(TypeError, match="time_delta_seconds must be Decimal"):
+            insert_temporal_alignment_batch([row])
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_batch_insert_validates_alignment_quality(self, mock_get_cursor):
+        """Test that invalid alignment_quality is rejected in batch."""
+        _mock_cursor_context(mock_get_cursor)
+
+        row = _default_alignment_dict()
+        row["alignment_quality"] = "perfect"
+
+        with pytest.raises(ValueError, match="alignment_quality must be one of"):
+            insert_temporal_alignment_batch([row])
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_batch_insert_defaults_quality_to_good(self, mock_get_cursor):
+        """Test that batch rows without alignment_quality default to 'good'."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+
+        row = _default_alignment_dict()
+        # alignment_quality NOT set -- should default to 'good'
+
+        insert_temporal_alignment_batch([row])
+
+        call_args = mock_cursor.executemany.call_args
+        params_list = call_args[0][1]
+        # alignment_quality is the 7th param (index 6)
+        assert params_list[0][6] == "good"
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_batch_insert_validates_decimal_yes_ask_price(self, mock_get_cursor):
+        """Test that float yes_ask_price is rejected in batch."""
+        _mock_cursor_context(mock_get_cursor)
+
+        row = _default_alignment_dict()
+        row["yes_ask_price"] = 0.55  # float -- should raise
+
+        with pytest.raises(TypeError, match="yes_ask_price must be Decimal"):
+            insert_temporal_alignment_batch([row])
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_batch_insert_calls_executemany(self, mock_get_cursor):
+        """Test that batch insert uses executemany for efficiency."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+
+        rows = [_default_alignment_dict()]
+        insert_temporal_alignment_batch(rows)
+
+        mock_cursor.executemany.assert_called_once()
+
+
+# =============================================================================
+# GET ALIGNMENTS BY MARKET TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetAlignmentsByMarket:
+    """Unit tests for get_alignments_by_market function."""
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_returns_empty_list(self, mock_fetch_all):
+        """Test that empty result set returns empty list."""
+        mock_fetch_all.return_value = []
+
+        result = get_alignments_by_market(42)
+
+        assert result == []
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_returns_list_of_dicts(self, mock_fetch_all):
+        """Test that result is a list of dicts."""
+        mock_fetch_all.return_value = [
+            {"id": 1, "market_id": 42, "alignment_quality": "good"},
+            {"id": 2, "market_id": 42, "alignment_quality": "exact"},
+        ]
+
+        result = get_alignments_by_market(42)
+
+        assert len(result) == 2
+        assert result[0]["id"] == 1
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_filters_by_min_quality(self, mock_fetch_all):
+        """Test filtering by min_quality includes correct quality levels."""
+        mock_fetch_all.return_value = []
+
+        get_alignments_by_market(42, min_quality="good")
+
+        query = mock_fetch_all.call_args[0][0]
+        params = mock_fetch_all.call_args[0][1]
+        assert "alignment_quality IN" in query
+        # 'good' and 'exact' should be in params (good or better)
+        assert "good" in params
+        assert "exact" in params
+        # 'stale', 'poor', 'fair' should NOT be in params
+        assert "stale" not in params
+        assert "poor" not in params
+        assert "fair" not in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_min_quality_stale_includes_all(self, mock_fetch_all):
+        """Test that min_quality='stale' includes all quality levels."""
+        mock_fetch_all.return_value = []
+
+        get_alignments_by_market(42, min_quality="stale")
+
+        params = mock_fetch_all.call_args[0][1]
+        for quality in _VALID_ALIGNMENT_QUALITIES:
+            assert quality in params
+
+    def test_validates_invalid_min_quality(self):
+        """Test that invalid min_quality is rejected."""
+        with pytest.raises(ValueError, match="min_quality must be one of"):
+            get_alignments_by_market(42, min_quality="excellent")
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_respects_limit(self, mock_fetch_all):
+        """Test that custom limit is applied."""
+        mock_fetch_all.return_value = []
+
+        get_alignments_by_market(42, limit=25)
+
+        params = mock_fetch_all.call_args[0][1]
+        assert 25 in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_default_limit(self, mock_fetch_all):
+        """Test that default limit of 100 is applied."""
+        mock_fetch_all.return_value = []
+
+        get_alignments_by_market(42)
+
+        params = mock_fetch_all.call_args[0][1]
+        assert 100 in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_orders_by_snapshot_time_desc(self, mock_fetch_all):
+        """Test that query orders by snapshot_time DESC, id DESC."""
+        mock_fetch_all.return_value = []
+
+        get_alignments_by_market(42)
+
+        query = mock_fetch_all.call_args[0][0]
+        assert "ORDER BY snapshot_time DESC, id DESC" in query
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_filters_by_market_id(self, mock_fetch_all):
+        """Test that query filters by market_id."""
+        mock_fetch_all.return_value = []
+
+        get_alignments_by_market(42)
+
+        query = mock_fetch_all.call_args[0][0]
+        params = mock_fetch_all.call_args[0][1]
+        assert "market_id = %s" in query
+        assert 42 in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_min_quality_fair_includes_fair_good_exact(self, mock_fetch_all):
+        """Test that min_quality='fair' includes fair, good, and exact."""
+        mock_fetch_all.return_value = []
+
+        get_alignments_by_market(42, min_quality="fair")
+
+        params = mock_fetch_all.call_args[0][1]
+        assert "fair" in params
+        assert "good" in params
+        assert "exact" in params
+        assert "stale" not in params
+        assert "poor" not in params
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_no_min_quality_omits_quality_filter(self, mock_fetch_all):
+        """Test that omitting min_quality does not add quality filter."""
+        mock_fetch_all.return_value = []
+
+        get_alignments_by_market(42)
+
+        query = mock_fetch_all.call_args[0][0]
+        assert "alignment_quality IN" not in query


### PR DESCRIPTION
## Summary
- **Migration 0026 (account_ledger):** Append-only transaction log tracking WHY balance changed (deposits, withdrawals, trade P&L, fees, rebates). Complements account_balance SCD snapshots. Running balance on every row for O(1) lookup. Glokta review incorporated: app-level guards, ORDER BY tiebreaker, enum validation in queries, redundant index removed.
- **Migration 0027 (temporal_alignment):** Links market_snapshots to game_states by timestamp proximity for Phase 4 backtesting. Denormalizes key fields to avoid joins. Quality rating categorizes time delta. **Design note:** future alignment algorithm should use SCD `row_start_ts`/`row_end_ts` validity windows, not raw time deltas, to properly handle event-driven records.
- **Migration 0028 (market_trades):** Public Kalshi trade tape for ML signal data (volume, price discovery, liquidity). Idempotent upserts via ON CONFLICT DO NOTHING. Separate from portfolio trades — this captures ALL public market activity.
- **CRUD:** 10 new functions + 4 constants. 83 new unit tests (25 + 28 + 30).

Closes #369, closes #375

## Test plan
- [x] 83 new unit tests all passing
- [x] 701 database unit tests passing (zero regressions)
- [x] 2066 unit tests passing
- [x] 990 integration/e2e passing
- [x] 1057 stress/chaos/race passing
- [x] Ruff lint + format clean
- [x] Mypy clean
- [x] Pre-commit + pre-push hooks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)