### PR TITLE
feat: Event-to-game matching logic with Kalshi team code support (#462)

### DIFF
--- a/src/precog/database/alembic/versions/0041_add_kalshi_team_code.py
+++ b/src/precog/database/alembic/versions/0041_add_kalshi_team_code.py
@@ -1,0 +1,62 @@
+"""Add kalshi_team_code to teams table and drop unused external_ids JSONB.
+
+Teams need a Kalshi-specific team code for matching Kalshi event tickers to
+games. Most teams use the same code on Kalshi as their ESPN team_code, but
+some differ (e.g., Kalshi uses "JAC" for Jacksonville, ESPN uses "JAX";
+Kalshi uses "LA" for the Rams, ESPN uses "LAR").
+
+The external_ids JSONB column was added in migration 0001 but never populated
+by any code path. Removing it keeps the schema clean.
+
+Steps:
+    1. ADD COLUMN kalshi_team_code VARCHAR(10) to teams
+    2. CREATE partial INDEX on (kalshi_team_code, league) WHERE NOT NULL
+    3. DROP COLUMN external_ids (unused JSONB)
+
+Revision ID: 0041
+Revises: 0040
+Create Date: 2026-03-23
+
+Related:
+    - Issue #462: Event-to-game matching
+    - Migration 0001: Original teams table with external_ids
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0041"
+down_revision: str = "0040"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add kalshi_team_code column and drop unused external_ids."""
+    # -- Step 1: Add kalshi_team_code column --
+    op.execute("ALTER TABLE teams ADD COLUMN kalshi_team_code VARCHAR(10)")
+
+    # -- Step 2: Partial index for fast lookups by Kalshi code + league --
+    op.execute("""
+        CREATE INDEX idx_teams_kalshi_code
+        ON teams(kalshi_team_code, league)
+        WHERE kalshi_team_code IS NOT NULL
+    """)
+
+    # -- Step 3: Drop unused external_ids JSONB column --
+    # This column was created in migration 0001 but never populated.
+    op.execute("ALTER TABLE teams DROP COLUMN IF EXISTS external_ids")
+
+
+def downgrade() -> None:
+    """Revert: drop kalshi_team_code, restore external_ids."""
+    # Drop index first
+    op.execute("DROP INDEX IF EXISTS idx_teams_kalshi_code")
+
+    # Drop column
+    op.execute("ALTER TABLE teams DROP COLUMN IF EXISTS kalshi_team_code")
+
+    # Restore external_ids JSONB column
+    op.execute("ALTER TABLE teams ADD COLUMN external_ids JSONB")

--- a/src/precog/database/crud_operations.py
+++ b/src/precog/database/crud_operations.py
@@ -8751,3 +8751,228 @@ def update_bracket_counts() -> int:
         cur.execute(null_query)
         updated_without_event: int = cur.rowcount
     return updated_with_event + updated_without_event
+
+
+# =============================================================================
+# TEAM KALSHI CODE OPERATIONS (Issue #462 - Event-to-Game Matching)
+# =============================================================================
+# These functions support matching Kalshi events to games by looking up
+# teams via Kalshi-specific team codes (which may differ from ESPN codes).
+
+
+def get_team_by_kalshi_code(kalshi_code: str, league: str) -> dict[str, Any] | None:
+    """Look up a team by its Kalshi platform team code and league.
+
+    Kalshi uses slightly different team codes than ESPN for some teams
+    (e.g., JAC vs JAX for Jacksonville). This function finds the team
+    regardless of which code system is used.
+
+    Search order:
+        1. Check kalshi_team_code column (explicit mismatches)
+        2. Check team_code column (most teams where codes match)
+
+    Args:
+        kalshi_code: Team code as used by Kalshi (e.g., "JAC", "HOU")
+        league: League code (e.g., "nfl", "nba")
+
+    Returns:
+        Dictionary with team data, or None if not found.
+
+    Example:
+        >>> team = get_team_by_kalshi_code("JAC", "nfl")
+        >>> if team:
+        ...     print(f"{team['team_name']} ({team['team_code']})")
+        ...     # Jacksonville Jaguars (JAX)
+
+    Related:
+        - Migration 0041: teams.kalshi_team_code column
+        - Issue #462: Event-to-game matching
+    """
+    # First check explicit kalshi_team_code (mismatches like JAC -> JAX)
+    query_kalshi = """
+        SELECT * FROM teams
+        WHERE kalshi_team_code = %s AND league = %s
+    """
+    result = fetch_one(query_kalshi, (kalshi_code, league))
+    if result:
+        return result
+
+    # Fall back to team_code (most teams use same code on both platforms)
+    query_code = """
+        SELECT * FROM teams
+        WHERE team_code = %s AND league = %s
+    """
+    return fetch_one(query_code, (kalshi_code, league))
+
+
+def get_teams_with_kalshi_codes(league: str | None = None) -> list[dict[str, Any]]:
+    """Get all teams for building the Kalshi team code registry.
+
+    Returns all teams (or teams for a specific league) with their
+    team_code, league, and kalshi_team_code. Used by TeamCodeRegistry
+    to build its in-memory lookup cache.
+
+    Args:
+        league: Optional league filter. If None, returns all teams.
+
+    Returns:
+        List of team dicts with keys: team_id, team_code, league,
+        kalshi_team_code (may be None).
+
+    Example:
+        >>> teams = get_teams_with_kalshi_codes("nfl")
+        >>> for t in teams:
+        ...     kalshi = t['kalshi_team_code'] or t['team_code']
+        ...     print(f"{kalshi} -> {t['team_code']}")
+
+    Related:
+        - TeamCodeRegistry.load(): Primary consumer
+        - Issue #462: Event-to-game matching
+    """
+    if league:
+        query = """
+            SELECT team_id, team_code, league, kalshi_team_code
+            FROM teams
+            WHERE league = %s
+            ORDER BY team_code
+        """
+        return fetch_all(query, (league,))
+
+    query = """
+        SELECT team_id, team_code, league, kalshi_team_code
+        FROM teams
+        ORDER BY league, team_code
+    """
+    return fetch_all(query)
+
+
+def update_event_game_id(event_internal_id: int, game_id: int) -> bool:
+    """Set game_id on an existing event. Returns True if updated.
+
+    Links a Kalshi event to an ESPN game by setting the FK. This is
+    called when the matching module finds a game for an event that was
+    previously unlinked (game_id IS NULL).
+
+    Args:
+        event_internal_id: The events.id (integer surrogate PK)
+        game_id: The games.id to link to
+
+    Returns:
+        True if the event was updated, False if event not found or
+        already linked to this game.
+
+    Example:
+        >>> updated = update_event_game_id(event_pk=42, game_id=15)
+        >>> if updated:
+        ...     print("Event linked to game")
+
+    Related:
+        - Migration 0038: events.game_id FK to games(id)
+        - Issue #462: Event-to-game matching
+    """
+    query = """
+        UPDATE events
+        SET game_id = %s, updated_at = NOW()
+        WHERE id = %s AND (game_id IS NULL OR game_id != %s)
+    """
+    with get_cursor(commit=True) as cur:
+        cur.execute(query, (game_id, event_internal_id, game_id))
+        return bool(cur.rowcount > 0)
+
+
+def find_unlinked_sports_events(league: str | None = None) -> list[dict[str, Any]]:
+    """Find events where game_id IS NULL and category='sports'.
+
+    Used by EventGameMatcher.backfill_unlinked_events() to find events
+    that need matching.
+
+    Args:
+        league: Optional subcategory/league filter (e.g., "nfl", "nba").
+
+    Returns:
+        List of event dicts with keys: id, event_id, title, subcategory.
+
+    Example:
+        >>> unlinked = find_unlinked_sports_events("nfl")
+        >>> print(f"{len(unlinked)} NFL events need matching")
+
+    Related:
+        - EventGameMatcher.backfill_unlinked_events(): Primary consumer
+        - Issue #462: Event-to-game matching
+    """
+    if league:
+        query = """
+            SELECT id, event_id, title, subcategory
+            FROM events
+            WHERE game_id IS NULL
+              AND category = 'sports'
+              AND subcategory = %s
+            ORDER BY id
+        """
+        return fetch_all(query, (league,))
+
+    query = """
+        SELECT id, event_id, title, subcategory
+        FROM events
+        WHERE game_id IS NULL
+          AND category = 'sports'
+        ORDER BY id
+    """
+    return fetch_all(query)
+
+
+def find_game_by_matchup(
+    league: str,
+    game_date: date,
+    home_team_code: str,
+    away_team_code: str,
+) -> int | None:
+    """Look up a game by league + date + team codes. Returns games.id or None.
+
+    The games table natural key is (sport, game_date, home_team_code,
+    away_team_code). This function maps from league to sport using the
+    LEAGUE_SPORT_CATEGORY dict and queries by the natural key.
+
+    Args:
+        league: League code (e.g., "nfl", "nba", "ncaaf")
+        game_date: Date of the game
+        home_team_code: ESPN/canonical home team code (e.g., "KC")
+        away_team_code: ESPN/canonical away team code (e.g., "BAL")
+
+    Returns:
+        games.id (integer) if found, None otherwise.
+
+    Example:
+        >>> from datetime import date
+        >>> game_id = find_game_by_matchup(
+        ...     league="nfl",
+        ...     game_date=date(2026, 1, 18),
+        ...     home_team_code="NE",
+        ...     away_team_code="HOU",
+        ... )
+
+    Related:
+        - Migration 0035: games dimension table with natural key
+        - EventGameMatcher._find_game(): Primary consumer
+        - Issue #462: Event-to-game matching
+    """
+    # Map league to sport for the natural key query
+    sport = LEAGUE_SPORT_CATEGORY.get(league)
+    if sport is None:
+        logger.warning(
+            "Unknown league '%s' — cannot map to sport for game lookup",
+            league,
+        )
+        return None
+
+    query = """
+        SELECT id FROM games
+        WHERE sport = %s
+          AND game_date = %s
+          AND home_team_code = %s
+          AND away_team_code = %s
+    """
+    result = fetch_one(query, (sport, game_date, home_team_code, away_team_code))
+    if result:
+        return cast("int", result["id"])
+    return None

--- a/src/precog/database/seeds/011_kalshi_teams_code_mapping.sql
+++ b/src/precog/database/seeds/011_kalshi_teams_code_mapping.sql
@@ -1,0 +1,73 @@
+-- Seed Data: Kalshi Platform Team Codes
+-- Date: 2026-03-23
+-- Purpose: Set kalshi_team_code for teams where Kalshi uses a different code
+--          than the canonical team_code (ESPN). For most teams, Kalshi uses
+--          the same code as ESPN, so only mismatches need explicit mapping.
+-- Related: Issue #462 (Event-to-game matching)
+
+-- ============================================================================
+-- BACKGROUND: Kalshi Team Code Mapping
+-- ============================================================================
+-- Kalshi event tickers embed team codes: "KXNFLGAME-26JAN18HOUNE"
+-- Most Kalshi codes match ESPN codes (HOU, NE, BUF, etc.)
+-- Known mismatches (verified from live Kalshi API data):
+--   NFL: JAC (Kalshi) vs JAX (ESPN), LA (Kalshi) vs LAR (ESPN)
+--   NBA: None confirmed yet (all match)
+--   NHL: Not yet verified
+--
+-- Strategy: Only set kalshi_team_code where it DIFFERS from team_code.
+-- The matching module treats NULL kalshi_team_code as "same as team_code".
+
+-- ============================================================================
+-- NFL TEAM CODE MISMATCHES
+-- ============================================================================
+-- Jacksonville: Kalshi uses JAC, ESPN/DB uses JAX
+UPDATE teams SET kalshi_team_code = 'JAC'
+WHERE team_code = 'JAX' AND league = 'nfl';
+
+-- LA Rams: Kalshi uses LA, ESPN/DB uses LAR
+UPDATE teams SET kalshi_team_code = 'LA'
+WHERE team_code = 'LAR' AND league = 'nfl';
+
+-- New Orleans: Kalshi uses NO in some tickers, ESPN/DB uses NO — same, skip.
+-- Green Bay: Kalshi uses GB, ESPN/DB uses GB — same, skip.
+
+-- ============================================================================
+-- NBA TEAM CODE MISMATCHES
+-- ============================================================================
+-- No confirmed mismatches. All NBA Kalshi codes match ESPN team_code.
+-- If mismatches are discovered from live data, add UPDATE statements here.
+
+-- ============================================================================
+-- NHL TEAM CODE MISMATCHES
+-- ============================================================================
+-- Not yet verified against live Kalshi NHL data.
+-- Add UPDATE statements here when mismatches are confirmed.
+
+-- ============================================================================
+-- VERIFICATION
+-- ============================================================================
+
+DO $$
+DECLARE
+    jax_code TEXT;
+    lar_code TEXT;
+BEGIN
+    -- Verify JAX team got JAC Kalshi code
+    SELECT kalshi_team_code INTO jax_code
+    FROM teams WHERE team_code = 'JAX' AND league = 'nfl';
+
+    IF jax_code IS DISTINCT FROM 'JAC' THEN
+        RAISE WARNING 'JAX kalshi_team_code not set (team may not exist yet): expected JAC, got %', COALESCE(jax_code, 'NULL');
+    END IF;
+
+    -- Verify LAR team got LA Kalshi code
+    SELECT kalshi_team_code INTO lar_code
+    FROM teams WHERE team_code = 'LAR' AND league = 'nfl';
+
+    IF lar_code IS DISTINCT FROM 'LA' THEN
+        RAISE WARNING 'LAR kalshi_team_code not set (team may not exist yet): expected LA, got %', COALESCE(lar_code, 'NULL');
+    END IF;
+
+    RAISE NOTICE 'Kalshi team code seed complete. Mismatches set: JAX->JAC, LAR->LA';
+END $$;

--- a/src/precog/matching/__init__.py
+++ b/src/precog/matching/__init__.py
@@ -1,0 +1,35 @@
+"""
+Event-to-game matching module for Precog.
+
+Matches Kalshi prediction market events to ESPN games by parsing event
+tickers for team codes and game dates, then looking up the corresponding
+game in the games dimension table.
+
+Public API:
+    - ParsedTicker: Structured result from ticker parsing
+    - parse_event_ticker(): Parse a Kalshi event ticker into components
+    - TeamCodeRegistry: In-memory cache of team code mappings
+    - EventGameMatcher: Orchestrates the full matching flow
+
+Example:
+    >>> from precog.matching import EventGameMatcher
+    >>> matcher = EventGameMatcher()
+    >>> matcher.registry.load()
+    >>> game_id = matcher.match_event("KXNFLGAME-26JAN18HOUNE")
+
+Related:
+    - Issue #462: Event-to-game matching
+    - Migration 0038: events.game_id FK to games(id)
+    - Migration 0041: teams.kalshi_team_code column
+"""
+
+from precog.matching.event_game_matcher import EventGameMatcher
+from precog.matching.team_code_registry import TeamCodeRegistry
+from precog.matching.ticker_parser import ParsedTicker, parse_event_ticker
+
+__all__ = [
+    "EventGameMatcher",
+    "ParsedTicker",
+    "TeamCodeRegistry",
+    "parse_event_ticker",
+]

--- a/src/precog/matching/event_game_matcher.py
+++ b/src/precog/matching/event_game_matcher.py
@@ -1,0 +1,273 @@
+"""
+Orchestrates matching Kalshi events to ESPN games.
+
+The matcher combines ticker parsing (extracting team codes and dates from
+Kalshi event tickers) with game lookups (finding the corresponding game in
+the games dimension table) to populate the events.game_id FK.
+
+Matching Phases:
+    Phase 1 (this module): Parse event_ticker for date + team codes
+    Phase 2 (TODO): Parse event title for team names (fallback)
+    Phase 3 (batch): backfill_unlinked_events() for historical data
+
+Flow:
+    1. Parse ticker -> league, date, away_code, home_code (Kalshi codes)
+    2. Resolve Kalshi codes to ESPN codes via TeamCodeRegistry
+    3. Look up sport from LEAGUE_SPORT_CATEGORY mapping
+    4. Query games table by (sport, game_date, home_team_code, away_team_code)
+    5. Return games.id or None
+
+Educational Note:
+    The games table natural key is (sport, game_date, home_team_code,
+    away_team_code) where sport is "football"/"basketball"/etc. and
+    team codes are ESPN codes. The matching module bridges the gap between
+    Kalshi's league-specific codes and the games table's sport-level codes.
+
+Related:
+    - Issue #462: Event-to-game matching
+    - Migration 0038: events.game_id FK to games(id)
+    - crud_operations.find_game_by_matchup(): Game lookup
+    - crud_operations.LEAGUE_SPORT_CATEGORY: League-to-sport mapping
+"""
+
+import logging
+from datetime import date
+
+from precog.matching.team_code_registry import TeamCodeRegistry
+from precog.matching.ticker_parser import ParsedTicker, parse_event_ticker
+
+logger = logging.getLogger(__name__)
+
+
+class EventGameMatcher:
+    """Matches Kalshi events to ESPN games.
+
+    Attributes:
+        registry: TeamCodeRegistry for resolving team codes.
+
+    Usage:
+        >>> matcher = EventGameMatcher()
+        >>> matcher.registry.load()
+        >>> game_id = matcher.match_event("KXNFLGAME-26JAN18HOUNE")
+        >>> if game_id:
+        ...     update_event_game_id(event_pk, game_id)
+
+    Educational Note:
+        The matcher uses dependency injection for the registry, making it
+        testable without a database. In production, the registry is loaded
+        from DB at poller startup. In tests, use load_from_data() with
+        mock team data.
+    """
+
+    def __init__(self, registry: TeamCodeRegistry | None = None) -> None:
+        """Initialize matcher with optional pre-configured registry.
+
+        Args:
+            registry: Pre-configured TeamCodeRegistry. If None, creates
+                      a new empty one (caller must call registry.load()
+                      before matching).
+        """
+        self.registry = registry or TeamCodeRegistry()
+
+    def match_event(self, event_ticker: str, title: str | None = None) -> int | None:
+        """Try to match an event to a game. Returns games.id or None.
+
+        Phase 1: Parse event_ticker for date + team codes, look up game.
+        Phase 2: If Phase 1 fails, parse title for team names (TODO).
+
+        Args:
+            event_ticker: Kalshi event ticker (e.g., "KXNFLGAME-26JAN18HOUNE")
+            title: Optional event title for fallback parsing (not yet implemented)
+
+        Returns:
+            games.id (integer) if a matching game is found, None otherwise.
+
+        Example:
+            >>> matcher = EventGameMatcher()
+            >>> matcher.registry.load()
+            >>> game_id = matcher.match_event("KXNFLGAME-26JAN18HOUNE")
+            >>> game_id  # e.g., 42 or None
+        """
+        # Phase 1: Ticker-based matching
+        game_id = self._match_via_ticker(event_ticker)
+        if game_id is not None:
+            return game_id
+
+        # Phase 2: Title-based fallback (TODO — stub)
+        if title:
+            game_id = self._match_via_title(title, event_ticker)
+            if game_id is not None:
+                return game_id
+
+        return None
+
+    def _match_via_ticker(self, event_ticker: str) -> int | None:
+        """Attempt to match using parsed ticker data.
+
+        Args:
+            event_ticker: Kalshi event ticker string.
+
+        Returns:
+            games.id or None.
+        """
+        # Extract league from ticker to get the right code set
+        parsed = self._parse_ticker(event_ticker)
+        if parsed is None:
+            logger.debug("Could not parse ticker: %s", event_ticker)
+            return None
+
+        # Resolve Kalshi codes to ESPN/canonical codes
+        away_espn = self.registry.resolve_kalshi_to_espn(parsed.away_team_code, parsed.league)
+        home_espn = self.registry.resolve_kalshi_to_espn(parsed.home_team_code, parsed.league)
+
+        if away_espn is None or home_espn is None:
+            logger.debug(
+                "Could not resolve team codes for %s: away=%s->%s, home=%s->%s",
+                event_ticker,
+                parsed.away_team_code,
+                away_espn,
+                parsed.home_team_code,
+                home_espn,
+            )
+            return None
+
+        # Look up the game in the games dimension table
+        return self._find_game(parsed.league, parsed.game_date, home_espn, away_espn)
+
+    def _parse_ticker(self, event_ticker: str) -> ParsedTicker | None:
+        """Parse ticker with league-appropriate valid codes.
+
+        Extracts league from ticker first to select the correct code set,
+        then re-parses with those codes for team splitting.
+
+        Args:
+            event_ticker: Kalshi event ticker string.
+
+        Returns:
+            ParsedTicker or None.
+        """
+        # First pass: parse without codes to extract league
+        # We need the league to get the right code set
+        from precog.matching.ticker_parser import _extract_league
+
+        parts = event_ticker.split("-", 1)
+        if len(parts) != 2:
+            return None
+
+        league = _extract_league(parts[0])
+        if league is None:
+            return None
+
+        # Get valid codes for this league
+        valid_codes = self.registry.get_kalshi_codes(league)
+        if not valid_codes:
+            logger.debug(
+                "No valid codes in registry for league '%s' (ticker: %s)",
+                league,
+                event_ticker,
+            )
+            return None
+
+        # Full parse with valid codes for team splitting
+        return parse_event_ticker(event_ticker, valid_codes)
+
+    def _match_via_title(self, _title: str, _event_ticker: str) -> int | None:
+        """Attempt to match using event title text.
+
+        TODO: Implement title-based matching as a fallback for tickers
+        that can't be parsed (non-standard formats, ambiguous splits).
+
+        Args:
+            _title: Event title text (e.g., "Chiefs vs Seahawks - Jan 18")
+            _event_ticker: Original ticker for logging context.
+
+        Returns:
+            games.id or None (always None until implemented).
+        """
+        # TODO(#462): Implement title-based fallback matching
+        # Parse team names from title, resolve to codes, look up game
+        return None
+
+    def _find_game(
+        self,
+        league: str,
+        game_date: date,
+        home_team_code: str,
+        away_team_code: str,
+    ) -> int | None:
+        """Look up a game in the games dimension table.
+
+        Uses the CRUD function find_game_by_matchup() which queries by
+        the natural key: (league, game_date, home_team_code, away_team_code).
+
+        Args:
+            league: League code (e.g., "nfl")
+            game_date: Game date
+            home_team_code: ESPN/canonical home team code
+            away_team_code: ESPN/canonical away team code
+
+        Returns:
+            games.id or None.
+        """
+        from precog.database.crud_operations import find_game_by_matchup
+
+        return find_game_by_matchup(
+            league=league,
+            game_date=game_date,
+            home_team_code=home_team_code,
+            away_team_code=away_team_code,
+        )
+
+    def backfill_unlinked_events(self, league: str | None = None) -> int:
+        """Find events with game_id=NULL and attempt matching.
+
+        Queries for unlinked sports events, attempts ticker-based matching
+        for each, and updates events.game_id where matches are found.
+
+        Args:
+            league: Optional league filter. If None, processes all leagues.
+
+        Returns:
+            Count of newly linked events.
+
+        Example:
+            >>> matcher = EventGameMatcher()
+            >>> matcher.registry.load()
+            >>> linked = matcher.backfill_unlinked_events("nfl")
+            >>> print(f"Linked {linked} events to games")
+        """
+        from precog.database.crud_operations import (
+            find_unlinked_sports_events,
+            update_event_game_id,
+        )
+
+        unlinked = find_unlinked_sports_events(league=league)
+        linked_count = 0
+
+        for event in unlinked:
+            event_ticker = event.get("event_id", "")
+            title = event.get("title")
+            event_id = event.get("id")
+
+            if not event_ticker or event_id is None:
+                continue
+
+            game_id = self.match_event(event_ticker, title=title)
+            if game_id is not None:
+                success = update_event_game_id(event_id, game_id)
+                if success:
+                    linked_count += 1
+                    logger.info(
+                        "Linked event %s (id=%d) to game_id=%d",
+                        event_ticker,
+                        event_id,
+                        game_id,
+                    )
+
+        logger.info(
+            "Backfill complete: %d/%d events linked (league=%s)",
+            linked_count,
+            len(unlinked),
+            league or "all",
+        )
+        return linked_count

--- a/src/precog/matching/team_code_registry.py
+++ b/src/precog/matching/team_code_registry.py
@@ -1,0 +1,192 @@
+"""
+In-memory cache of team code mappings for fast lookup during matching.
+
+The registry loads team codes from the database at poller startup and
+provides fast in-memory lookups for:
+    1. Resolving Kalshi codes to canonical ESPN/DB team codes
+    2. Getting all valid Kalshi codes for a league (for ticker splitting)
+
+Mapping Strategy:
+    - Teams WITH kalshi_team_code: Kalshi uses a different code than ESPN
+      (e.g., JAC -> JAX, LA -> LAR)
+    - Teams WITHOUT kalshi_team_code: Kalshi code is assumed to be the
+      same as team_code (true for ~95% of teams)
+
+The registry is designed to be loaded once at startup and refreshed
+periodically (e.g., daily) rather than queried per-event.
+
+Educational Note:
+    Why an in-memory cache instead of DB lookups per event?
+    The poller processes hundreds of events per cycle. A DB lookup per
+    event would add ~100ms * N latency. The registry loads all codes in
+    one query (~5ms) and provides O(1) lookups thereafter.
+
+Related:
+    - Issue #462: Event-to-game matching
+    - Migration 0041: teams.kalshi_team_code column
+    - crud_operations.get_teams_with_kalshi_codes(): Data source
+"""
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class TeamCodeRegistry:
+    """Cache of team code mappings for fast lookup during matching.
+
+    Attributes:
+        _kalshi_to_espn: dict[league, dict[kalshi_code, espn_team_code]]
+            Maps Kalshi team codes to canonical ESPN team codes per league.
+        _kalshi_codes: dict[league, set[str]]
+            All valid Kalshi codes per league (for ticker splitting).
+        _loaded: Whether the registry has been loaded from DB.
+
+    Usage:
+        >>> registry = TeamCodeRegistry()
+        >>> registry.load()  # One-time at startup
+        >>> espn_code = registry.resolve_kalshi_to_espn("JAC", "nfl")
+        >>> espn_code  # "JAX"
+        >>> codes = registry.get_kalshi_codes("nfl")
+        >>> "JAC" in codes  # True (Kalshi code)
+        >>> "JAX" in codes  # False (ESPN code, not in Kalshi set)
+    """
+
+    def __init__(self) -> None:
+        """Initialize empty registry. Call load() before use."""
+        self._kalshi_to_espn: dict[str, dict[str, str]] = {}
+        self._kalshi_codes: dict[str, set[str]] = {}
+        self._loaded: bool = False
+
+    @property
+    def is_loaded(self) -> bool:
+        """Whether the registry has been loaded from the database."""
+        return self._loaded
+
+    def load(self, league: str | None = None) -> None:
+        """Load team codes from DB into in-memory cache.
+
+        Queries the teams table for all teams (or a specific league) and
+        builds the mapping dictionaries. Safe to call multiple times
+        (replaces existing data for reloaded leagues).
+
+        Args:
+            league: Optional league filter. If None, loads all leagues.
+
+        Example:
+            >>> registry = TeamCodeRegistry()
+            >>> registry.load()           # Load all leagues
+            >>> registry.load("nfl")      # Refresh NFL only
+        """
+        # Import here to avoid circular imports at module level
+        from precog.database.crud_operations import get_teams_with_kalshi_codes
+
+        teams = get_teams_with_kalshi_codes(league=league)
+        self._build_cache(teams, league)
+        self._loaded = True
+
+        total_codes = sum(len(codes) for codes in self._kalshi_codes.values())
+        logger.info(
+            "TeamCodeRegistry loaded: %d leagues, %d total codes",
+            len(self._kalshi_codes),
+            total_codes,
+        )
+
+    def load_from_data(self, teams: list[dict[str, Any]]) -> None:
+        """Load registry from pre-fetched team data (for testing).
+
+        Args:
+            teams: List of team dicts with keys: team_code, league,
+                   kalshi_team_code (optional).
+
+        Example:
+            >>> registry = TeamCodeRegistry()
+            >>> registry.load_from_data([
+            ...     {"team_code": "JAX", "league": "nfl", "kalshi_team_code": "JAC"},
+            ...     {"team_code": "KC", "league": "nfl", "kalshi_team_code": None},
+            ... ])
+        """
+        self._build_cache(teams, league=None)
+        self._loaded = True
+
+    def _build_cache(self, teams: list[dict[str, Any]], league: str | None) -> None:
+        """Build internal cache from team data.
+
+        Args:
+            teams: List of team dicts from DB or test data.
+            league: If provided, only clear/rebuild that league's data.
+        """
+        if league:
+            # Clear only the specified league
+            self._kalshi_to_espn.pop(league, None)
+            self._kalshi_codes.pop(league, None)
+        else:
+            # Clear all
+            self._kalshi_to_espn.clear()
+            self._kalshi_codes.clear()
+
+        for team in teams:
+            team_code = team.get("team_code", "")
+            team_league = team.get("league", "")
+            kalshi_code = team.get("kalshi_team_code")
+
+            if not team_code or not team_league:
+                continue
+
+            # Initialize league dicts if needed
+            if team_league not in self._kalshi_to_espn:
+                self._kalshi_to_espn[team_league] = {}
+                self._kalshi_codes[team_league] = set()
+
+            if kalshi_code:
+                # Explicit Kalshi code differs from ESPN code
+                upper_kalshi = kalshi_code.upper()
+                self._kalshi_to_espn[team_league][upper_kalshi] = team_code
+                self._kalshi_codes[team_league].add(upper_kalshi)
+            else:
+                # Kalshi code is same as ESPN code (most teams)
+                upper_code = team_code.upper()
+                self._kalshi_to_espn[team_league][upper_code] = team_code
+                self._kalshi_codes[team_league].add(upper_code)
+
+    def resolve_kalshi_to_espn(self, kalshi_code: str, league: str) -> str | None:
+        """Resolve a Kalshi team code to the canonical ESPN/DB team_code.
+
+        Args:
+            kalshi_code: Team code as used by Kalshi (e.g., "JAC", "HOU")
+            league: League code (e.g., "nfl", "nba")
+
+        Returns:
+            Canonical team_code from the teams table, or None if unknown.
+
+        Example:
+            >>> registry.resolve_kalshi_to_espn("JAC", "nfl")
+            'JAX'
+            >>> registry.resolve_kalshi_to_espn("HOU", "nfl")
+            'HOU'
+            >>> registry.resolve_kalshi_to_espn("ZZZ", "nfl")
+            None
+        """
+        league_map = self._kalshi_to_espn.get(league, {})
+        return league_map.get(kalshi_code.upper())
+
+    def get_kalshi_codes(self, league: str) -> set[str]:
+        """Get all known Kalshi codes for a league.
+
+        Used by the ticker parser to determine valid split points when
+        parsing concatenated team codes from event tickers.
+
+        Args:
+            league: League code (e.g., "nfl", "nba")
+
+        Returns:
+            Set of uppercase Kalshi team codes. Empty set if league unknown.
+
+        Example:
+            >>> codes = registry.get_kalshi_codes("nfl")
+            >>> "JAC" in codes   # True (Kalshi's code for Jacksonville)
+            >>> "JAX" in codes   # False (ESPN's code, not in Kalshi set)
+            >>> "HOU" in codes   # True (same on both platforms)
+        """
+        return self._kalshi_codes.get(league, set())

--- a/src/precog/matching/ticker_parser.py
+++ b/src/precog/matching/ticker_parser.py
@@ -1,0 +1,285 @@
+"""
+Parse Kalshi event tickers into structured game data.
+
+Kalshi event tickers encode league, date, and team matchup information:
+    Format: {SERIES}-{YY}{MON}{DD}{AWAY}{HOME}
+    Example: KXNFLGAME-26JAN18HOUNE
+             series=KXNFLGAME, date=2026-01-18, away=HOU, home=NE
+
+The parser extracts:
+    - League from series prefix (NFL, NBA, NCAAF, NHL, MLB)
+    - Game date from the encoded date segment
+    - Away and home team codes (variable length: 2-4 chars)
+
+Team code splitting requires a set of valid codes for the league, since
+codes are concatenated without a delimiter. The split algorithm tries all
+possible positions and returns the one where both halves are valid codes.
+
+Educational Note:
+    Why not use a regex for team splitting? Because team codes are variable
+    length (NE=2, HOU=3, WAKE=4) and concatenated: "HOUNE" could be
+    HOU+NE or HO+UNE. Only by checking against known valid codes can we
+    determine the correct split point.
+
+Related:
+    - Issue #462: Event-to-game matching
+    - team_code_registry.py: Provides valid code sets for splitting
+"""
+
+import logging
+import re
+from dataclasses import dataclass
+from datetime import date
+
+logger = logging.getLogger(__name__)
+
+# Month abbreviations used in Kalshi tickers (uppercase)
+_MONTH_MAP: dict[str, int] = {
+    "JAN": 1,
+    "FEB": 2,
+    "MAR": 3,
+    "APR": 4,
+    "MAY": 5,
+    "JUN": 6,
+    "JUL": 7,
+    "AUG": 8,
+    "SEP": 9,
+    "OCT": 10,
+    "NOV": 11,
+    "DEC": 12,
+}
+
+# Pattern to extract league from series prefix.
+# Matches the FIRST sport keyword found in the series string.
+# Order matters: NCAAF before NFL (longer match first), NCAAB before NBA.
+_LEAGUE_PATTERNS: list[tuple[str, str]] = [
+    ("NCAAF", "ncaaf"),
+    ("NCAAB", "ncaab"),
+    ("NFL", "nfl"),
+    ("NBA", "nba"),
+    ("NHL", "nhl"),
+    ("MLB", "mlb"),
+]
+
+# Regex for the date portion: 2-digit year, 3-letter month, 2-digit day
+_DATE_PATTERN = re.compile(r"^(\d{2})([A-Z]{3})(\d{2})")
+
+
+@dataclass(frozen=True)
+class ParsedTicker:
+    """Result of parsing a Kalshi event ticker.
+
+    Attributes:
+        series: Full series prefix (e.g., "KXNFLGAME")
+        league: Lowercase league code extracted from series (e.g., "nfl")
+        game_date: Parsed game date
+        away_team_code: Kalshi team code for away team (e.g., "HOU")
+        home_team_code: Kalshi team code for home team (e.g., "NE")
+
+    Educational Note:
+        frozen=True makes ParsedTicker immutable and hashable, which is
+        appropriate since parsed data should not be modified after creation.
+    """
+
+    series: str
+    league: str
+    game_date: date
+    away_team_code: str
+    home_team_code: str
+
+
+def _extract_league(series: str) -> str | None:
+    """Extract league code from series prefix.
+
+    Args:
+        series: Series prefix string (e.g., "KXNFLGAME", "KXNCAAFGAME")
+
+    Returns:
+        Lowercase league code (e.g., "nfl") or None if no league found.
+
+    Example:
+        >>> _extract_league("KXNFLGAME")
+        'nfl'
+        >>> _extract_league("KXNCAAFD3GAME")
+        'ncaaf'
+        >>> _extract_league("KXNBA2HWINNER")
+        'nba'
+    """
+    upper = series.upper()
+    for pattern, league in _LEAGUE_PATTERNS:
+        if pattern in upper:
+            return league
+    return None
+
+
+def _parse_date_segment(segment: str) -> tuple[date, str] | None:
+    """Parse date from the beginning of a ticker segment.
+
+    The date format is YYMONDD where:
+        YY = 2-digit year (20xx)
+        MON = 3-letter month abbreviation
+        DD = 2-digit day
+
+    Args:
+        segment: The portion after the hyphen (e.g., "26JAN18HOUNE")
+
+    Returns:
+        Tuple of (parsed_date, remaining_string) or None if parsing fails.
+
+    Example:
+        >>> _parse_date_segment("26JAN18HOUNE")
+        (date(2026, 1, 18), 'HOUNE')
+        >>> _parse_date_segment("25DEC31DALNYG")
+        (date(2025, 12, 31), 'DALNYG')
+    """
+    match = _DATE_PATTERN.match(segment.upper())
+    if not match:
+        return None
+
+    year_str, month_str, day_str = match.groups()
+    month = _MONTH_MAP.get(month_str)
+    if month is None:
+        return None
+
+    try:
+        year = 2000 + int(year_str)
+        day = int(day_str)
+        parsed_date = date(year, month, day)
+    except ValueError:
+        # Invalid date (e.g., Feb 30)
+        return None
+
+    remaining = segment[match.end() :]
+    return parsed_date, remaining
+
+
+def split_team_codes(combined: str, valid_codes: set[str]) -> tuple[str, str] | None:
+    """Split concatenated team codes using a set of valid codes.
+
+    Tries all split points from position 2 to len-2 and returns the split
+    where BOTH halves are recognized as valid team codes for the league.
+
+    Args:
+        combined: Concatenated team codes (e.g., "HOUNE", "OKCBOS", "WAKEMSST")
+        valid_codes: Set of valid Kalshi team codes for the league (uppercase)
+
+    Returns:
+        Tuple of (away_code, home_code) or None if no valid split found.
+        Returns None if multiple valid splits are found (ambiguous).
+
+    Example:
+        >>> codes = {"HOU", "NE", "KC", "BUF"}
+        >>> split_team_codes("HOUNE", codes)
+        ('HOU', 'NE')
+        >>> split_team_codes("KCBUF", codes)
+        ('KC', 'BUF')
+    """
+    if len(combined) < 4:
+        # Minimum: 2-char code + 2-char code
+        return None
+
+    upper = combined.upper()
+    valid_upper = {c.upper() for c in valid_codes}
+    matches: list[tuple[str, str]] = []
+
+    # Try split points from position 2 to len(combined)-2
+    for i in range(2, len(upper) - 1):
+        left = upper[:i]
+        right = upper[i:]
+        if left in valid_upper and right in valid_upper:
+            matches.append((left, right))
+
+    if len(matches) == 1:
+        return matches[0]
+    if len(matches) > 1:
+        # Ambiguous split — can't determine which is correct
+        logger.warning(
+            "Ambiguous team code split for '%s': %d valid splits found: %s",
+            combined,
+            len(matches),
+            matches,
+        )
+        return None
+
+    # No valid split found
+    return None
+
+
+def parse_event_ticker(ticker: str, valid_codes: set[str] | None = None) -> ParsedTicker | None:
+    """Parse a Kalshi event ticker into structured game data.
+
+    Extracts league, game date, and team codes from the ticker string.
+    Team code splitting requires valid_codes to disambiguate variable-length
+    codes. If valid_codes is not provided, team splitting is skipped.
+
+    Args:
+        ticker: Full Kalshi event ticker (e.g., "KXNFLGAME-26JAN18HOUNE")
+        valid_codes: Set of valid Kalshi team codes for the league.
+                     Required for team code extraction. Get from
+                     TeamCodeRegistry.get_kalshi_codes().
+
+    Returns:
+        ParsedTicker with all fields populated, or None if parsing fails.
+
+    Example:
+        >>> nfl_codes = {"ARI", "ATL", "BAL", "BUF", "HOU", "NE", ...}
+        >>> result = parse_event_ticker("KXNFLGAME-26JAN18HOUNE", nfl_codes)
+        >>> result.league
+        'nfl'
+        >>> result.game_date
+        datetime.date(2026, 1, 18)
+        >>> result.away_team_code
+        'HOU'
+        >>> result.home_team_code
+        'NE'
+
+    Related:
+        - TeamCodeRegistry.get_kalshi_codes(): Provides valid code sets
+        - EventGameMatcher.match_event(): Primary caller
+    """
+    if not ticker or not isinstance(ticker, str):
+        return None
+
+    # Split on first hyphen: series prefix and the rest
+    parts = ticker.split("-", 1)
+    if len(parts) != 2:
+        return None
+
+    series, remainder = parts
+    if not series or not remainder:
+        return None
+
+    # Extract league from series
+    league = _extract_league(series)
+    if league is None:
+        return None
+
+    # Parse date from remainder
+    date_result = _parse_date_segment(remainder)
+    if date_result is None:
+        return None
+
+    game_date, team_segment = date_result
+
+    # If no valid codes provided or no team segment, return partial result
+    if not team_segment:
+        return None
+
+    if valid_codes is None:
+        # Can't split team codes without valid code set
+        return None
+
+    # Split concatenated team codes
+    split = split_team_codes(team_segment, valid_codes)
+    if split is None:
+        return None
+
+    away_code, home_code = split
+
+    return ParsedTicker(
+        series=series,
+        league=league,
+        game_date=game_date,
+        away_team_code=away_code,
+        home_team_code=home_code,
+    )

--- a/src/precog/schedulers/kalshi_poller.py
+++ b/src/precog/schedulers/kalshi_poller.py
@@ -55,8 +55,10 @@ from precog.database.crud_operations import (
     get_or_create_event,
     get_or_create_series,
     update_bracket_counts,
+    update_event_game_id,
     update_market_with_versioning,
 )
+from precog.matching.event_game_matcher import EventGameMatcher
 from precog.schedulers.base_poller import BasePoller
 from precog.validation.kalshi_validation import KalshiDataValidator
 
@@ -202,6 +204,12 @@ class KalshiMarketPoller(BasePoller):
         # when creating markets (markets.event_internal_id FK).
         # See migration 0020: events now uses SERIAL PK instead of VARCHAR PK.
         self._event_id_map: dict[str, int] = {}
+
+        # Event-to-game matcher (Issue #462). Matches Kalshi events to ESPN
+        # games by parsing team codes from event tickers. The registry is
+        # loaded lazily on first poll cycle to avoid startup DB dependency.
+        self._event_game_matcher: EventGameMatcher | None = None
+        self._matcher_loaded: bool = False
 
         # Validation stats tracked separately from PollerStats TypedDict
         # to avoid type contract violations. Merged in get_stats().
@@ -738,6 +746,60 @@ class KalshiMarketPoller(BasePoller):
 
         return len(all_markets), markets_updated, markets_created
 
+    # =========================================================================
+    # Event-to-Game Matching (Issue #462)
+    # =========================================================================
+
+    def _ensure_matcher_loaded(self) -> None:
+        """Initialize and load the event-game matcher on first use.
+
+        Lazy initialization avoids DB queries during __init__ (which may
+        run before the DB is ready). The registry is loaded once and
+        cached for the lifetime of the poller.
+        """
+        if self._matcher_loaded:
+            return
+
+        try:
+            self._event_game_matcher = EventGameMatcher()
+            self._event_game_matcher.registry.load()
+            self._matcher_loaded = True
+            logger.info("Event-game matcher loaded successfully")
+        except Exception:
+            logger.warning(
+                "Failed to load event-game matcher — events will not be linked to games this cycle",
+                exc_info=True,
+            )
+            self._event_game_matcher = None
+            # Don't set _matcher_loaded so we retry next cycle
+
+    def _match_event_to_game(self, event_ticker: str, title: str | None = None) -> int | None:
+        """Try to match a Kalshi event to an ESPN game.
+
+        Lazily initializes the matcher on first call. Returns None if
+        matching fails or the matcher is unavailable (non-blocking).
+
+        Args:
+            event_ticker: Kalshi event ticker (e.g., "KXNFLGAME-26JAN18HOUNE")
+            title: Optional event title for fallback matching.
+
+        Returns:
+            games.id if matched, None otherwise.
+        """
+        self._ensure_matcher_loaded()
+        if self._event_game_matcher is None:
+            return None
+
+        try:
+            return self._event_game_matcher.match_event(event_ticker, title=title)
+        except Exception:
+            logger.debug(
+                "Event matching failed for %s (non-blocking)",
+                event_ticker,
+                exc_info=True,
+            )
+            return None
+
     def _sync_market_to_db(
         self, market: ProcessedMarketData, series_ticker: str = ""
     ) -> bool | None:
@@ -864,6 +926,11 @@ class KalshiMarketPoller(BasePoller):
                             event_ticker,
                         )
 
