### PR TITLE
feat: Migration 0036 — PK naming consistency

### DIFF
--- a/src/precog/database/alembic/versions/0036_pk_naming_consistency.py
+++ b/src/precog/database/alembic/versions/0036_pk_naming_consistency.py
@@ -1,0 +1,44 @@
+"""Rename inconsistent PKs to `id` for naming consistency.
+
+All data tables should use `id` as their surrogate PK column name,
+matching the pattern established in migrations 0019-0022 (series, events,
+markets all use `id`).
+
+Tables affected:
+    - trades: trade_id -> id
+    - settlements: settlement_id -> id
+    - account_balance: balance_id -> id
+
+No FK references point to these columns, so the rename is safe.
+
+Revision ID: 0036
+Revises: 0035
+Create Date: 2026-03-21
+
+Related:
+    - migration_batch_plan_v1.md: PK naming consistency spec
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0036"
+down_revision: str = "0035"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Rename trade_id, settlement_id, balance_id to id."""
+    op.execute("ALTER TABLE trades RENAME COLUMN trade_id TO id")
+    op.execute("ALTER TABLE settlements RENAME COLUMN settlement_id TO id")
+    op.execute("ALTER TABLE account_balance RENAME COLUMN balance_id TO id")
+
+
+def downgrade() -> None:
+    """Restore original PK column names."""
+    op.execute("ALTER TABLE trades RENAME COLUMN id TO trade_id")
+    op.execute("ALTER TABLE settlements RENAME COLUMN id TO settlement_id")
+    op.execute("ALTER TABLE account_balance RENAME COLUMN id TO balance_id")

