### PR TITLE
refactor: Rename markets.league to markets.subcategory (#460 Phase A)

### DIFF
--- a/src/precog/database/alembic/versions/0037_rename_markets_league_to_subcategory.py
+++ b/src/precog/database/alembic/versions/0037_rename_markets_league_to_subcategory.py
@@ -1,0 +1,141 @@
+"""Rename markets.league to markets.subcategory for naming consistency.
+
+The markets.league column stores the Kalshi API subcategory value (e.g., "nfl",
+"nba"). This is the same concept as events.subcategory. Renaming makes the
+semantic relationship explicit and eliminates the confusing terminology overlap
+with game_states.league / teams.league (which are different: they store the
+league on the games side of the schema).
+
+Naming convention after this migration:
+- Markets side: subcategory (Kalshi's term, e.g., "nfl")
+- Games side: league (ESPN's term, e.g., "nfl") + sport (e.g., "football")
+
+Steps:
+    1. RENAME COLUMN markets.league -> subcategory
+    2. RENAME INDEX idx_markets_league -> idx_markets_subcategory
+    3. RECREATE current_markets view with new column name
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-03-22
+
+Related:
+- Issue #460: Category/subcategory naming consistency
+- Migration 0033: Original column creation (as 'league')
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0037"
+down_revision: str = "0036"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Rename markets.league to markets.subcategory."""
+    # -- Step 1: Rename column --
+    op.execute("ALTER TABLE markets RENAME COLUMN league TO subcategory")
+
+    # -- Step 2: Rename index --
+    op.execute("ALTER INDEX idx_markets_league RENAME TO idx_markets_subcategory")
+
+    # -- Step 3: Recreate current_markets view --
+    # Must reflect the renamed column. View definition matches migration 0036
+    # (which was the last to touch this view), with league -> subcategory.
+    op.execute("DROP VIEW IF EXISTS current_markets")
+    op.execute("""
+        CREATE OR REPLACE VIEW current_markets AS
+        SELECT
+            m.id,
+            m.platform_id,
+            m.event_internal_id,
+            m.external_id,
+            m.ticker,
+            m.title,
+            m.subtitle,
+            m.market_type,
+            m.status,
+            m.settlement_value,
+            m.open_time,
+            m.close_time,
+            m.expiration_time,
+            m.outcome_label,
+            m.subcategory,
+            m.bracket_count,
+            m.source_url,
+            m.metadata,
+            m.created_at,
+            m.updated_at,
+            ms.yes_ask_price,
+            ms.no_ask_price,
+            ms.yes_bid_price,
+            ms.no_bid_price,
+            ms.last_price,
+            ms.spread,
+            ms.volume,
+            ms.open_interest,
+            ms.liquidity,
+            ms.row_start_ts,
+            ms.row_end_ts,
+            ms.row_current_ind
+        FROM markets m
+        LEFT JOIN market_snapshots ms
+            ON ms.market_id = m.id
+            AND ms.row_current_ind = TRUE
+    """)
+
+
+def downgrade() -> None:
+    """Revert: rename markets.subcategory back to markets.league."""
+    # -- Step 1: Rename column back --
+    op.execute("ALTER TABLE markets RENAME COLUMN subcategory TO league")
+
+    # -- Step 2: Rename index back --
+    op.execute("ALTER INDEX idx_markets_subcategory RENAME TO idx_markets_league")
+
+    # -- Step 3: Recreate current_markets view --
+    op.execute("DROP VIEW IF EXISTS current_markets")
+    op.execute("""
+        CREATE OR REPLACE VIEW current_markets AS
+        SELECT
+            m.id,
+            m.platform_id,
+            m.event_internal_id,
+            m.external_id,
+            m.ticker,
+            m.title,
+            m.subtitle,
+            m.market_type,
+            m.status,
+            m.settlement_value,
+            m.open_time,
+            m.close_time,
+            m.expiration_time,
+            m.outcome_label,
+            m.league,
+            m.bracket_count,
+            m.source_url,
+            m.metadata,
+            m.created_at,
+            m.updated_at,
+            ms.yes_ask_price,
+            ms.no_ask_price,
+            ms.yes_bid_price,
+            ms.no_bid_price,
+            ms.last_price,
+            ms.spread,
+            ms.volume,
+            ms.open_interest,
+            ms.liquidity,
+            ms.row_start_ts,
+            ms.row_end_ts,
+            ms.row_current_ind
+        FROM markets m
+        LEFT JOIN market_snapshots ms
+            ON ms.market_id = m.id
+            AND ms.row_current_ind = TRUE
+    """)

--- a/src/precog/database/crud_operations.py
+++ b/src/precog/database/crud_operations.py
@@ -1111,7 +1111,7 @@ def create_market(
     close_time: str | None = None,
     expiration_time: str | None = None,
     outcome_label: str | None = None,
-    league: str | None = None,
+    subcategory: str | None = None,
     bracket_count: int | None = None,
     source_url: str | None = None,
 ) -> int:
@@ -1142,7 +1142,7 @@ def create_market(
         close_time: When the market closes for trading (ISO 8601 string)
         expiration_time: When the market expires/settles (ISO 8601 string)
         outcome_label: Parsed outcome from ticker (e.g., "YES", "Over 42.5")
-        league: Sport league (e.g., "NFL", "NCAAF")
+        subcategory: Sport subcategory (e.g., "nfl", "nba") — matches events.subcategory
         bracket_count: Number of markets in the parent event bracket
         source_url: URL to the market on the platform
 
@@ -1171,6 +1171,7 @@ def create_market(
         - Migration 0021: markets split into dimension + market_snapshots fact
         - Migration 0022: market_id VARCHAR dropped, downstream uses integer FK
         - Migration 0033: enrichment columns added to dimension table
+        - Migration 0037: league renamed to subcategory
     """
     # Runtime type validation (enforces Decimal precision)
     yes_ask_price = validate_decimal(yes_ask_price, "yes_ask_price")
@@ -1182,13 +1183,14 @@ def create_market(
         # Step 1: Insert dimension row
         # Migration 0022: market_id VARCHAR dropped — no longer inserted.
         # Migration 0033: enrichment columns added (subtitle, timestamps, etc.)
+        # Migration 0037: league renamed to subcategory
         cur.execute(
             """
             INSERT INTO markets (
                 platform_id, event_internal_id, external_id,
                 ticker, title, market_type, status,
                 subtitle, open_time, close_time, expiration_time,
-                outcome_label, league, bracket_count, source_url,
+                outcome_label, subcategory, bracket_count, source_url,
                 metadata, updated_at
             )
             VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
@@ -1207,7 +1209,7 @@ def create_market(
                 close_time,
                 expiration_time,
                 outcome_label,
-                league,
+                subcategory,
                 bracket_count,
                 source_url,
                 json.dumps(metadata) if metadata else None,
@@ -1281,7 +1283,7 @@ def get_current_market(ticker: str) -> dict[str, Any] | None:
             m.close_time,
             m.expiration_time,
             m.outcome_label,
-            m.league,
+            m.subcategory,
             m.bracket_count,
             m.source_url,
             m.metadata,
@@ -1348,7 +1350,7 @@ def update_market_with_versioning(
     close_time: str | None = None,
     expiration_time: str | None = None,
     outcome_label: str | None = None,
-    league: str | None = None,
+    subcategory: str | None = None,
     bracket_count: int | None = None,
     source_url: str | None = None,
 ) -> int:
@@ -1376,7 +1378,7 @@ def update_market_with_versioning(
         close_time: When market closes for trading (optional, ISO 8601)
         expiration_time: When market expires/settles (optional, ISO 8601)
         outcome_label: Parsed outcome from ticker (optional)
-        league: Sport league (optional)
+        subcategory: Sport subcategory (optional) — matches events.subcategory
         bracket_count: Number of markets in parent event bracket (optional)
         source_url: URL to the market on the platform (optional)
 
@@ -1393,6 +1395,7 @@ def update_market_with_versioning(
     Reference:
         - Migration 0021: markets dimension + market_snapshots fact
         - Migration 0033: enrichment columns on dimension table
+        - Migration 0037: league renamed to subcategory
     """
     # Runtime type validation (enforces Decimal precision)
     if yes_ask_price is not None:
@@ -1424,7 +1427,7 @@ def update_market_with_versioning(
         expiration_time if expiration_time is not None else current["expiration_time"]
     )
     new_outcome_label = outcome_label if outcome_label is not None else current["outcome_label"]
-    new_league = league if league is not None else current["league"]
+    new_subcategory = subcategory if subcategory is not None else current["subcategory"]
     new_bracket_count = bracket_count if bracket_count is not None else current["bracket_count"]
     new_source_url = source_url if source_url is not None else current["source_url"]
 
@@ -1442,7 +1445,7 @@ def update_market_with_versioning(
                 close_time = %s,
                 expiration_time = %s,
                 outcome_label = %s,
-                league = %s,
+                subcategory = %s,
                 bracket_count = %s,
                 source_url = %s,
                 updated_at = NOW()
@@ -1456,7 +1459,7 @@ def update_market_with_versioning(
                 new_close_time,
                 new_expiration_time,
                 new_outcome_label,
-                new_league,
+                new_subcategory,
                 new_bracket_count,
                 new_source_url,
                 market_pk,
@@ -1565,14 +1568,15 @@ def get_markets_summary(
     Reference:
         - Migration 0021: markets dimension + market_snapshots fact
     """
-    # Migration 0033: enrichment columns (subtitle, league, close_time) added for GUI.
+    # Migration 0033: enrichment columns (subtitle, subcategory, close_time) added for GUI.
+    # Migration 0037: league renamed to subcategory. Prefer market's denormalized copy,
+    # fall back to event's subcategory for markets without the enrichment column populated.
     query = """
         SELECT
             m.ticker,
             m.title,
             m.subtitle,
-            COALESCE(e.subcategory, 'unknown') as subcategory,
-            m.league,
+            COALESCE(m.subcategory, e.subcategory, 'unknown') as subcategory,
             ms.yes_ask_price,
             ms.no_ask_price,
             m.status,
@@ -1588,7 +1592,7 @@ def get_markets_summary(
     params: list[Any] = []
 
     if subcategory is not None:
-        query += " AND LOWER(e.subcategory) = LOWER(%s)"
+        query += " AND LOWER(COALESCE(m.subcategory, e.subcategory)) = LOWER(%s)"
         params.append(subcategory)
 
     if status is not None:

--- a/src/precog/schedulers/kalshi_poller.py
+++ b/src/precog/schedulers/kalshi_poller.py
@@ -800,9 +800,9 @@ class KalshiMarketPoller(BasePoller):
         elif "MLB" in effective_series.upper():
             subcategory = "mlb"
 
-        # Enrichment columns (migration 0033)
-        # Use lowercase to match game_states.league, teams.sport convention
-        league = subcategory  # already lowercase (e.g., "nfl", "nba")
+        # Enrichment columns (migration 0033, renamed in 0037)
+        # subcategory is already lowercase (e.g., "nfl", "nba") — passed directly
+        # to create_market/update_market_with_versioning as subcategory parameter.
         source_url = (
             f"https://kalshi.com/markets/{effective_series.lower()}/{ticker}"
             if effective_series
@@ -880,7 +880,7 @@ class KalshiMarketPoller(BasePoller):
                 open_time=market.get("open_time"),
                 close_time=market.get("close_time"),
                 expiration_time=market.get("expiration_time"),
-                league=league,
+                subcategory=subcategory,
                 source_url=source_url,
                 outcome_label=outcome_label,
                 metadata={
@@ -916,7 +916,7 @@ class KalshiMarketPoller(BasePoller):
                 open_time=market.get("open_time"),
                 close_time=market.get("close_time"),
                 expiration_time=market.get("expiration_time"),
-                league=league,
+                subcategory=subcategory,
                 source_url=source_url,
             )
             logger.debug(

--- a/tests/fixtures/testcontainers_fixtures.py
+++ b/tests/fixtures/testcontainers_fixtures.py
@@ -177,7 +177,7 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
         close_time TIMESTAMP WITH TIME ZONE,
         expiration_time TIMESTAMP WITH TIME ZONE,
         outcome_label VARCHAR(100),
-        league VARCHAR(20),
+        subcategory VARCHAR(20),
         bracket_count INTEGER CHECK (bracket_count >= 0),
         source_url VARCHAR(500),
         metadata JSONB,
@@ -190,7 +190,7 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
     CREATE INDEX IF NOT EXISTS idx_markets_status ON markets(status);
     CREATE INDEX IF NOT EXISTS idx_markets_close_time ON markets(close_time);
     CREATE INDEX IF NOT EXISTS idx_markets_expiration_time ON markets(expiration_time);
-    CREATE INDEX IF NOT EXISTS idx_markets_league ON markets(league);
+    CREATE INDEX IF NOT EXISTS idx_markets_subcategory ON markets(subcategory);
 
     -- market_snapshots table (fact — migration 0021: SCD Type 2 versioned pricing)
     CREATE TABLE IF NOT EXISTS market_snapshots (
@@ -732,7 +732,7 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
         m.id, m.platform_id, m.event_internal_id, m.external_id,
         m.ticker, m.title, m.subtitle, m.market_type, m.status, m.settlement_value,
         m.open_time, m.close_time, m.expiration_time,
-        m.outcome_label, m.league, m.bracket_count, m.source_url,
+        m.outcome_label, m.subcategory, m.bracket_count, m.source_url,
         m.metadata, m.created_at, m.updated_at,
         ms.yes_ask_price, ms.no_ask_price, ms.yes_bid_price, ms.no_bid_price,
         ms.last_price, ms.spread, ms.volume, ms.open_interest, ms.liquidity,

--- a/tests/test_crud_operations.py
+++ b/tests/test_crud_operations.py
@@ -103,7 +103,7 @@ def test_create_market_with_enrichment_columns(db_pool, clean_test_data, sample_
     sample_market_data["close_time"] = "2026-01-15T18:00:00Z"
     sample_market_data["expiration_time"] = "2026-01-15T23:59:59Z"
     sample_market_data["outcome_label"] = "YES"
-    sample_market_data["league"] = "NFL"
+    sample_market_data["subcategory"] = "nfl"
     sample_market_data["bracket_count"] = 4
     sample_market_data["source_url"] = "https://kalshi.com/markets/test-enriched"
 
@@ -114,7 +114,7 @@ def test_create_market_with_enrichment_columns(db_pool, clean_test_data, sample_
     assert market is not None
     assert market["subtitle"] == "Week 14"
     assert market["outcome_label"] == "YES"
-    assert market["league"] == "NFL"
+    assert market["subcategory"] == "nfl"
     assert market["bracket_count"] == 4
     assert market["source_url"] == "https://kalshi.com/markets/test-enriched"
     # Timestamps are stored as TIMESTAMPTZ — verify actual values round-trip
@@ -139,7 +139,7 @@ def test_create_market_enrichment_columns_optional(db_pool, clean_test_data, sam
     assert market["close_time"] is None
     assert market["expiration_time"] is None
     assert market["outcome_label"] is None
-    assert market["league"] is None
+    assert market["subcategory"] is None
     assert market["bracket_count"] is None
     assert market["source_url"] is None
 
@@ -157,7 +157,7 @@ def test_update_market_with_enrichment_columns(db_pool, clean_test_data, sample_
         close_time="2026-02-01T18:00:00Z",
         expiration_time="2026-02-01T23:59:59Z",
         outcome_label="Seahawks",
-        league="NFL",
+        subcategory="nfl",
         bracket_count=6,
         source_url="https://kalshi.com/markets/updated",
     )
@@ -169,7 +169,7 @@ def test_update_market_with_enrichment_columns(db_pool, clean_test_data, sample_
     assert market["close_time"].day == 1
     assert market["expiration_time"].hour == 23
     assert market["outcome_label"] == "Seahawks"
-    assert market["league"] == "NFL"
+    assert market["subcategory"] == "nfl"
     assert market["bracket_count"] == 6
     assert market["source_url"] == "https://kalshi.com/markets/updated"
 
@@ -178,7 +178,7 @@ def test_update_market_with_enrichment_columns(db_pool, clean_test_data, sample_
 def test_get_markets_summary_includes_enrichment(db_pool, clean_test_data, sample_market_data):
     """Test that get_markets_summary returns enrichment columns from migration 0033."""
     sample_market_data["subtitle"] = "Week 14"
-    sample_market_data["league"] = "NFL"
+    sample_market_data["subcategory"] = "nfl"
     sample_market_data["close_time"] = "2026-01-15T18:00:00Z"
     create_market(**sample_market_data)
 
@@ -188,7 +188,7 @@ def test_get_markets_summary_includes_enrichment(db_pool, clean_test_data, sampl
     match = [r for r in results if r["ticker"] == sample_market_data["ticker"]]
     assert len(match) == 1
     assert match[0]["subtitle"] == "Week 14"
-    assert match[0]["league"] == "NFL"
+    assert match[0]["subcategory"] == "nfl"
     assert match[0]["close_time"] is not None
 
 


### PR DESCRIPTION
## Summary
- Migration 0037: rename `markets.league` → `markets.subcategory` (column, index, view)
- CRUD: rename parameter in `create_market()`, `update_market_with_versioning()`, update SQL in `get_current_market()`, `get_markets_summary()`
- Fix `get_markets_summary()` WHERE filter to use `COALESCE(m.subcategory, e.subcategory)` matching the SELECT logic
- Poller: remove redundant `league = subcategory` alias, pass `subcategory` directly
- Test fixtures and assertions updated (6 lines)

Closes #460 partially (Phase A only — column rename. Phase B sport value refactor deferred to separate session)

## Why
`markets.league` stored the same value as `events.subcategory` (Kalshi API subcategory like "nfl"). Renaming eliminates confusion with `game_states.league` / `teams.league` on the ESPN side, which are different concepts.

## Test plan
- [x] 2159 unit tests pass
- [x] 982 integration + E2E tests pass (20 skipped)
- [x] 1057 stress + chaos + race tests pass
- [x] Lint clean (ruff check + format)
- [x] Reviewer (Spock): APPROVE — found filter inconsistency, fixed
- [x] QA (Ripley): PASS — zero orphaned `markets.league` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)