+                    # Attempt event-to-game matching (Issue #462)
+                    # Try to match this event to an ESPN game BEFORE creation
+                    # so game_id can be passed to create_event().
+                    game_id = self._match_event_to_game(event_ticker, market.get("title"))
+
                     event_pk, _created = get_or_create_event(
                         event_id=event_ticker,
                         platform_id=self.PLATFORM_ID,
@@ -872,12 +939,18 @@ class KalshiMarketPoller(BasePoller):
                         title=market.get("title", event_ticker),
                         series_internal_id=series_pk,  # Integer FK to series(id)
                         subcategory=subcategory,
+                        game_id=game_id,  # Link to games table (may be None)
                         metadata={
                             "series_ticker": effective_series,
                         },
                     )
                     # Cache the integer PK for subsequent markets in the same event
                     self._event_id_map[event_ticker] = event_pk
+
+                    # If event already existed with game_id=NULL and we found a
+                    # match, update it now (handles the TODO in get_or_create_event)
+                    if not _created and game_id is not None:
+                        update_event_game_id(event_pk, game_id)
 
             # Migration 0022: create_market returns int PK
             # Migration 0033: subtitle, open_time, close_time, expiration_time

--- a/tests/fixtures/testcontainers_fixtures.py
+++ b/tests/fixtures/testcontainers_fixtures.py
@@ -230,8 +230,8 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
         conference VARCHAR(50),
         division VARCHAR(50),
         espn_team_id VARCHAR(50),