--- a/src/precog/database/crud_operations.py
+++ b/src/precog/database/crud_operations.py
@@ -2121,7 +2121,7 @@ def create_trade(
         execution_environment: 'live', 'paper', or 'backtest' (default 'live')
 
     Returns:
-        trade_id of newly created trade
+        id of newly created trade
 
     Educational Note:
         Migration 0025 Redesign:
@@ -2163,7 +2163,7 @@ def create_trade(
             execution_environment
         )
         VALUES (%s, %s, %s, %s, %s, %s, %s, %s, NOW(), %s, %s, %s, %s)
-        RETURNING trade_id
+        RETURNING id
     """
 
     params = (
@@ -2184,7 +2184,7 @@ def create_trade(
     with get_cursor(commit=True) as cur:
         cur.execute(query, params)
         result = cur.fetchone()
-        return cast("int", result["trade_id"])
+        return cast("int", result["id"])
 
 
 def get_trades_by_market(
@@ -2304,7 +2304,7 @@ def create_account_balance(
         currency: Currency code (default: "USD")
 
     Returns:
-        balance_id of newly created record
+        id of newly created record
 
     Raises:
         ValueError: If balance is float (not Decimal)
@@ -2351,7 +2351,7 @@ def create_account_balance(
             platform_id, balance, currency, row_current_ind, created_at
         )
         VALUES (%s, %s, %s, TRUE, NOW())
-        RETURNING balance_id
+        RETURNING id
     """
 
     params = (platform_id, balance, currency)
@@ -2359,7 +2359,7 @@ def create_account_balance(
     with get_cursor(commit=True) as cur:
         cur.execute(query, params)
         result = cur.fetchone()
-        return result["balance_id"] if result else None
+        return result["id"] if result else None
 
 
 def update_account_balance_with_versioning(
@@ -2381,7 +2381,7 @@ def update_account_balance_with_versioning(
         currency: Currency code (default: "USD")
 
     Returns:
-        balance_id of newly created record
+        id of newly created record
 
     Raises:
         ValueError: If new_balance is float (not Decimal)
@@ -2444,7 +2444,7 @@ def update_account_balance_with_versioning(
             platform_id, balance, currency, row_current_ind, created_at
         )
         VALUES (%s, %s, %s, TRUE, NOW())
-        RETURNING balance_id
+        RETURNING id
     """
 
     with get_cursor(commit=True) as cur:
@@ -2454,7 +2454,7 @@ def update_account_balance_with_versioning(
         # Insert new balance
         cur.execute(insert_query, (platform_id, new_balance, currency))
         result = cur.fetchone()
-        return result["balance_id"] if result else None
+        return result["id"] if result else None
 
 
 # =============================================================================
@@ -2481,7 +2481,7 @@ def create_settlement(
         payout: Payout amount as DECIMAL(10,4)
 
     Returns:
-        settlement_id of newly created record
+        id of newly created record
 
     Raises:
         ValueError: If payout is float (not Decimal)
@@ -2528,7 +2528,7 @@ def create_settlement(
             market_internal_id, platform_id, outcome, payout, created_at
         )
         VALUES (%s, %s, %s, %s, NOW())
-        RETURNING settlement_id
+        RETURNING id
     """
 
     params = (market_internal_id, platform_id, outcome, payout)
@@ -2536,7 +2536,7 @@ def create_settlement(
     with get_cursor(commit=True) as cur:
         cur.execute(query, params)
         result = cur.fetchone()
-        return result["settlement_id"] if result else None
+        return result["id"] if result else None
 
 
 # =============================================================================
@@ -2976,7 +2976,7 @@ def get_trade_by_id(trade_id: int) -> dict[str, Any] | None:
         LEFT JOIN orders o ON t.order_id = o.id
         LEFT JOIN strategies s ON o.strategy_id = s.strategy_id
         LEFT JOIN probability_models pm ON o.model_id = pm.model_id
-        WHERE t.trade_id = %s
+        WHERE t.id = %s
     """
     return fetch_one(query, (trade_id,))
 

--- a/tests/fixtures/testcontainers_fixtures.py
+++ b/tests/fixtures/testcontainers_fixtures.py
@@ -596,7 +596,7 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
     -- trades table (migration 0025: attribution columns removed, order_id FK added)
     -- Trades are pure fill/execution records. Attribution lives on orders.
     CREATE TABLE IF NOT EXISTS trades (
-        trade_id SERIAL PRIMARY KEY,
+        id SERIAL PRIMARY KEY,
         market_internal_id INTEGER NOT NULL REFERENCES markets(id) ON DELETE CASCADE,
         platform_id VARCHAR(50) REFERENCES platforms(platform_id) ON DELETE CASCADE,
         order_id INTEGER REFERENCES orders(id) ON DELETE SET NULL,
@@ -623,7 +623,7 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
     CREATE INDEX IF NOT EXISTS idx_trades_created ON trades(created_at);
 
     CREATE TABLE IF NOT EXISTS settlements (
-        settlement_id SERIAL PRIMARY KEY,
+        id SERIAL PRIMARY KEY,
         market_internal_id INTEGER NOT NULL REFERENCES markets(id) ON DELETE CASCADE,
         platform_id VARCHAR(50) REFERENCES platforms(platform_id) ON DELETE CASCADE,
         outcome VARCHAR(50) NOT NULL,
@@ -660,7 +660,7 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
     CREATE INDEX IF NOT EXISTS idx_exit_attempts_position ON exit_attempts(position_internal_id);
 
     CREATE TABLE IF NOT EXISTS account_balance (
-        balance_id SERIAL PRIMARY KEY,
+        id SERIAL PRIMARY KEY,
         platform_id VARCHAR(50) REFERENCES platforms(platform_id) ON DELETE CASCADE,
         balance DECIMAL(10,4) NOT NULL CHECK (balance >= 0.0000),
         currency VARCHAR(10) DEFAULT 'USD',

--- a/tests/integration/cli/_deprecated_test_cli_database_integration.py
+++ b/tests/integration/cli/_deprecated_test_cli_database_integration.py
@@ -166,7 +166,7 @@ def test_fetch_balance_saves_to_database(
     with get_cursor() as cur:
         cur.execute(
             """
-            SELECT balance_id, balance, currency, row_current_ind
+            SELECT id, balance, currency, row_current_ind
             FROM account_balance
             WHERE platform_id = 'kalshi' AND row_current_ind = TRUE
         """
@@ -222,10 +222,10 @@ def test_fetch_balance_updates_with_scd_type2(
     with get_cursor() as cur:
         cur.execute(
             """
-            SELECT balance_id, balance, row_current_ind
+            SELECT id, balance, row_current_ind
             FROM account_balance
             WHERE platform_id = 'kalshi'
-            ORDER BY balance_id
+            ORDER BY id
         """
         )
         records = cur.fetchall()
@@ -236,7 +236,7 @@ def test_fetch_balance_updates_with_scd_type2(
         assert records[0]["row_current_ind"] is True
 
         # Save balance_id for later verification
-        first_balance_id = records[0]["balance_id"]
+        first_balance_id = records[0]["id"]
 
     # SECOND FETCH: balance = $1500.00 (150000 cents -> $1500.00 after conversion)
     with my_vcr.use_cassette("cli/balance_1500.yaml"):
@@ -252,10 +252,10 @@ def test_fetch_balance_updates_with_scd_type2(
     with get_cursor() as cur:
         cur.execute(
             """
-            SELECT balance_id, balance, row_current_ind
+            SELECT id, balance, row_current_ind
             FROM account_balance
             WHERE platform_id = 'kalshi'
-            ORDER BY balance_id
+            ORDER BY id
         """
         )
         records = cur.fetchall()
@@ -263,7 +263,7 @@ def test_fetch_balance_updates_with_scd_type2(
         assert len(records) == 2, f"Expected 2 balance records (SCD Type 2), got {len(records)}"
 
         # First record should be marked as NOT current
-        assert records[0]["balance_id"] == first_balance_id
+        assert records[0]["id"] == first_balance_id
         # Client converts cents to dollars: 100000 cents = $1000
         assert records[0]["balance"] == Decimal("1000")
         assert records[0]["row_current_ind"] is False, (

--- a/tests/test_attribution_comprehensive.py
+++ b/tests/test_attribution_comprehensive.py
@@ -549,7 +549,7 @@ def test_chaos_trade_with_null_attribution_fields(
 
     # Verify: Trade created successfully
     assert trade is not None
-    assert trade["trade_id"] == trade_id
+    assert trade["id"] == trade_id
 
     # Verify: Attribution fields are NULL (except model_id which is required)
     assert trade["calculated_probability"] is None

--- a/tests/test_crud_operations.py
+++ b/tests/test_crud_operations.py
@@ -415,8 +415,8 @@ def test_get_trades_by_market(db_pool, clean_test_data, sample_market_data, samp
     trades = get_trades_by_market(market_id, limit=10)
 
     assert len(trades) >= 2
-    assert any(t["trade_id"] == trade_id1 for t in trades)
-    assert any(t["trade_id"] == trade_id2 for t in trades)
+    assert any(t["id"] == trade_id1 for t in trades)
+    assert any(t["id"] == trade_id2 for t in trades)
 
 
 @pytest.mark.integration
@@ -430,7 +430,7 @@ def test_get_recent_trades(db_pool, clean_test_data, sample_market_data, sample_
 
     # Should include our test trade
     assert len(trades) > 0
-    assert any(t["trade_id"] == trade_id for t in trades)
+    assert any(t["id"] == trade_id for t in trades)
 
 
 @pytest.mark.integration
@@ -574,7 +574,7 @@ def test_create_account_balance_with_decimal(db_pool, clean_test_data):
     # Verify: Check balance was created correctly
     with get_cursor() as cur:
         cur.execute(
-            "SELECT * FROM account_balance WHERE balance_id = %s AND row_current_ind = TRUE",
+            "SELECT * FROM account_balance WHERE id = %s AND row_current_ind = TRUE",
             (balance_id,),
         )
         result = cur.fetchone()
@@ -799,7 +799,7 @@ def test_get_recent_trades_with_strategy_filter(
 
     # Should only return trade1
     assert len(trades) == 1
-    assert trades[0]["trade_id"] == trade1
+    assert trades[0]["id"] == trade1
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Renames `trade_id`, `settlement_id`, `balance_id` to `id` on three leaf tables (trades, settlements, account_balance)
- Completes the surrogate PK naming convention established in migrations 0019-0022
- Updates all CRUD operations, test fixtures, and test assertions to use the new column name
- No FK references point to these columns — safe rename with full downgrade support

## Test plan
- [x] Unit tests pass (2,142)
- [x] Integration + E2E tests pass (980)
- [x] Stress + Chaos + Race tests pass (1,057)
- [x] Blast radius search: zero remaining references to old column names in non-archived code
- [x] Reviewer (Spock) caught 1 missed reference at line 169 of deprecated CLI test — fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)