### PR TITLE
feat: Sport-aware SCD change detection for game_states (#397)

### DIFF
--- a/src/precog/database/crud_operations.py
+++ b/src/precog/database/crud_operations.py
@@ -3677,7 +3677,7 @@ def get_current_game_state(espn_event_id: str) -> dict[str, Any] | None:
 # Reference: ESPNSituationData in api_connectors/espn_client.py
 TRACKED_SITUATION_KEYS: dict[str, list[str]] = {
     "football": ["possession", "down", "distance", "yard_line", "is_red_zone"],
-    "basketball": ["possession", "bonus", "possession_arrow"],
+    "basketball": ["possession", "bonus", "possession_arrow", "home_fouls", "away_fouls"],
     "hockey": ["home_powerplay", "away_powerplay"],
 }
 

--- a/tests/chaos/test_crud_operations_chaos.py
+++ b/tests/chaos/test_crud_operations_chaos.py
@@ -846,12 +846,13 @@ class TestGameStateChangedChaos:
         assert result is False
 
     def test_situation_with_extra_fields_ignored(self):
-        """Extra fields in situation dict should not affect comparison.
+        """Extra fields in situation dict should not affect comparison when league is known.
 
         Educational Note:
-            game_state_changed() compares specific situation fields. Fields
-            not in the comparison list should be ignored. This ensures
-            backward compatibility when ESPN adds new fields.
+            game_state_changed() compares sport-specific situation fields when
+            league is provided. Fields not in the tracked list should be ignored.
+            This ensures backward compatibility when ESPN adds new fields.
+            When league is None/unknown, ALL fields are compared (safe fallback).
         """
         from precog.database.crud_operations import game_state_changed
 
@@ -863,7 +864,7 @@ class TestGameStateChangedChaos:
             "situation": {"down": 2, "distance": 5, "possession": "home"},
         }
 
-        # Same core fields but with extra fields
+        # Same core fields but with extra fields — league provided so only tracked keys matter
         result = game_state_changed(
             current=current,
             home_score=14,
@@ -877,6 +878,7 @@ class TestGameStateChangedChaos:
                 "extra_field": "should_be_ignored",
                 "another_extra": 12345,
             },
+            league="nfl",
         )
 
         # Same core values, extra fields ignored - no change

--- a/tests/unit/database/test_crud_operations_unit.py
+++ b/tests/unit/database/test_crud_operations_unit.py
@@ -1228,8 +1228,8 @@ class TestGameStateChangedSportAwareUnit:
 
     # --- Basketball ---
 
-    def test_basketball_foul_change_does_not_trigger(self):
-        """Basketball foul count change does NOT trigger new row."""
+    def test_basketball_foul_change_triggers(self):
+        """Basketball foul count change triggers new row (useful for model training)."""
         current = {
             "home_score": 55,
             "away_score": 52,
@@ -1246,7 +1246,7 @@ class TestGameStateChangedSportAwareUnit:
             situation={"possession": "home", "home_fouls": 4, "away_fouls": 2, "bonus": None},
             league="nba",
         )
-        assert result is False
+        assert result is True
 
     def test_basketball_bonus_change_triggers(self):
         """Basketball bonus status change DOES trigger new row."""
@@ -1315,16 +1315,16 @@ class TestGameStateChangedSportAwareUnit:
             "away_score": 28,
             "period": 2,
             "game_status": "in_progress",
-            "situation": {"possession": "home", "home_fouls": 2},
+            "situation": {"possession": "home", "home_timeouts": 3},
         }
-        # Only fouls changed - should NOT trigger
+        # Only timeouts changed - should NOT trigger (timeouts are noise)
         result = game_state_changed(
             current=current,
             home_score=30,
             away_score=28,
             period=2,
             game_status="in_progress",
-            situation={"possession": "home", "home_fouls": 3},
+            situation={"possession": "home", "home_timeouts": 2},
             league="wnba",
         )
         assert result is False
@@ -1491,16 +1491,16 @@ class TestGameStateChangedSportAwareUnit:
             "away_score": 52,
             "period": 3,
             "game_status": "in_progress",
-            "situation": {"possession": "home", "home_fouls": 3},
+            "situation": {"possession": "home", "home_timeouts": 4},
         }
-        # Only fouls changed with uppercase league - should NOT trigger
+        # Only timeouts changed with uppercase league - should NOT trigger
         result = game_state_changed(
             current=current,
             home_score=55,
             away_score=52,
             period=3,
             game_status="in_progress",
-            situation={"possession": "home", "home_fouls": 5},
+            situation={"possession": "home", "home_timeouts": 3},
             league="NBA",
         )
         assert result is False


### PR DESCRIPTION
## Summary
- Makes `game_state_changed()` sport-aware — only compares ML-relevant situation fields per sport
- Football: possession, down, distance, yard_line, is_red_zone (unchanged)
- Basketball: possession, bonus, possession_arrow, home_fouls, away_fouls (NEW — fouls tracked for model training)
- Hockey: home_powerplay, away_powerplay (NEW)
- Unknown/missing league falls back to comparing ALL situation keys (safe default)
- Passes `league` through from `upsert_game_state()` to `game_state_changed()`

Closes #397

## Test plan
- [x] 17 new unit tests covering all sports + fallback + edge cases
- [x] Unit tests pass (2,159)
- [x] Integration + E2E pass (980)
- [x] Stress + Chaos + Race pass (1,057) — includes fix for chaos test that assumed old behavior
- [x] Reviewer (Spock): APPROVE — tracked key selections validated against ESPNSituationData TypedDict
- [x] QA (Ripley): APPROVE — verified full poller→upsert→change_detection path is wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)