+        kalshi_team_code VARCHAR(10),
         current_elo_rating DECIMAL(10,2) CHECK (current_elo_rating IS NULL OR current_elo_rating BETWEEN 0 AND 3000),
-        external_ids JSONB,
         metadata JSONB,
         created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
         updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
@@ -240,6 +240,7 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
     CREATE INDEX IF NOT EXISTS idx_teams_sport ON teams(sport);
     CREATE INDEX IF NOT EXISTS idx_teams_league ON teams(league);
     CREATE INDEX IF NOT EXISTS idx_teams_espn_id ON teams(espn_team_id);
+    CREATE INDEX IF NOT EXISTS idx_teams_kalshi_code ON teams(kalshi_team_code, league) WHERE kalshi_team_code IS NOT NULL;
     CREATE INDEX IF NOT EXISTS idx_teams_elo_rating ON teams(current_elo_rating);
     CREATE UNIQUE INDEX IF NOT EXISTS idx_teams_espn_id_league_unique ON teams(espn_team_id, league) WHERE espn_team_id IS NOT NULL;
     CREATE UNIQUE INDEX IF NOT EXISTS idx_teams_code_league_pro ON teams(team_code, league) WHERE league IN ('nfl', 'nba', 'nhl', 'wnba', 'mlb', 'mls');

