### PR TITLE
fix: Replace executemany with execute_values for accurate batch rowcount (#472)

### DIFF
--- a/src/precog/database/crud_operations.py
+++ b/src/precog/database/crud_operations.py
@@ -263,6 +263,7 @@ from decimal import Decimal
 from typing import Any, Literal, cast
 
 import psycopg2.errors
+from psycopg2.extras import execute_values
 
 from .connection import fetch_all, fetch_one, get_cursor
 
@@ -7275,7 +7276,8 @@ def insert_temporal_alignment_batch(alignments: list[dict]) -> int:
             - game_id (int | None) — FK to games(id), denormalized from events
 
     Returns:
-        Count of rows inserted.
+        Count of rows submitted for insertion (not deduplicated — this table
+        has no ON CONFLICT clause, so all submitted rows are inserted).
 
     Raises:
         TypeError: If Decimal fields are not Decimal type
@@ -7545,8 +7547,8 @@ def upsert_market_trades_batch(trades: list[dict]) -> int:
     """
     Bulk insert public market trades, skipping duplicates (idempotent).
 
-    Validates all rows before inserting any. Uses executemany with
-    ON CONFLICT DO NOTHING for safe bulk ingestion.
+    Validates all rows before inserting any. Uses execute_values with
+    ON CONFLICT DO NOTHING for safe bulk ingestion and accurate rowcount.
 
     Args:
         trades: List of dicts, each with keys:
@@ -7605,12 +7607,16 @@ def upsert_market_trades_batch(trades: list[dict]) -> int:
                 f"taker_side must be one of {_VALID_TAKER_SIDES}, got '{taker_side}' in trades[{i}]"
             )
 
+        count = row["count"]
+        if not isinstance(count, int) or count <= 0:
+            raise ValueError(f"count must be a positive integer, got {count!r} in trades[{i}]")
+
         validated_params.append(
             (
                 row["platform_id"],
                 row["external_trade_id"],
                 row["market_internal_id"],
-                row["count"],
+                count,
                 yes_price,
                 no_price,
                 taker_side,
@@ -7624,12 +7630,14 @@ def upsert_market_trades_batch(trades: list[dict]) -> int:
             count, yes_price, no_price, taker_side,
             trade_time
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        VALUES %s
         ON CONFLICT (platform_id, external_trade_id) DO NOTHING
     """
 
+    template = "(%s, %s, %s, %s, %s, %s, %s, %s)"
+
     with get_cursor(commit=True) as cur:
-        cur.executemany(insert_query, validated_params)
+        execute_values(cur, insert_query, validated_params, template=template)
         return cast("int", cur.rowcount)
 
 

--- a/tests/unit/database/test_market_trades_crud.py
+++ b/tests/unit/database/test_market_trades_crud.py
@@ -205,8 +205,9 @@ class TestUpsertMarketTrade:
 class TestUpsertMarketTradesBatch:
     """Unit tests for upsert_market_trades_batch function."""
 
+    @patch("precog.database.crud_operations.execute_values")
     @patch("precog.database.crud_operations.get_cursor")
-    def test_batch_returns_rowcount(self, mock_get_cursor):
+    def test_batch_returns_rowcount(self, mock_get_cursor, mock_exec_values):
         """Test batch insert returns cur.rowcount (actual inserts, not skipped)."""
         mock_cursor = _mock_cursor_context(mock_get_cursor)
         mock_cursor.rowcount = 2
@@ -217,6 +218,7 @@ class TestUpsertMarketTradesBatch:
         result = upsert_market_trades_batch(rows)
 
         assert result == 2
+        mock_exec_values.assert_called_once()
 
     def test_batch_empty_list_returns_zero(self):
         """Test that empty list returns 0 without DB interaction."""
@@ -257,32 +259,37 @@ class TestUpsertMarketTradesBatch:
         with pytest.raises(ValueError, match="taker_side must be one of"):
             upsert_market_trades_batch([row])
 
+    @patch("precog.database.crud_operations.execute_values")
     @patch("precog.database.crud_operations.get_cursor")
-    def test_batch_calls_executemany(self, mock_get_cursor):
-        """Test that batch insert uses executemany for efficiency."""
+    def test_batch_calls_execute_values(self, mock_get_cursor, mock_exec_values):
+        """Test that batch insert uses execute_values for accurate rowcount."""
         mock_cursor = _mock_cursor_context(mock_get_cursor)
         mock_cursor.rowcount = 1
 
         rows = [_default_trade_dict()]
         upsert_market_trades_batch(rows)
 
-        mock_cursor.executemany.assert_called_once()
+        mock_exec_values.assert_called_once()
+        # Verify cursor is first arg
+        assert mock_exec_values.call_args[0][0] is mock_cursor
 
+    @patch("precog.database.crud_operations.execute_values")
     @patch("precog.database.crud_operations.get_cursor")
-    def test_batch_sql_contains_on_conflict(self, mock_get_cursor):
+    def test_batch_sql_contains_on_conflict(self, mock_get_cursor, mock_exec_values):
         """Test that batch SQL uses ON CONFLICT DO NOTHING."""
         mock_cursor = _mock_cursor_context(mock_get_cursor)
         mock_cursor.rowcount = 1
 
         upsert_market_trades_batch([_default_trade_dict()])
 
-        call_args = mock_cursor.executemany.call_args
-        sql = call_args[0][0]
+        call_args = mock_exec_values.call_args
+        sql = call_args[0][1]  # execute_values(cur, sql, ...)
         assert "ON CONFLICT" in sql
         assert "DO NOTHING" in sql
 
+    @patch("precog.database.crud_operations.execute_values")
     @patch("precog.database.crud_operations.get_cursor")
-    def test_batch_allows_none_optional_fields(self, mock_get_cursor):
+    def test_batch_allows_none_optional_fields(self, mock_get_cursor, mock_exec_values):
         """Test that batch rows without optional fields work fine."""
         mock_cursor = _mock_cursor_context(mock_get_cursor)
         mock_cursor.rowcount = 1
@@ -291,12 +298,28 @@ class TestUpsertMarketTradesBatch:
         row = _default_trade_dict()
         upsert_market_trades_batch([row])
 
-        call_args = mock_cursor.executemany.call_args
-        params_list = call_args[0][1]
+        call_args = mock_exec_values.call_args
+        params_list = call_args[0][2]  # execute_values(cur, sql, argslist, ...)
         # yes_price (index 4), no_price (index 5), taker_side (index 6) should be None
         assert params_list[0][4] is None
         assert params_list[0][5] is None
         assert params_list[0][6] is None
+
+    def test_batch_validates_count_positive(self):
+        """Test that count <= 0 is rejected in batch."""
+        row = _default_trade_dict()
+        row["count"] = 0
+
+        with pytest.raises(ValueError, match="count must be a positive integer"):
+            upsert_market_trades_batch([row])
+
+    def test_batch_validates_count_not_negative(self):
+        """Test that negative count is rejected in batch."""
+        row = _default_trade_dict()
+        row["count"] = -5
+
+        with pytest.raises(ValueError, match="count must be a positive integer"):
+            upsert_market_trades_batch([row])
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Replace `executemany` with `execute_values` in `upsert_market_trades_batch` — psycopg2's `executemany` only reports the last statement's rowcount, not the aggregate. With `ON CONFLICT DO NOTHING`, monitoring was getting 0 or 1 instead of the true insert count.
- Add `count > 0` validation in the CRUD layer (previously relied solely on DB CHECK constraint)
- Fix `insert_temporal_alignment_batch` docstring — said "rows inserted" but returns "rows submitted"

Closes #472

## Test plan
- [x] 32 market_trades CRUD tests pass (2 new: count validation)
- [x] 28 temporal_alignment CRUD tests pass
- [x] Full unit suite: 2259 passed
- [x] Ruff lint + format clean
- [x] Mypy type check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)