--- a/tests/unit/database/test_crud_operations_unit.py
+++ b/tests/unit/database/test_crud_operations_unit.py
@@ -29,6 +29,7 @@ from precog.database.crud_operations import (
     create_game_state,
     create_team_ranking,
     create_venue,
+    find_game_by_matchup,
     game_state_changed,
     get_current_game_state,
     get_current_rankings,
@@ -38,8 +39,10 @@ from precog.database.crud_operations import (
     get_or_create_game,
     get_team_by_espn_id,
     get_team_rankings,
+    get_teams_with_kalshi_codes,
     get_venue_by_espn_id,
     get_venue_by_id,
+    update_event_game_id,
     update_game_result,
     upsert_game_state,
 )
@@ -1817,5 +1820,220 @@ class TestDeleteSchedulerStatusUnit:
         mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
 
         result = delete_scheduler_status("NONEXISTENT-HOST", "unknown_service")
+
+        assert result is False
+
+
+# =============================================================================
+# FIND GAME BY MATCHUP UNIT TESTS (Issue #462)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestFindGameByMatchupUnit:
+    """Unit tests for find_game_by_matchup — league-to-sport mapping + game lookup."""
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_nfl_maps_to_football(self, mock_fetch_one):
+        """NFL league maps to 'football' sport in query."""
+        mock_fetch_one.return_value = {"id": 42}
+
+        result = find_game_by_matchup(
+            league="nfl",
+            game_date=date(2026, 1, 18),
+            home_team_code="NE",
+            away_team_code="HOU",
+        )
+
+        assert result == 42
+        # Verify the sport param passed to query is "football"
+        call_args = mock_fetch_one.call_args[0]
+        params = call_args[1]
+        assert params[0] == "football"
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_nba_maps_to_basketball(self, mock_fetch_one):
+        """NBA league maps to 'basketball' sport in query."""
+        mock_fetch_one.return_value = {"id": 99}
+
+        result = find_game_by_matchup(
+            league="nba",
+            game_date=date(2026, 3, 25),
+            home_team_code="BOS",
+            away_team_code="OKC",
+        )
+
+        assert result == 99
+        call_args = mock_fetch_one.call_args[0]
+        params = call_args[1]
+        assert params[0] == "basketball"
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_ncaaf_maps_to_football(self, mock_fetch_one):
+        """NCAAF league maps to 'football' sport."""
+        mock_fetch_one.return_value = {"id": 7}
+
+        result = find_game_by_matchup(
+            league="ncaaf",
+            game_date=date(2026, 1, 2),
+            home_team_code="MSST",
+            away_team_code="WAKE",
+        )
+
+        assert result == 7
+        call_args = mock_fetch_one.call_args[0]
+        params = call_args[1]
+        assert params[0] == "football"
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_nhl_maps_to_hockey(self, mock_fetch_one):
+        """NHL league maps to 'hockey' sport."""
+        mock_fetch_one.return_value = {"id": 55}
+
+        result = find_game_by_matchup(
+            league="nhl",
+            game_date=date(2026, 1, 15),
+            home_team_code="TOR",
+            away_team_code="BOS",
+        )
+
+        assert result == 55
+        call_args = mock_fetch_one.call_args[0]
+        params = call_args[1]
+        assert params[0] == "hockey"
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_returns_none_when_no_match(self, mock_fetch_one):
+        """Returns None when no game found in database."""
+        mock_fetch_one.return_value = None
+
+        result = find_game_by_matchup(
+            league="nfl",
+            game_date=date(2026, 1, 18),
+            home_team_code="NE",
+            away_team_code="HOU",
+        )
+
+        assert result is None
+        mock_fetch_one.assert_called_once()
+
+    def test_returns_none_for_unknown_league(self):
+        """Returns None for league not in LEAGUE_SPORT_CATEGORY (no DB call)."""
+        result = find_game_by_matchup(
+            league="xyz_unknown",
+            game_date=date(2026, 1, 18),
+            home_team_code="NE",
+            away_team_code="HOU",
+        )
+
+        assert result is None
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_passes_all_params_to_query(self, mock_fetch_one):
+        """Verify game_date, home_team_code, away_team_code all passed."""
+        mock_fetch_one.return_value = {"id": 1}
+        target_date = date(2026, 2, 14)
+
+        find_game_by_matchup(
+            league="nba",
+            game_date=target_date,
+            home_team_code="LAL",
+            away_team_code="GSW",
+        )
+
+        call_args = mock_fetch_one.call_args[0]
+        params = call_args[1]
+        assert params == ("basketball", target_date, "LAL", "GSW")
+
+
+# =============================================================================
+# GET TEAMS WITH KALSHI CODES UNIT TESTS (Issue #462)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetTeamsWithKalshiCodesUnit:
+    """Unit tests for get_teams_with_kalshi_codes — team registry data source."""
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_returns_list_of_team_dicts(self, mock_fetch_all):
+        """Returns list of team dicts with expected keys."""
+        mock_fetch_all.return_value = [
+            {"team_id": 1, "team_code": "HOU", "league": "nfl", "kalshi_team_code": None},
+            {"team_id": 2, "team_code": "JAX", "league": "nfl", "kalshi_team_code": "JAC"},
+        ]
+
+        result = get_teams_with_kalshi_codes(league="nfl")
+
+        assert len(result) == 2
+        assert result[0]["team_code"] == "HOU"
+        assert result[1]["kalshi_team_code"] == "JAC"
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_filters_by_league(self, mock_fetch_all):
+        """When league is provided, passes it as query param."""
+        mock_fetch_all.return_value = []
+
+        get_teams_with_kalshi_codes(league="nba")
+
+        call_args = mock_fetch_all.call_args[0]
+        # Query should contain WHERE league = %s
+        sql = call_args[0]
+        assert "WHERE league" in sql
+        params = call_args[1]
+        assert params == ("nba",)
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_returns_all_when_league_none(self, mock_fetch_all):
+        """When league is None, returns all teams (no WHERE clause on league)."""
+        mock_fetch_all.return_value = [
+            {"team_id": 1, "team_code": "HOU", "league": "nfl", "kalshi_team_code": None},
+            {"team_id": 3, "team_code": "BOS", "league": "nba", "kalshi_team_code": None},
+        ]
+
+        result = get_teams_with_kalshi_codes(league=None)
+
+        assert len(result) == 2
+        call_args = mock_fetch_all.call_args[0]
+        sql = call_args[0]
+        assert "WHERE league" not in sql
+
+
+# =============================================================================
+# UPDATE EVENT GAME ID UNIT TESTS (Issue #462)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestUpdateEventGameIdUnit:
+    """Unit tests for update_event_game_id — linking events to games."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_returns_true_when_updated(self, mock_get_cursor):
+        """Returns True when event was found and updated."""
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 1
+        mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = update_event_game_id(event_internal_id=42, game_id=15)
+
+        assert result is True
+        mock_cursor.execute.assert_called_once()
+        # Verify params include game_id and event_internal_id
+        call_args = mock_cursor.execute.call_args[0]
+        params = call_args[1]
+        assert 15 in params  # game_id
+        assert 42 in params  # event_internal_id
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_returns_false_when_no_event_found(self, mock_get_cursor):
+        """Returns False when no event matched (rowcount=0)."""
+        mock_cursor = MagicMock()
+        mock_cursor.rowcount = 0
+        mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = update_event_game_id(event_internal_id=999, game_id=15)
 
         assert result is False

--- a/tests/unit/matching/__init__.py
+++ b/tests/unit/matching/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the event-to-game matching module."""

--- a/tests/unit/matching/test_event_game_matcher.py
+++ b/tests/unit/matching/test_event_game_matcher.py
@@ -1,0 +1,201 @@
+"""Unit tests for EventGameMatcher.
+
+Tests the full matching flow with mocked registry and CRUD functions.
+No database required — all external dependencies are mocked.
+
+Related:
+    - Issue #462: Event-to-game matching
+    - src/precog/matching/event_game_matcher.py
+"""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+from precog.matching.event_game_matcher import EventGameMatcher
+from precog.matching.team_code_registry import TeamCodeRegistry
+
+# =============================================================================
+# Test Data
+# =============================================================================
+
+NFL_TEAMS: list[dict] = [
+    {"team_code": "JAX", "league": "nfl", "kalshi_team_code": "JAC"},
+    {"team_code": "LAR", "league": "nfl", "kalshi_team_code": "LA"},
+    {"team_code": "HOU", "league": "nfl", "kalshi_team_code": None},
+    {"team_code": "NE", "league": "nfl", "kalshi_team_code": None},
+    {"team_code": "KC", "league": "nfl", "kalshi_team_code": None},
+    {"team_code": "BUF", "league": "nfl", "kalshi_team_code": None},
+    {"team_code": "SF", "league": "nfl", "kalshi_team_code": None},
+    {"team_code": "BAL", "league": "nfl", "kalshi_team_code": None},
+    {"team_code": "DAL", "league": "nfl", "kalshi_team_code": None},
+    {"team_code": "NYG", "league": "nfl", "kalshi_team_code": None},
+]
+
+
+def _make_registry() -> TeamCodeRegistry:
+    """Create a registry pre-loaded with test data."""
+    registry = TeamCodeRegistry()
+    registry.load_from_data(NFL_TEAMS)
+    return registry
+
+
+# =============================================================================
+# Match Event Tests
+# =============================================================================
+
+
+class TestMatchEvent:
+    """Tests for EventGameMatcher.match_event()."""
+
+    @patch("precog.matching.event_game_matcher.EventGameMatcher._find_game")
+    def test_successful_match(self, mock_find: MagicMock) -> None:
+        """Successful ticker-based match returns game_id."""
+        mock_find.return_value = 42
+
+        matcher = EventGameMatcher(registry=_make_registry())
+        result = matcher.match_event("KXNFLGAME-26JAN18HOUNE")
+
+        assert result == 42
+        mock_find.assert_called_once_with("nfl", date(2026, 1, 18), "NE", "HOU")
+
+    @patch("precog.matching.event_game_matcher.EventGameMatcher._find_game")
+    def test_match_with_kalshi_code_mismatch(self, mock_find: MagicMock) -> None:
+        """Kalshi JAC resolves to ESPN JAX before game lookup."""
+        mock_find.return_value = 99
+
+        matcher = EventGameMatcher(registry=_make_registry())
+        result = matcher.match_event("KXNFLGAME-26JAN18JACNE")
+
+        assert result == 99
+        # Should pass JAX (ESPN code) not JAC (Kalshi code)
+        mock_find.assert_called_once_with("nfl", date(2026, 1, 18), "NE", "JAX")
+
+    @patch("precog.matching.event_game_matcher.EventGameMatcher._find_game")
+    def test_match_la_rams(self, mock_find: MagicMock) -> None:
+        """Kalshi LA resolves to ESPN LAR for Rams."""
+        mock_find.return_value = 55
+
+        matcher = EventGameMatcher(registry=_make_registry())
+        result = matcher.match_event("KXNFLGAME-26JAN18LASF")
+
+        assert result == 55
+        mock_find.assert_called_once_with("nfl", date(2026, 1, 18), "SF", "LAR")
+
+    def test_no_match_non_sports(self) -> None:
+        """Non-sports ticker returns None."""
+        matcher = EventGameMatcher(registry=_make_registry())
+        result = matcher.match_event("KXPOLITICS-PRES2028")
+        assert result is None
+
+    def test_no_match_empty_ticker(self) -> None:
+        matcher = EventGameMatcher(registry=_make_registry())
+        result = matcher.match_event("")
+        assert result is None
+
+    @patch("precog.matching.event_game_matcher.EventGameMatcher._find_game")
+    def test_no_match_game_not_found(self, mock_find: MagicMock) -> None:
+        """Ticker parses but no game exists in DB."""
+        mock_find.return_value = None
+
+        matcher = EventGameMatcher(registry=_make_registry())
+        result = matcher.match_event("KXNFLGAME-26JAN18HOUNE")
+
+        assert result is None
+
+    def test_no_match_empty_registry(self) -> None:
+        """Empty registry can't resolve any codes."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data([])
+        matcher = EventGameMatcher(registry=registry)
+        result = matcher.match_event("KXNFLGAME-26JAN18HOUNE")
+        assert result is None
+
+    def test_title_fallback_stub_returns_none(self) -> None:
+        """Title-based fallback is stubbed — always returns None."""
+        matcher = EventGameMatcher(registry=_make_registry())
+        # Even with a title, should return None since title parsing is TODO
+        result = matcher.match_event(
+            "KXUNKNOWNSERIES-26JAN18",
+            title="Texans vs Patriots",
+        )
+        assert result is None
+
+
+# =============================================================================
+# Backfill Tests
+# =============================================================================
+
+
+class TestBackfillUnlinkedEvents:
+    """Tests for EventGameMatcher.backfill_unlinked_events()."""
+
+    @patch("precog.database.crud_operations.update_event_game_id")
+    @patch("precog.database.crud_operations.find_unlinked_sports_events")
+    def test_backfill_links_events(
+        self,
+        mock_find_unlinked: MagicMock,
+        mock_update: MagicMock,
+    ) -> None:
+        """Backfill finds unlinked events and links them."""
+        mock_find_unlinked.return_value = [
+            {
+                "id": 1,
+                "event_id": "KXNFLGAME-26JAN18HOUNE",
+                "title": "HOU @ NE",
+                "subcategory": "nfl",
+            },
+            {
+                "id": 2,
+                "event_id": "KXNFLGAME-26JAN18KCBUF",
+                "title": "KC @ BUF",
+                "subcategory": "nfl",
+            },
+        ]
+        mock_update.return_value = True
+
+        matcher = EventGameMatcher(registry=_make_registry())
+
+        with patch.object(matcher, "_find_game", return_value=42):
+            count = matcher.backfill_unlinked_events("nfl")
+
+        assert count == 2
+        assert mock_update.call_count == 2
+
+    @patch("precog.database.crud_operations.update_event_game_id")
+    @patch("precog.database.crud_operations.find_unlinked_sports_events")
+    def test_backfill_no_unlinked(
+        self,
+        mock_find_unlinked: MagicMock,
+        mock_update: MagicMock,
+    ) -> None:
+        """No unlinked events means zero linked."""
+        mock_find_unlinked.return_value = []
+
+        matcher = EventGameMatcher(registry=_make_registry())
+        count = matcher.backfill_unlinked_events("nfl")
+
+        assert count == 0
+        mock_update.assert_not_called()
+
+    @patch("precog.database.crud_operations.update_event_game_id")
+    @patch("precog.database.crud_operations.find_unlinked_sports_events")
+    def test_backfill_partial_match(
+        self,
+        mock_find_unlinked: MagicMock,
+        mock_update: MagicMock,
+    ) -> None:
+        """Some events match, some don't."""
+        mock_find_unlinked.return_value = [
+            {"id": 1, "event_id": "KXNFLGAME-26JAN18HOUNE", "title": None, "subcategory": "nfl"},
+            {"id": 2, "event_id": "KXPOLITICS-UNKNOWN", "title": None, "subcategory": "politics"},
+        ]
+        mock_update.return_value = True
+
+        matcher = EventGameMatcher(registry=_make_registry())
+
+        # Only the first event will parse successfully
+        with patch.object(matcher, "_find_game", return_value=42):
+            count = matcher.backfill_unlinked_events()
+
+        # Only 1 match (the NFL event), politics ticker won't parse
+        assert count == 1

--- a/tests/unit/matching/test_team_code_registry.py
+++ b/tests/unit/matching/test_team_code_registry.py
@@ -1,0 +1,252 @@
+"""Unit tests for TeamCodeRegistry.
+
+Tests the in-memory cache of team code mappings used for matching
+Kalshi events to games. Uses load_from_data() to avoid DB dependency.
+
+Related:
+    - Issue #462: Event-to-game matching
+    - src/precog/matching/team_code_registry.py
+"""
+
+from precog.matching.team_code_registry import TeamCodeRegistry
+
+# =============================================================================
+# Test Data
+# =============================================================================
+
+NFL_TEAMS: list[dict] = [
+    {"team_code": "JAX", "league": "nfl", "kalshi_team_code": "JAC"},
+    {"team_code": "LAR", "league": "nfl", "kalshi_team_code": "LA"},
+    {"team_code": "HOU", "league": "nfl", "kalshi_team_code": None},
+    {"team_code": "NE", "league": "nfl", "kalshi_team_code": None},
+    {"team_code": "KC", "league": "nfl", "kalshi_team_code": None},
+    {"team_code": "BUF", "league": "nfl", "kalshi_team_code": None},
+    {"team_code": "SF", "league": "nfl", "kalshi_team_code": None},
+]
+
+NBA_TEAMS: list[dict] = [
+    {"team_code": "BOS", "league": "nba", "kalshi_team_code": None},
+    {"team_code": "OKC", "league": "nba", "kalshi_team_code": None},
+    {"team_code": "LAL", "league": "nba", "kalshi_team_code": None},
+]
+
+# NCAAF teams with 4-char Kalshi codes
+NCAAF_TEAMS: list[dict] = [
+    {"team_code": "WF", "league": "ncaaf", "kalshi_team_code": "WAKE"},
+    {"team_code": "MSST", "league": "ncaaf", "kalshi_team_code": None},
+    {"team_code": "TXST", "league": "ncaaf", "kalshi_team_code": None},
+    {"team_code": "RICE", "league": "ncaaf", "kalshi_team_code": None},
+]
+
+
+class TestTeamCodeRegistry:
+    """Tests for TeamCodeRegistry."""
+
+    def test_load_from_data(self) -> None:
+        """Registry loads data and reports as loaded."""
+        registry = TeamCodeRegistry()
+        assert not registry.is_loaded
+
+        registry.load_from_data(NFL_TEAMS + NBA_TEAMS)
+        assert registry.is_loaded
+
+    def test_resolve_known_mismatch_jac(self) -> None:
+        """JAC (Kalshi) resolves to JAX (ESPN)."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+
+        result = registry.resolve_kalshi_to_espn("JAC", "nfl")
+        assert result == "JAX"
+
+    def test_resolve_known_mismatch_la(self) -> None:
+        """LA (Kalshi) resolves to LAR (ESPN)."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+
+        result = registry.resolve_kalshi_to_espn("LA", "nfl")
+        assert result == "LAR"
+
+    def test_resolve_matching_code(self) -> None:
+        """HOU resolves to HOU (same on both platforms)."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+
+        result = registry.resolve_kalshi_to_espn("HOU", "nfl")
+        assert result == "HOU"
+
+    def test_resolve_two_char_code(self) -> None:
+        """NE and KC (2-char codes) resolve correctly."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+
+        assert registry.resolve_kalshi_to_espn("NE", "nfl") == "NE"
+        assert registry.resolve_kalshi_to_espn("KC", "nfl") == "KC"
+
+    def test_resolve_unknown_code(self) -> None:
+        """Unknown code returns None."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+
+        result = registry.resolve_kalshi_to_espn("ZZZ", "nfl")
+        assert result is None
+
+    def test_resolve_wrong_league(self) -> None:
+        """Code from wrong league returns None."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+
+        # HOU exists in NFL but we ask for NBA
+        result = registry.resolve_kalshi_to_espn("HOU", "nba")
+        assert result is None
+
+    def test_resolve_case_insensitive(self) -> None:
+        """Lookup should work regardless of input case."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+
+        assert registry.resolve_kalshi_to_espn("hou", "nfl") == "HOU"
+        assert registry.resolve_kalshi_to_espn("jac", "nfl") == "JAX"
+
+    def test_get_kalshi_codes_nfl(self) -> None:
+        """Get all valid Kalshi codes for NFL."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+
+        codes = registry.get_kalshi_codes("nfl")
+        # Explicit mismatches use Kalshi code
+        assert "JAC" in codes  # Kalshi code for Jacksonville
+        assert "LA" in codes  # Kalshi code for Rams
+        # Matching codes are in the set as-is
+        assert "HOU" in codes
+        assert "NE" in codes
+        assert "KC" in codes
+        assert "BUF" in codes
+        assert "SF" in codes
+        # ESPN codes for mismatched teams are NOT in the set
+        assert "JAX" not in codes
+        assert "LAR" not in codes
+
+    def test_get_kalshi_codes_nba(self) -> None:
+        """Get all valid Kalshi codes for NBA."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS + NBA_TEAMS)
+
+        codes = registry.get_kalshi_codes("nba")
+        assert "BOS" in codes
+        assert "OKC" in codes
+        assert "LAL" in codes
+        assert len(codes) == 3
+
+    def test_get_kalshi_codes_unknown_league(self) -> None:
+        """Unknown league returns empty set."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+
+        codes = registry.get_kalshi_codes("mlb")
+        assert codes == set()
+
+    def test_multi_league_isolation(self) -> None:
+        """Codes for different leagues don't interfere."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS + NBA_TEAMS)
+
+        nfl_codes = registry.get_kalshi_codes("nfl")
+        nba_codes = registry.get_kalshi_codes("nba")
+
+        # NFL has JAC, NBA doesn't
+        assert "JAC" in nfl_codes
+        assert "JAC" not in nba_codes
+
+        # NBA has BOS, NFL doesn't (in our test data)
+        assert "BOS" in nba_codes
+        assert "BOS" not in nfl_codes
+
+    def test_empty_data(self) -> None:
+        """Loading empty data yields empty registry."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data([])
+        assert registry.is_loaded
+        assert registry.get_kalshi_codes("nfl") == set()
+
+    def test_teams_without_league_skipped(self) -> None:
+        """Teams with missing league are skipped."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(
+            [
+                {"team_code": "TST", "league": "", "kalshi_team_code": None},
+                {"team_code": "HOU", "league": "nfl", "kalshi_team_code": None},
+            ]
+        )
+        assert registry.resolve_kalshi_to_espn("TST", "") is None
+        assert registry.resolve_kalshi_to_espn("HOU", "nfl") == "HOU"
+
+    def test_ncaaf_four_char_kalshi_code_resolves(self) -> None:
+        """NCAAF 4-char Kalshi code (WAKE) resolves to ESPN code (WF)."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NCAAF_TEAMS)
+
+        result = registry.resolve_kalshi_to_espn("WAKE", "ncaaf")
+        assert result == "WF"
+
+    def test_ncaaf_matching_code_resolves(self) -> None:
+        """NCAAF team where Kalshi code matches ESPN code."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NCAAF_TEAMS)
+
+        assert registry.resolve_kalshi_to_espn("MSST", "ncaaf") == "MSST"
+        assert registry.resolve_kalshi_to_espn("TXST", "ncaaf") == "TXST"
+        assert registry.resolve_kalshi_to_espn("RICE", "ncaaf") == "RICE"
+
+    def test_get_kalshi_codes_ncaaf(self) -> None:
+        """Get all valid Kalshi codes for NCAAF including 4-char codes."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NCAAF_TEAMS)
+
+        codes = registry.get_kalshi_codes("ncaaf")
+        assert "WAKE" in codes  # 4-char Kalshi code
+        assert "MSST" in codes  # 4-char matching code
+        assert "TXST" in codes
+        assert "RICE" in codes
+        assert len(codes) == 4
+        # ESPN code for mismatched team should NOT be in the set
+        assert "WF" not in codes
+
+    def test_ncaaf_codes_isolated_from_nfl(self) -> None:
+        """NCAAF codes don't leak into NFL results and vice versa."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS + NCAAF_TEAMS)
+
+        nfl_codes = registry.get_kalshi_codes("nfl")
+        ncaaf_codes = registry.get_kalshi_codes("ncaaf")
+
+        # NCAAF-only codes should not appear in NFL
+        assert "WAKE" not in nfl_codes
+        assert "MSST" not in nfl_codes
+        assert "TXST" not in nfl_codes
+        assert "RICE" not in nfl_codes
+
+        # NFL-only codes should not appear in NCAAF
+        assert "JAC" not in ncaaf_codes
+        assert "LA" not in ncaaf_codes
+
+    def test_ncaaf_resolve_wrong_league_returns_none(self) -> None:
+        """NCAAF Kalshi code queried with NFL league returns None."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS + NCAAF_TEAMS)
+
+        # WAKE is NCAAF, not NFL
+        assert registry.resolve_kalshi_to_espn("WAKE", "nfl") is None
+        # JAC is NFL, not NCAAF
+        assert registry.resolve_kalshi_to_espn("JAC", "ncaaf") is None
+
+    def test_reload_replaces_data(self) -> None:
+        """Loading new data replaces old data."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+        assert "JAC" in registry.get_kalshi_codes("nfl")
+
+        # Reload with only NBA data
+        registry.load_from_data(NBA_TEAMS)
+        # NFL data should be gone
+        assert registry.get_kalshi_codes("nfl") == set()
+        assert "BOS" in registry.get_kalshi_codes("nba")

--- a/tests/unit/matching/test_ticker_parser.py
+++ b/tests/unit/matching/test_ticker_parser.py
@@ -1,0 +1,488 @@
+"""Unit tests for Kalshi event ticker parser.
+
+Tests the parsing of Kalshi event tickers into structured game data:
+    - League extraction from series prefix
+    - Date parsing from ticker segments
+    - Team code splitting with variable-length codes
+    - Edge cases: invalid tickers, ambiguous splits, date boundaries
+
+Related:
+    - Issue #462: Event-to-game matching
+    - src/precog/matching/ticker_parser.py
+"""
+
+from datetime import date
+
+import pytest
+
+from precog.matching.ticker_parser import (
+    ParsedTicker,
+    _extract_league,
+    _parse_date_segment,
+    parse_event_ticker,
+    split_team_codes,
+)
+
+# =============================================================================
+# Valid code sets for testing
+# =============================================================================
+
+# NFL Kalshi codes (verified from live API data)
+NFL_CODES: set[str] = {
+    "ARI",
+    "ATL",
+    "BAL",
+    "BUF",
+    "CAR",
+    "CHI",
+    "CIN",
+    "CLE",
+    "DAL",
+    "DEN",
+    "DET",
+    "GB",
+    "HOU",
+    "IND",
+    "JAC",
+    "KC",
+    "LA",
+    "LAC",
+    "LV",
+    "MIA",
+    "MIN",
+    "NE",
+    "NYG",
+    "NYJ",
+    "NO",
+    "PHI",
+    "PIT",
+    "SEA",
+    "SF",
+    "TB",
+    "TEN",
+    "WAS",
+}
+
+# NBA Kalshi codes
+NBA_CODES: set[str] = {
+    "ATL",
+    "BOS",
+    "BKN",
+    "CHA",
+    "CHI",
+    "CLE",
+    "DAL",
+    "DEN",
+    "DET",
+    "GSW",
+    "HOU",
+    "IND",
+    "LAC",
+    "LAL",
+    "MEM",
+    "MIA",
+    "MIL",
+    "MIN",
+    "NOP",
+    "NYK",
+    "OKC",
+    "ORL",
+    "PHI",
+    "PHX",
+    "POR",
+    "SAC",
+    "SAS",
+    "TOR",
+    "UTA",
+    "WAS",
+}
+
+# NHL Kalshi codes (subset for testing)
+NHL_CODES: set[str] = {
+    "BOS",
+    "NYR",
+    "TOR",
+    "MTL",
+    "DET",
+    "CHI",
+    "TB",
+    "FLA",
+    "CAR",
+    "WSH",
+}
+
+# MLB Kalshi codes (subset for testing)
+MLB_CODES: set[str] = {
+    "NYY",
+    "BOS",
+    "LAD",
+    "SF",
+    "CHC",
+    "STL",
+    "HOU",
+    "ATL",
+    "NYM",
+    "PHI",
+}
+
+# NCAAF codes (subset for testing variable-length)
+NCAAF_CODES: set[str] = {
+    "WAKE",
+    "MSST",
+    "ALA",
+    "LSU",
+    "OHIO",
+    "MICH",
+    "USC",
+    "ND",
+    "TXST",
+    "RICE",
+    "ARMY",
+    "NAVY",
+}
+
+
+# =============================================================================
+# League Extraction Tests
+# =============================================================================
+
+
+class TestExtractLeague:
+    """Tests for _extract_league()."""
+
+    def test_nfl_game(self) -> None:
+        assert _extract_league("KXNFLGAME") == "nfl"
+
+    def test_nba_game(self) -> None:
+        assert _extract_league("KXNBAGAME") == "nba"
+
+    def test_ncaaf_game(self) -> None:
+        assert _extract_league("KXNCAAFGAME") == "ncaaf"
+
+    def test_ncaaf_d3_game(self) -> None:
+        """NCAAF Division 3 variant."""
+        assert _extract_league("KXNCAAFD3GAME") == "ncaaf"
+
+    def test_nba_2h_winner(self) -> None:
+        """NBA second half winner series."""
+        assert _extract_league("KXNBA2HWINNER") == "nba"
+
+    def test_nhl_game(self) -> None:
+        assert _extract_league("KXNHLGAME") == "nhl"
+
+    def test_mlb_game(self) -> None:
+        assert _extract_league("KXMLBGAME") == "mlb"
+
+    def test_ncaab_game(self) -> None:
+        assert _extract_league("KXNCAABGAME") == "ncaab"
+
+    def test_unknown_series(self) -> None:
+        assert _extract_league("KXPOLITICS") is None
+
+    def test_empty_string(self) -> None:
+        assert _extract_league("") is None
+
+    def test_case_insensitive(self) -> None:
+        """Series prefix matching should be case-insensitive."""
+        assert _extract_league("kxnflgame") == "nfl"
+
+
+# =============================================================================
+# Date Parsing Tests
+# =============================================================================
+
+
+class TestParseDateSegment:
+    """Tests for _parse_date_segment()."""
+
+    def test_standard_date(self) -> None:
+        result = _parse_date_segment("26JAN18HOUNE")
+        assert result is not None
+        parsed_date, remaining = result
+        assert parsed_date == date(2026, 1, 18)
+        assert remaining == "HOUNE"
+
+    def test_december_31(self) -> None:
+        """Year boundary: Dec 31."""
+        result = _parse_date_segment("25DEC31DALNYG")
+        assert result is not None
+        parsed_date, remaining = result
+        assert parsed_date == date(2025, 12, 31)
+        assert remaining == "DALNYG"
+
+    def test_january_01(self) -> None:
+        """Year boundary: Jan 1."""
+        result = _parse_date_segment("26JAN01KCBUF")
+        assert result is not None
+        parsed_date, remaining = result
+        assert parsed_date == date(2026, 1, 1)
+        assert remaining == "KCBUF"
+
+    def test_february_date(self) -> None:
+        result = _parse_date_segment("26FEB14MIANE")
+        assert result is not None
+        parsed_date, remaining = result
+        assert parsed_date == date(2026, 2, 14)
+        assert remaining == "MIANE"
+
+    def test_invalid_month(self) -> None:
+        result = _parse_date_segment("26XXX18HOUNE")
+        assert result is None
+
+    def test_invalid_day(self) -> None:
+        """Feb 30 is not a valid date."""
+        result = _parse_date_segment("26FEB30HOUNE")
+        assert result is None
+
+    def test_empty_remaining(self) -> None:
+        """Date with no team codes after it."""
+        result = _parse_date_segment("26JAN18")
+        assert result is not None
+        parsed_date, remaining = result
+        assert parsed_date == date(2026, 1, 18)
+        assert remaining == ""
+
+    def test_empty_string(self) -> None:
+        assert _parse_date_segment("") is None
+
+    def test_no_date_prefix(self) -> None:
+        assert _parse_date_segment("HOUNE") is None
+
+
+# =============================================================================
+# Team Code Splitting Tests
+# =============================================================================
+
+
+class TestSplitTeamCodes:
+    """Tests for split_team_codes()."""
+
+    def test_3_char_plus_2_char(self) -> None:
+        """HOU (3) + NE (2) = HOUNE."""
+        result = split_team_codes("HOUNE", NFL_CODES)
+        assert result == ("HOU", "NE")
+
+    def test_2_char_plus_3_char(self) -> None:
+        """KC (2) + BUF (3) = KCBUF."""
+        result = split_team_codes("KCBUF", NFL_CODES)
+        assert result == ("KC", "BUF")
+
+    def test_2_char_plus_2_char(self) -> None:
+        """NE (2) + SF (2) = NESF."""
+        result = split_team_codes("NESF", NFL_CODES)
+        assert result == ("NE", "SF")
+
+    def test_2_char_plus_2_char_gb_kc(self) -> None:
+        """GB (2) + KC (2) = GBKC."""
+        result = split_team_codes("GBKC", NFL_CODES)
+        assert result == ("GB", "KC")
+
+    def test_3_char_plus_3_char(self) -> None:
+        """OKC (3) + BOS (3) = OKCBOS."""
+        result = split_team_codes("OKCBOS", NBA_CODES)
+        assert result == ("OKC", "BOS")
+
+    def test_4_char_plus_4_char_ncaaf(self) -> None:
+        """WAKE (4) + MSST (4) = WAKEMSST."""
+        result = split_team_codes("WAKEMSST", NCAAF_CODES)
+        assert result == ("WAKE", "MSST")
+
+    def test_4_char_plus_4_char_txst_rice(self) -> None:
+        """TXST (4) + RICE (4) = TXSTRICE."""
+        result = split_team_codes("TXSTRICE", NCAAF_CODES)
+        assert result == ("TXST", "RICE")
+
+    def test_3_char_plus_2_char_lv_tb(self) -> None:
+        """LV (2) + TB (2) = LVTB."""
+        result = split_team_codes("LVTB", NFL_CODES)
+        assert result == ("LV", "TB")
+
+    def test_no_valid_split(self) -> None:
+        """No valid split found returns None."""
+        result = split_team_codes("ZZZYY", NFL_CODES)
+        assert result is None
+
+    def test_too_short(self) -> None:
+        """Fewer than 4 chars can't be split into two valid codes."""
+        result = split_team_codes("ABC", NFL_CODES)
+        assert result is None
+
+    def test_empty_string(self) -> None:
+        result = split_team_codes("", NFL_CODES)
+        assert result is None
+
+    def test_case_insensitive(self) -> None:
+        """Should work regardless of input case."""
+        result = split_team_codes("houne", NFL_CODES)
+        assert result == ("HOU", "NE")
+
+    def test_ambiguous_split_returns_none(self) -> None:
+        """If multiple valid splits exist, return None (ambiguous).
+
+        This is a contrived example. In practice, ambiguity is rare
+        because real team code sets are designed to avoid collisions.
+        """
+        # Create a code set that makes "ABCDE" ambiguous:
+        # AB + CDE and ABC + DE both valid
+        ambiguous_codes = {"AB", "CDE", "ABC", "DE"}
+        result = split_team_codes("ABCDE", ambiguous_codes)
+        assert result is None
+
+
+# =============================================================================
+# Full Ticker Parsing Tests
+# =============================================================================
+
+
+class TestParseEventTicker:
+    """Tests for parse_event_ticker()."""
+
+    def test_nfl_ticker(self) -> None:
+        """Standard NFL game ticker."""
+        result = parse_event_ticker("KXNFLGAME-26JAN18HOUNE", NFL_CODES)
+        assert result is not None
+        assert result == ParsedTicker(
+            series="KXNFLGAME",
+            league="nfl",
+            game_date=date(2026, 1, 18),
+            away_team_code="HOU",
+            home_team_code="NE",
+        )
+
+    def test_nba_ticker(self) -> None:
+        """Standard NBA game ticker."""
+        result = parse_event_ticker("KXNBAGAME-26MAR25OKCBOS", NBA_CODES)
+        assert result is not None
+        assert result.league == "nba"
+        assert result.game_date == date(2026, 3, 25)
+        assert result.away_team_code == "OKC"
+        assert result.home_team_code == "BOS"
+
+    def test_ncaaf_ticker_variable_length(self) -> None:
+        """NCAAF with 4-char codes."""
+        result = parse_event_ticker("KXNCAAFGAME-26JAN02WAKEMSST", NCAAF_CODES)
+        assert result is not None
+        assert result.league == "ncaaf"
+        assert result.game_date == date(2026, 1, 2)
+        assert result.away_team_code == "WAKE"
+        assert result.home_team_code == "MSST"
+
+    def test_ncaaf_d3_series(self) -> None:
+        """NCAAF Division 3 series variant."""
+        result = parse_event_ticker("KXNCAAFD3GAME-26JAN02ARMYNAVY", NCAAF_CODES)
+        assert result is not None
+        assert result.league == "ncaaf"
+        assert result.series == "KXNCAAFD3GAME"
+        assert result.away_team_code == "ARMY"
+        assert result.home_team_code == "NAVY"
+
+    def test_nba_2h_winner_series(self) -> None:
+        """NBA second-half winner series variant."""
+        result = parse_event_ticker("KXNBA2HWINNER-26MAR25OKCBOS", NBA_CODES)
+        assert result is not None
+        assert result.league == "nba"
+        assert result.series == "KXNBA2HWINNER"
+
+    def test_year_boundary_dec31(self) -> None:
+        """Dec 31 date parsing."""
+        result = parse_event_ticker("KXNFLGAME-25DEC31DALNYG", NFL_CODES)
+        assert result is not None
+        assert result.game_date == date(2025, 12, 31)
+
+    def test_year_boundary_jan01(self) -> None:
+        """Jan 1 date parsing."""
+        result = parse_event_ticker("KXNFLGAME-26JAN01KCBUF", NFL_CODES)
+        assert result is not None
+        assert result.game_date == date(2026, 1, 1)
+
+    def test_two_char_codes(self) -> None:
+        """Shortest possible team codes (2 + 2)."""
+        result = parse_event_ticker("KXNFLGAME-26JAN18NESF", NFL_CODES)
+        assert result is not None
+        assert result.away_team_code == "NE"
+        assert result.home_team_code == "SF"
+
+    def test_empty_string(self) -> None:
+        result = parse_event_ticker("", NFL_CODES)
+        assert result is None
+
+    def test_none_input(self) -> None:
+        result = parse_event_ticker(None, NFL_CODES)  # type: ignore[arg-type]
+        assert result is None
+
+    def test_non_sports_ticker(self) -> None:
+        """Non-sports ticker (politics, crypto, etc.)."""
+        result = parse_event_ticker("KXPOLITICS-PRES2028", NFL_CODES)
+        assert result is None
+
+    def test_no_hyphen(self) -> None:
+        """Ticker with no hyphen separator."""
+        result = parse_event_ticker("KXNFLGAME26JAN18HOUNE", NFL_CODES)
+        assert result is None
+
+    def test_malformed_date(self) -> None:
+        """Invalid date in ticker."""
+        result = parse_event_ticker("KXNFLGAME-26XXX18HOUNE", NFL_CODES)
+        assert result is None
+
+    def test_no_team_segment(self) -> None:
+        """Ticker with date but no team codes."""
+        result = parse_event_ticker("KXNFLGAME-26JAN18", NFL_CODES)
+        assert result is None
+
+    def test_no_valid_codes_provided(self) -> None:
+        """Without valid codes, can't split teams."""
+        result = parse_event_ticker("KXNFLGAME-26JAN18HOUNE", None)
+        assert result is None
+
+    def test_empty_valid_codes(self) -> None:
+        """Empty code set yields no match."""
+        result = parse_event_ticker("KXNFLGAME-26JAN18HOUNE", set())
+        assert result is None
+
+    def test_nhl_ticker(self) -> None:
+        """Standard NHL game ticker."""
+        result = parse_event_ticker("KXNHLGAME-26JAN15BOSTOR", NHL_CODES)
+        assert result is not None
+        assert result == ParsedTicker(
+            series="KXNHLGAME",
+            league="nhl",
+            game_date=date(2026, 1, 15),
+            away_team_code="BOS",
+            home_team_code="TOR",
+        )
+
+    def test_nhl_two_char_codes(self) -> None:
+        """NHL ticker with short team codes (TB + 3-char)."""
+        result = parse_event_ticker("KXNHLGAME-26FEB20TBFLA", NHL_CODES)
+        assert result is not None
+        assert result.league == "nhl"
+        assert result.away_team_code == "TB"
+        assert result.home_team_code == "FLA"
+
+    def test_mlb_ticker(self) -> None:
+        """Standard MLB game ticker."""
+        result = parse_event_ticker("KXMLBGAME-26APR05NYYHOU", MLB_CODES)
+        assert result is not None
+        assert result == ParsedTicker(
+            series="KXMLBGAME",
+            league="mlb",
+            game_date=date(2026, 4, 5),
+            away_team_code="NYY",
+            home_team_code="HOU",
+        )
+
+    def test_mlb_three_char_codes(self) -> None:
+        """MLB ticker with two 3-char codes."""
+        result = parse_event_ticker("KXMLBGAME-26JUN15LADNYM", MLB_CODES)
+        assert result is not None
+        assert result.league == "mlb"
+        assert result.away_team_code == "LAD"
+        assert result.home_team_code == "NYM"
+
+    def test_parsed_ticker_is_frozen(self) -> None:
+        """ParsedTicker should be immutable (frozen dataclass)."""
+        result = parse_event_ticker("KXNFLGAME-26JAN18HOUNE", NFL_CODES)
+        assert result is not None
+        with pytest.raises(AttributeError):
+            result.league = "nba"  # type: ignore[misc]

--- a/tests/unit/schedulers/test_kalshi_poller.py
+++ b/tests/unit/schedulers/test_kalshi_poller.py
@@ -922,3 +922,34 @@ class TestKalshiPollerValidation:
 
         # Market was still created despite alert failure
         mock_create.assert_called_once()
+
+
+# =============================================================================
+# Event-to-Game Matching Tests (Issue #462)
+# =============================================================================
+
+
+class TestEventGameMatching:
+    """Test that game_id flows from _match_event_to_game through to get_or_create_event."""
+
+    @pytest.mark.unit
+    def test_game_id_flows_to_get_or_create_event(self, poller_with_mock_client, mock_market_data):
+        """When _match_event_to_game returns a game_id, get_or_create_event receives it."""
+        with (
+            patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None),
+            patch(
+                "precog.schedulers.kalshi_poller.get_or_create_event",
+                return_value=(1, True),
+            ) as mock_create_event,
+            patch("precog.schedulers.kalshi_poller.create_market", return_value=1),
+            patch.object(
+                poller_with_mock_client,
+                "_match_event_to_game",
+                return_value=42,
+            ),
+        ):
+            poller_with_mock_client._sync_market_to_db(mock_market_data)
+
+            mock_create_event.assert_called_once()
+            call_kwargs = mock_create_event.call_args.kwargs
+            assert call_kwargs["game_id"] == 42


### PR DESCRIPTION
## Summary
- Add `src/precog/matching/` module that links Kalshi events to ESPN games by parsing event_ticker patterns (e.g., `KXNFLGAME-26JAN18HOUNE` → HOU at NE on 2026-01-18)
- Migration 0041: Add `kalshi_team_code VARCHAR(10)` to teams table + drop unused `external_ids JSONB`
- Kalshi poller integration: automatic matching at event creation time with lazy initialization
- 98 new unit tests covering ticker parsing, team code registry, event-game matching, CRUD functions, and poller integration

Closes #462

## Design Decisions
- **Option A chosen**: `kalshi_team_code` column on teams table (follows `espn_team_id` precedent)
- **Three-phase matching**: ticker parsing (primary) → title fallback (TODO) → batch reconciliation
- **ESPN codes remain canonical**: Kalshi codes translate to ESPN via registry lookup
- **Dedicated module**: `src/precog/matching/` with ticker_parser, team_code_registry, event_game_matcher

## Known Kalshi Code Mismatches (NFL)
| Team | Kalshi | ESPN/DB |
|------|--------|---------|
| Jacksonville | JAC | JAX |
| LA Rams | LA | LAR |

## Test plan
- [x] 76 matching module unit tests (ticker parser, registry, matcher)
- [x] 12 new CRUD unit tests (find_game_by_matchup, get_teams_with_kalshi_codes, update_event_game_id)
- [x] 1 poller integration test (game_id flow verification)
- [x] Full unit suite: 2,257 passed, 0 regressions
- [x] Integration + E2E: 982 passed, 20 skipped
- [x] Ruff lint + format clean, Mypy clean
- [x] All 17 pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)