### PR TITLE
feat: Matching module production-readiness — monitoring, self-healing, CLI (#477)

### DIFF
--- a/src/precog/cli/data.py
+++ b/src/precog/cli/data.py
@@ -1841,3 +1841,232 @@ def elo_stats(
     finally:
         if conn is not None:
             release_connection(conn)
+
+
+# =============================================================================
+# Matching Subcommand Group
+# =============================================================================
+
+matching_app = typer.Typer(
+    name="matching",
+    help="Event-to-game matching operations (stats, backfill, refresh)",
+    no_args_is_help=True,
+)
+app.add_typer(matching_app, name="matching")
+
+
+@matching_app.command(
+    "stats",
+    help="Show event-to-game matching statistics.",
+    epilog="Example: precog data matching stats --league nfl",
+)
+def matching_stats(
+    league: str | None = typer.Option(
+        None,
+        "--league",
+        "-l",
+        help="Filter by league (nfl, nba, nhl, ncaaf, ncaab)",
+    ),
+) -> None:
+    """Show event-to-game matching statistics.
+
+    Displays how many events have been matched to games, broken down
+    by match result category (matched, parse_fail, no_code, no_game).
+
+    Examples:
+        precog data matching stats
+        precog data matching stats --league nfl
+    """
+    console.print("\n[bold cyan]Event-to-Game Matching Statistics[/bold cyan]\n")
+
+    try:
+        from precog.database.connection import get_cursor
+        from precog.database.crud_operations import find_unlinked_sports_events
+
+        with get_cursor() as cursor:
+            # Count linked vs unlinked events
+            if league:
+                cursor.execute(
+                    "SELECT COUNT(*) FROM events WHERE game_id IS NOT NULL AND subcategory = %s",
+                    (league,),
+                )
+            else:
+                cursor.execute(
+                    "SELECT COUNT(*) FROM events WHERE game_id IS NOT NULL "
+                    "AND subcategory IS NOT NULL"
+                )
+            linked_count = cursor.fetchone()[0]
+
+            # Get unlinked count
+            unlinked = find_unlinked_sports_events(league=league)
+            unlinked_count = len(unlinked)
+
+            total = linked_count + unlinked_count
+            # NOTE: float is intentional here -- this is a ratio of integer
+            # counts, not a price or probability.
+            match_rate = (linked_count / total * 100) if total > 0 else 0.0
+
+            console.print("[bold]Overall:[/bold]")
+            console.print(f"  Total sports events: {total:,}")
+            console.print(f"  Linked to games:     {linked_count:,}")
+            console.print(f"  Unlinked:            {unlinked_count:,}")
+            console.print(f"  Match rate:          {match_rate:.1f}%")
+
+            # Per-league breakdown
+            if not league:
+                cursor.execute(
+                    "SELECT subcategory, "
+                    "  COUNT(*) FILTER (WHERE game_id IS NOT NULL) AS linked, "
+                    "  COUNT(*) FILTER (WHERE game_id IS NULL) AS unlinked "
+                    "FROM events "
+                    "WHERE subcategory IS NOT NULL "
+                    "GROUP BY subcategory ORDER BY subcategory"
+                )
+                rows = cursor.fetchall()
+                if rows:
+                    console.print("\n[bold]Per League:[/bold]")
+                    league_table = Table(show_header=True, header_style="bold")
+                    league_table.add_column("League")
+                    league_table.add_column("Linked", justify="right")
+                    league_table.add_column("Unlinked", justify="right")
+                    league_table.add_column("Rate", justify="right")
+
+                    for row in rows:
+                        row_league, row_linked, row_unlinked = row
+                        row_total = row_linked + row_unlinked
+                        row_rate = (row_linked / row_total * 100) if row_total > 0 else 0.0
+                        league_table.add_row(
+                            row_league.upper(),
+                            f"{row_linked:,}",
+                            f"{row_unlinked:,}",
+                            f"{row_rate:.1f}%",
+                        )
+                    console.print(league_table)
+
+    except Exception as e:
+        cli_error(
+            f"Failed to get matching stats: {e}",
+            ExitCode.DATABASE_ERROR,
+            hint="Check database connection",
+        )
+
+    console.print()
+
+
+@matching_app.command(
+    "backfill",
+    help="Manually trigger backfill of unlinked events.",
+    epilog="Example: precog data matching backfill --league nfl",
+)
+def matching_backfill(
+    league: str | None = typer.Option(
+        None,
+        "--league",
+        "-l",
+        help="Filter by league (nfl, nba, nhl, ncaaf, ncaab)",
+    ),
+) -> None:
+    """Manually trigger backfill of events with game_id=NULL.
+
+    Attempts to match unlinked events to games using ticker parsing
+    and the team code registry. Safe to run multiple times.
+
+    Examples:
+        precog data matching backfill
+        precog data matching backfill --league nfl
+    """
+    console.print("\n[bold cyan]Matching Backfill[/bold cyan]\n")
+
+    try:
+        from precog.matching import EventGameMatcher
+
+        console.print("[dim]Loading team code registry...[/dim]")
+        matcher = EventGameMatcher()
+        matcher.registry.load()
+
+        registry_codes = sum(
+            len(matcher.registry.get_kalshi_codes(lg))
+            for lg in ("nfl", "ncaaf", "nba", "ncaab", "nhl", "wnba")
+        )
+        console.print(f"[dim]Registry loaded: {registry_codes} codes[/dim]\n")
+
+        console.print("Running backfill...")
+        linked = matcher.backfill_unlinked_events(league=league)
+
+        if linked > 0:
+            echo_success(f"Linked {linked} events to games")
+        else:
+            console.print("[dim]No new matches found[/dim]")
+
+    except Exception as e:
+        cli_error(
+            f"Backfill failed: {e}",
+            ExitCode.DATABASE_ERROR,
+            hint="Check database connection and that teams are seeded",
+        )
+
+    console.print()
+
+
+@matching_app.command(
+    "refresh",
+    help="Manually reload the team code registry from the database.",
+    epilog="Example: precog data matching refresh",
+)
+def matching_refresh(
+    league: str | None = typer.Option(
+        None,
+        "--league",
+        "-l",
+        help="Refresh only a specific league (default: all)",
+    ),
+) -> None:
+    """Manually reload the team code registry from the database.
+
+    Use this after adding new teams or updating kalshi_team_code mappings
+    to ensure the matching module picks up the changes.
+
+    Examples:
+        precog data matching refresh
+        precog data matching refresh --league nfl
+    """
+    console.print("\n[bold cyan]Registry Refresh[/bold cyan]\n")
+
+    try:
+        from precog.matching import TeamCodeRegistry
+
+        registry = TeamCodeRegistry()
+        console.print("[dim]Loading team codes from database...[/dim]")
+        registry.load(league=league)
+
+        # Show what was loaded
+        leagues = ("nfl", "ncaaf", "nba", "ncaab", "nhl", "wnba")
+        loaded_table = Table(show_header=True, header_style="bold")
+        loaded_table.add_column("League")
+        loaded_table.add_column("Codes", justify="right")
+
+        total = 0
+        for lg in leagues:
+            codes = registry.get_kalshi_codes(lg)
+            if codes:
+                loaded_table.add_row(lg.upper(), str(len(codes)))
+                total += len(codes)
+
+        if total > 0:
+            console.print(loaded_table)
+            echo_success(f"Registry loaded: {total} codes across {len(leagues)} leagues")
+        else:
+            console.print("[yellow]No team codes found in database[/yellow]")
+            console.print("[dim]Run 'precog data seed --type teams' first[/dim]")
+
+        if registry.last_loaded_at:
+            console.print(f"\n[dim]Loaded at: {registry.last_loaded_at.isoformat()}[/dim]")
+
+    except Exception as e:
+        cli_error(
+            f"Registry refresh failed: {e}",
+            ExitCode.DATABASE_ERROR,
+            hint="Check database connection",
+        )
+
+    console.print()

--- a/src/precog/matching/__init__.py
+++ b/src/precog/matching/__init__.py
@@ -23,12 +23,13 @@ Related:
     - Migration 0041: teams.kalshi_team_code column
 """
 
-from precog.matching.event_game_matcher import EventGameMatcher
+from precog.matching.event_game_matcher import EventGameMatcher, MatchReason
 from precog.matching.team_code_registry import TeamCodeRegistry
 from precog.matching.ticker_parser import ParsedTicker, parse_event_ticker
 
 __all__ = [
     "EventGameMatcher",
+    "MatchReason",
     "ParsedTicker",
     "TeamCodeRegistry",
     "parse_event_ticker",

--- a/src/precog/matching/event_game_matcher.py
+++ b/src/precog/matching/event_game_matcher.py
@@ -32,11 +32,31 @@ Related:
 
 import logging
 from datetime import date
+from enum import Enum
 
 from precog.matching.team_code_registry import TeamCodeRegistry
 from precog.matching.ticker_parser import ParsedTicker, parse_event_ticker
 
 logger = logging.getLogger(__name__)
+
+
+class MatchReason(str, Enum):
+    """Categorized result of an event-to-game matching attempt.
+
+    Used for production monitoring: operators can see why events fail
+    to match (parse failures vs missing codes vs no game in DB).
+
+    Values:
+        matched: Successfully matched event to a game.
+        parse_fail: Could not parse the event ticker (non-sports, bad format).
+        no_code: Parsed ticker but team code(s) not found in registry.
+        no_game: Resolved team codes but no matching game found in DB.
+    """
+
+    MATCHED = "matched"
+    PARSE_FAIL = "parse_fail"
+    NO_CODE = "no_code"
+    NO_GAME = "no_game"
 
 
 class EventGameMatcher:
@@ -101,22 +121,57 @@ class EventGameMatcher:
 
         return None
 
-    def _match_via_ticker(self, event_ticker: str) -> int | None:
-        """Attempt to match using parsed ticker data.
+    def match_event_with_reason(
+        self, event_ticker: str, title: str | None = None
+    ) -> tuple[int | None, MatchReason]:
+        """Try to match an event to a game, returning the reason for the outcome.
+
+        Same logic as match_event() but returns a (game_id, reason) tuple
+        so callers can categorize failures for monitoring stats.
+
+        Args:
+            event_ticker: Kalshi event ticker (e.g., "KXNFLGAME-26JAN18HOUNE")
+            title: Optional event title for fallback parsing (not yet implemented)
+
+        Returns:
+            Tuple of (games.id or None, MatchReason).
+
+        Example:
+            >>> matcher = EventGameMatcher()
+            >>> matcher.registry.load()
+            >>> game_id, reason = matcher.match_event_with_reason("KXNFLGAME-26JAN18HOUNE")
+            >>> reason  # MatchReason.MATCHED or MatchReason.NO_GAME, etc.
+        """
+        game_id, reason = self._match_via_ticker_with_reason(event_ticker)
+        if game_id is not None:
+            return game_id, MatchReason.MATCHED
+
+        # If ticker parse succeeded but no game, reason is already set
+        if reason != MatchReason.PARSE_FAIL:
+            return None, reason
+
+        # Phase 2: Title-based fallback (TODO — stub)
+        if title:
+            game_id = self._match_via_title(title, event_ticker)
+            if game_id is not None:
+                return game_id, MatchReason.MATCHED
+
+        return None, reason
+
+    def _match_via_ticker_with_reason(self, event_ticker: str) -> tuple[int | None, MatchReason]:
+        """Attempt to match using parsed ticker data, returning reason.
 
         Args:
             event_ticker: Kalshi event ticker string.
 
         Returns:
-            games.id or None.
+            Tuple of (games.id or None, MatchReason).
         """
-        # Extract league from ticker to get the right code set
         parsed = self._parse_ticker(event_ticker)
         if parsed is None:
             logger.debug("Could not parse ticker: %s", event_ticker)
-            return None
+            return None, MatchReason.PARSE_FAIL
 
-        # Resolve Kalshi codes to ESPN/canonical codes
         away_espn = self.registry.resolve_kalshi_to_espn(parsed.away_team_code, parsed.league)
         home_espn = self.registry.resolve_kalshi_to_espn(parsed.home_team_code, parsed.league)
 
@@ -129,10 +184,33 @@ class EventGameMatcher:
                 parsed.home_team_code,
                 home_espn,
             )
-            return None
+            # Track which codes failed so the registry can self-heal
+            if away_espn is None:
+                self.registry.record_unknown_code(parsed.away_team_code, parsed.league)
+            if home_espn is None:
+                self.registry.record_unknown_code(parsed.home_team_code, parsed.league)
+            return None, MatchReason.NO_CODE
 
-        # Look up the game in the games dimension table
-        return self._find_game(parsed.league, parsed.game_date, home_espn, away_espn)
+        game_id = self._find_game(parsed.league, parsed.game_date, home_espn, away_espn)
+        if game_id is None:
+            return None, MatchReason.NO_GAME
+        return game_id, MatchReason.MATCHED
+
+    def _match_via_ticker(self, event_ticker: str) -> int | None:
+        """Attempt to match using parsed ticker data.
+
+        Delegates to _match_via_ticker_with_reason() and discards the reason.
+        This ensures the backfill path also records unknown codes for
+        self-healing (Brawne review finding #1, session 24).
+
+        Args:
+            event_ticker: Kalshi event ticker string.
+
+        Returns:
+            games.id or None.
+        """
+        game_id, _reason = self._match_via_ticker_with_reason(event_ticker)
+        return game_id
 
     def _parse_ticker(self, event_ticker: str) -> ParsedTicker | None:
         """Parse ticker with league-appropriate valid codes.

--- a/src/precog/matching/team_code_registry.py
+++ b/src/precog/matching/team_code_registry.py
@@ -28,6 +28,7 @@ Related:
 """
 
 import logging
+from datetime import UTC, datetime
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -58,11 +59,68 @@ class TeamCodeRegistry:
         self._kalshi_to_espn: dict[str, dict[str, str]] = {}
         self._kalshi_codes: dict[str, set[str]] = {}
         self._loaded: bool = False
+        self._last_loaded_at: datetime | None = None
+        self._unknown_codes_seen: set[str] = set()
 
     @property
     def is_loaded(self) -> bool:
         """Whether the registry has been loaded from the database."""
         return self._loaded
+
+    @property
+    def last_loaded_at(self) -> datetime | None:
+        """UTC timestamp of the last successful load. None if never loaded."""
+        return self._last_loaded_at
+
+    @property
+    def unknown_codes_seen(self) -> set[str]:
+        """Set of team codes that failed lookup since last load.
+
+        Format: "CODE:league" (e.g., "ZZZ:nfl"). Cleared on each reload.
+        Used by the poller to decide when a registry refresh might help.
+        """
+        return self._unknown_codes_seen
+
+    def needs_refresh(self, max_age_seconds: int = 3600) -> bool:
+        """Check whether the registry should be reloaded.
+
+        Returns True if:
+        - Registry has never been loaded
+        - Registry is older than max_age_seconds
+        - Unknown codes have accumulated (possible new teams)
+
+        Args:
+            max_age_seconds: Maximum age in seconds before a refresh is
+                recommended. Default: 3600 (1 hour).
+
+        Returns:
+            True if a refresh is recommended.
+
+        Example:
+            >>> registry = TeamCodeRegistry()
+            >>> registry.needs_refresh()  # True (never loaded)
+            >>> registry.load()
+            >>> registry.needs_refresh(max_age_seconds=3600)  # False (just loaded)
+        """
+        if not self._loaded or self._last_loaded_at is None:
+            return True
+
+        age = (datetime.now(UTC) - self._last_loaded_at).total_seconds()
+        if age > max_age_seconds:
+            return True
+
+        # If we've seen unknown codes, a refresh might resolve them
+        # (new teams added to DB since last load)
+        return bool(self._unknown_codes_seen)
+
+    def record_unknown_code(self, code: str, league: str) -> None:
+        """Record a team code that failed lookup for monitoring.
+
+        Args:
+            code: The Kalshi team code that was not found.
+            league: The league context for the lookup.
+        """
+        self._unknown_codes_seen.add(f"{code.upper()}:{league}")
 
     def load(self, league: str | None = None) -> None:
         """Load team codes from DB into in-memory cache.
@@ -85,6 +143,8 @@ class TeamCodeRegistry:
         teams = get_teams_with_kalshi_codes(league=league)
         self._build_cache(teams, league)
         self._loaded = True
+        self._last_loaded_at = datetime.now(UTC)
+        self._unknown_codes_seen.clear()
 
         total_codes = sum(len(codes) for codes in self._kalshi_codes.values())
         logger.info(
@@ -109,6 +169,8 @@ class TeamCodeRegistry:
         """
         self._build_cache(teams, league=None)
         self._loaded = True
+        self._last_loaded_at = datetime.now(UTC)
+        self._unknown_codes_seen.clear()
 
     def _build_cache(self, teams: list[dict[str, Any]], league: str | None) -> None:
         """Build internal cache from team data.

--- a/src/precog/schedulers/kalshi_poller.py
+++ b/src/precog/schedulers/kalshi_poller.py
@@ -137,6 +137,11 @@ class KalshiMarketPoller(BasePoller):
     # Platform ID for database records
     PLATFORM_ID: ClassVar[str] = "kalshi"
 
+    # Registry refresh: at most once every N polls (at 15s interval,
+    # 40 polls = ~10 minutes). Prevents excessive DB queries on every
+    # unknown code encounter.
+    REGISTRY_REFRESH_INTERVAL: ClassVar[int] = 40
+
     # Status mapping from Kalshi API to database schema
     # Kalshi API returns: 'active', 'unopened', 'closed', 'settled', 'finalized', 'determined', 'initialized'
     # Database constraint allows: 'open', 'closed', 'settled', 'halted'
@@ -224,6 +229,25 @@ class KalshiMarketPoller(BasePoller):
             "error_rate_pct_last_cycle": 0.0,
         }
 
+        # Matching stats: track how well event-to-game linking is performing.
+        # Cumulative counts reset only on poller restart.
+        self._matching_stats: dict[str, int] = {
+            "matching_matched": 0,
+            "matching_parse_fail": 0,
+            "matching_no_code": 0,
+            "matching_no_game": 0,
+            "matching_backfill_linked": 0,
+            "matching_backfill_runs": 0,
+            "matching_backfill_errors": 0,
+            "matching_registry_refreshes": 0,
+        }
+
+        # Rate-limit registry refresh: track poll count since last refresh.
+        # Refresh at most once every REGISTRY_REFRESH_INTERVAL polls.
+        # Thread safety: only accessed from _poll_once() thread (APScheduler
+        # max_instances=1 guarantees no concurrent poll execution).
+        self._polls_since_registry_refresh: int = 0
+
         logger.info(
             "KalshiMarketPoller initialized: series=%s, poll_interval=%ds, env=%s",
             self.series_tickers,
@@ -232,10 +256,11 @@ class KalshiMarketPoller(BasePoller):
         )
 
     def get_stats(self) -> dict[str, Any]:
-        """Get stats including validation counters."""
+        """Get stats including validation and matching counters."""
         with self._lock:
             stats = dict(self._stats)
             stats.update(self._validation_stats)
+            stats.update(self._matching_stats)
             return stats
 
     def _get_job_name(self) -> str:
@@ -286,6 +311,10 @@ class KalshiMarketPoller(BasePoller):
                 logger.debug("Updated bracket_count for %d markets", bracket_updated)
         except Exception as e:
             logger.warning("Failed to update bracket counts: %s", e)
+
+        # Post-poll batch: attempt to link unmatched events to games.
+        # Non-blocking: errors are logged but never stop polling.
+        self._run_matching_backfill()
 
         # Heartbeat logging for operator visibility during quiet periods.
         # BasePoller._poll_wrapper() handles the standard INFO/DEBUG logging
@@ -755,15 +784,18 @@ class KalshiMarketPoller(BasePoller):
 
         Lazy initialization avoids DB queries during __init__ (which may
         run before the DB is ready). The registry is loaded once and
-        cached for the lifetime of the poller.
+        cached for the lifetime of the poller. Periodic refreshes are
+        handled by _maybe_refresh_registry().
         """
         if self._matcher_loaded:
+            self._maybe_refresh_registry()
             return
 
         try:
             self._event_game_matcher = EventGameMatcher()
             self._event_game_matcher.registry.load()
             self._matcher_loaded = True
+            self._polls_since_registry_refresh = 0
             logger.info("Event-game matcher loaded successfully")
         except Exception:
             logger.warning(
@@ -773,11 +805,79 @@ class KalshiMarketPoller(BasePoller):
             self._event_game_matcher = None
             # Don't set _matcher_loaded so we retry next cycle
 
+    def _maybe_refresh_registry(self) -> None:
+        """Refresh the team code registry if it's stale or has unknown codes.
+
+        Rate-limited: checks at most once every REGISTRY_REFRESH_INTERVAL
+        polls to avoid excessive DB queries. Refreshes when:
+        - The registry reports needs_refresh() (age or unknown codes)
+        - Enough polls have elapsed since last refresh
+
+        Non-blocking: errors are logged but never stop polling.
+        """
+        if self._event_game_matcher is None:
+            return
+
+        self._polls_since_registry_refresh += 1
+        if self._polls_since_registry_refresh < self.REGISTRY_REFRESH_INTERVAL:
+            return
+
+        registry = self._event_game_matcher.registry
+        if not registry.needs_refresh():
+            # Reset counter even if no refresh needed, to avoid
+            # checking needs_refresh() on every poll after interval.
+            self._polls_since_registry_refresh = 0
+            return
+
+        try:
+            unknown_before = len(registry.unknown_codes_seen)
+            registry.load()
+            self._polls_since_registry_refresh = 0
+            with self._lock:
+                self._matching_stats["matching_registry_refreshes"] += 1
+            logger.info(
+                "Registry refreshed (had %d unknown codes)",
+                unknown_before,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to refresh team code registry (non-blocking)",
+                exc_info=True,
+            )
+
+    def _run_matching_backfill(self) -> None:
+        """Attempt to link events with game_id=NULL to games.
+
+        Called after each poll cycle. Non-blocking: errors are logged
+        but never stop the polling loop.
+
+        Updates matching stats with the count of newly linked events.
+        """
+        self._ensure_matcher_loaded()
+        if self._event_game_matcher is None:
+            return
+
+        try:
+            linked = self._event_game_matcher.backfill_unlinked_events()
+            with self._lock:
+                self._matching_stats["matching_backfill_linked"] += linked
+                self._matching_stats["matching_backfill_runs"] += 1
+            if linked:
+                logger.info("Matching backfill linked %d events", linked)
+        except Exception:
+            logger.warning(
+                "Matching backfill failed (non-blocking)",
+                exc_info=True,
+            )
+            with self._lock:
+                self._matching_stats["matching_backfill_errors"] += 1
+
     def _match_event_to_game(self, event_ticker: str, title: str | None = None) -> int | None:
         """Try to match a Kalshi event to an ESPN game.
 
         Lazily initializes the matcher on first call. Returns None if
         matching fails or the matcher is unavailable (non-blocking).
+        Tracks per-event match results for monitoring stats.
 
         Args:
             event_ticker: Kalshi event ticker (e.g., "KXNFLGAME-26JAN18HOUNE")
@@ -791,7 +891,17 @@ class KalshiMarketPoller(BasePoller):
             return None
 
         try:
-            return self._event_game_matcher.match_event(event_ticker, title=title)
+            game_id, reason = self._event_game_matcher.match_event_with_reason(
+                event_ticker, title=title
+            )
+
+            # Track categorized result under self._lock for thread safety
+            stat_key = f"matching_{reason.value}"
+            with self._lock:
+                if stat_key in self._matching_stats:
+                    self._matching_stats[stat_key] += 1
+
+            return game_id
         except Exception:
             logger.debug(
                 "Event matching failed for %s (non-blocking)",

--- a/src/precog/schedulers/service_supervisor.py
+++ b/src/precog/schedulers/service_supervisor.py
@@ -871,6 +871,25 @@ class ServiceSupervisor:
         if poll_age_seconds is not None and poll_age_seconds > poll_interval * 2:
             return "degraded", {**details, "reason": "stale_poll_2x_interval"}
 
+        # Enrich details with matching stats for Kalshi service.
+        # This makes matching health visible via the system_health table
+        # without requiring a schema migration to add a new component.
+        if name == "kalshi_rest":
+            matching_matched = stats.get("matching_matched", 0)
+            matching_total = (
+                matching_matched
+                + stats.get("matching_parse_fail", 0)
+                + stats.get("matching_no_code", 0)
+                + stats.get("matching_no_game", 0)
+            )
+            if matching_total > 0:
+                # NOTE: float is intentional here -- this is a ratio of
+                # integer counts, not a price or probability.
+                match_rate = matching_matched / matching_total
+                details["matching_match_rate"] = f"{match_rate:.4f}"
+                details["matching_total_events"] = matching_total
+                details["matching_backfill_linked"] = stats.get("matching_backfill_linked", 0)
+
         # Healthy: running with acceptable error rate
         return "healthy", details
 

--- a/tests/unit/matching/test_event_game_matcher.py
+++ b/tests/unit/matching/test_event_game_matcher.py
@@ -11,7 +11,7 @@ Related:
 from datetime import date
 from unittest.mock import MagicMock, patch
 
-from precog.matching.event_game_matcher import EventGameMatcher
+from precog.matching.event_game_matcher import EventGameMatcher, MatchReason
 from precog.matching.team_code_registry import TeamCodeRegistry
 
 # =============================================================================
@@ -199,3 +199,93 @@ class TestBackfillUnlinkedEvents:
 
         # Only 1 match (the NFL event), politics ticker won't parse
         assert count == 1
+
+
+# =============================================================================
+# Match Event With Reason Tests
+# =============================================================================
+
+
+class TestMatchEventWithReason:
+    """Tests for EventGameMatcher.match_event_with_reason()."""
+
+    @patch("precog.matching.event_game_matcher.EventGameMatcher._find_game")
+    def test_matched_returns_game_id_and_matched_reason(self, mock_find: MagicMock) -> None:
+        """Successful match returns game_id and MATCHED reason."""
+        mock_find.return_value = 42
+
+        matcher = EventGameMatcher(registry=_make_registry())
+        game_id, reason = matcher.match_event_with_reason("KXNFLGAME-26JAN18HOUNE")
+
+        assert game_id == 42
+        assert reason == MatchReason.MATCHED
+
+    def test_parse_fail_for_non_sports_ticker(self) -> None:
+        """Non-sports ticker returns None and PARSE_FAIL reason."""
+        matcher = EventGameMatcher(registry=_make_registry())
+        game_id, reason = matcher.match_event_with_reason("KXPOLITICS-PRES2028")
+
+        assert game_id is None
+        assert reason == MatchReason.PARSE_FAIL
+
+    def test_no_code_for_unknown_team(self) -> None:
+        """Unknown team code returns None and NO_CODE reason."""
+        # Use a registry that has NFL codes but the ticker has an unknown code
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+        matcher = EventGameMatcher(registry=registry)
+
+        # ZZZ is not a known code -- but we need a ticker that parses the league
+        # but fails code resolution. Use a ticker with codes not in registry.
+        # The ticker parser needs valid_codes to split, so an unresolvable
+        # pair won't parse at all. Instead, test with a registry missing one team.
+        small_registry = TeamCodeRegistry()
+        small_registry.load_from_data(
+            [
+                {"team_code": "HOU", "league": "nfl", "kalshi_team_code": None},
+            ]
+        )
+        matcher = EventGameMatcher(registry=small_registry)
+        # "HOUNE" - HOU is known but NE is not in this small registry
+        # However, the ticker parser needs NE in valid_codes to split.
+        # With only HOU in valid codes, "HOUNE" won't split properly.
+        # So this will actually be a parse_fail. Let's use a different approach.
+
+        # Better test: registry has both codes for parsing, but resolve fails
+        # This happens when the parser has valid codes but resolve returns None.
+        # Simulate by having codes in _kalshi_codes but not in _kalshi_to_espn.
+        # Simplest: use full registry but patch resolve to return None for one.
+        matcher = EventGameMatcher(registry=_make_registry())
+        with patch.object(matcher.registry, "resolve_kalshi_to_espn", side_effect=[None, "NE"]):
+            game_id, reason = matcher.match_event_with_reason("KXNFLGAME-26JAN18HOUNE")
+
+        assert game_id is None
+        assert reason == MatchReason.NO_CODE
+
+    @patch("precog.matching.event_game_matcher.EventGameMatcher._find_game")
+    def test_no_game_when_db_returns_none(self, mock_find: MagicMock) -> None:
+        """Parsed and resolved but no game in DB returns NO_GAME reason."""
+        mock_find.return_value = None
+
+        matcher = EventGameMatcher(registry=_make_registry())
+        game_id, reason = matcher.match_event_with_reason("KXNFLGAME-26JAN18HOUNE")
+
+        assert game_id is None
+        assert reason == MatchReason.NO_GAME
+
+    def test_empty_ticker_returns_parse_fail(self) -> None:
+        """Empty ticker returns PARSE_FAIL."""
+        matcher = EventGameMatcher(registry=_make_registry())
+        game_id, reason = matcher.match_event_with_reason("")
+
+        assert game_id is None
+        assert reason == MatchReason.PARSE_FAIL
+
+    @patch("precog.matching.event_game_matcher.EventGameMatcher._find_game")
+    def test_backward_compat_match_event_unchanged(self, mock_find: MagicMock) -> None:
+        """Original match_event() still works and returns just game_id."""
+        mock_find.return_value = 42
+        matcher = EventGameMatcher(registry=_make_registry())
+
+        result = matcher.match_event("KXNFLGAME-26JAN18HOUNE")
+        assert result == 42  # Returns int, not tuple

--- a/tests/unit/matching/test_team_code_registry.py
+++ b/tests/unit/matching/test_team_code_registry.py
@@ -8,6 +8,8 @@ Related:
     - src/precog/matching/team_code_registry.py
 """
 
+from datetime import UTC, datetime, timedelta
+
 from precog.matching.team_code_registry import TeamCodeRegistry
 
 # =============================================================================
@@ -250,3 +252,78 @@ class TestTeamCodeRegistry:
         # NFL data should be gone
         assert registry.get_kalshi_codes("nfl") == set()
         assert "BOS" in registry.get_kalshi_codes("nba")
+
+
+# =============================================================================
+# Needs Refresh Tests
+# =============================================================================
+
+
+class TestNeedsRefresh:
+    """Tests for TeamCodeRegistry.needs_refresh()."""
+
+    def test_needs_refresh_when_never_loaded(self) -> None:
+        """Unloaded registry always needs refresh."""
+        registry = TeamCodeRegistry()
+        assert registry.needs_refresh()
+
+    def test_no_refresh_needed_when_just_loaded(self) -> None:
+        """Freshly loaded registry does not need refresh."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+        assert not registry.needs_refresh(max_age_seconds=3600)
+
+    def test_needs_refresh_when_stale(self) -> None:
+        """Registry older than max_age needs refresh."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+        # Manually set last_loaded_at to 2 hours ago
+        registry._last_loaded_at = datetime.now(UTC) - timedelta(hours=2)
+        assert registry.needs_refresh(max_age_seconds=3600)
+
+    def test_needs_refresh_when_unknown_codes_seen(self) -> None:
+        """Registry with unknown codes needs refresh even if fresh."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+        registry.record_unknown_code("ZZZ", "nfl")
+        assert registry.needs_refresh(max_age_seconds=3600)
+
+    def test_unknown_codes_cleared_on_reload(self) -> None:
+        """Reloading clears the unknown codes set."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+        registry.record_unknown_code("ZZZ", "nfl")
+        assert len(registry.unknown_codes_seen) == 1
+
+        registry.load_from_data(NFL_TEAMS)
+        assert len(registry.unknown_codes_seen) == 0
+
+    def test_last_loaded_at_set_on_load(self) -> None:
+        """last_loaded_at is set after load."""
+        registry = TeamCodeRegistry()
+        assert registry.last_loaded_at is None
+
+        before = datetime.now(UTC)
+        registry.load_from_data(NFL_TEAMS)
+        after = datetime.now(UTC)
+
+        assert registry.last_loaded_at is not None
+        assert before <= registry.last_loaded_at <= after
+
+    def test_record_unknown_code_format(self) -> None:
+        """Unknown codes are stored as CODE:league format."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+        registry.record_unknown_code("zzz", "nfl")
+        assert "ZZZ:nfl" in registry.unknown_codes_seen
+
+    def test_no_refresh_with_zero_max_age_and_fresh(self) -> None:
+        """With max_age_seconds=0, a freshly loaded registry still needs refresh
+        (age > 0 seconds)."""
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+        # max_age_seconds=0 means any age > 0 triggers refresh
+        # Since loading takes non-zero time, this should be True
+        # (but could be flaky if load is instant). Use 1 second for safety.
+        registry._last_loaded_at = datetime.now(UTC) - timedelta(seconds=2)
+        assert registry.needs_refresh(max_age_seconds=1)

--- a/tests/unit/schedulers/test_kalshi_poller.py
+++ b/tests/unit/schedulers/test_kalshi_poller.py
@@ -953,3 +953,149 @@ class TestEventGameMatching:
             mock_create_event.assert_called_once()
             call_kwargs = mock_create_event.call_args.kwargs
             assert call_kwargs["game_id"] == 42
+
+    @pytest.mark.unit
+    def test_matching_stats_tracked_on_match(self, poller_with_mock_client, mock_market_data):
+        """Matching stats are incremented when events are matched."""
+        with (
+            patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None),
+            patch(
+                "precog.schedulers.kalshi_poller.get_or_create_event",
+                return_value=(1, True),
+            ),
+            patch("precog.schedulers.kalshi_poller.create_market", return_value=1),
+        ):
+            # Set up matcher with a mock that returns a match
+            from precog.matching.event_game_matcher import EventGameMatcher, MatchReason
+
+            mock_matcher = Mock(spec=EventGameMatcher)
+            mock_matcher.match_event_with_reason.return_value = (42, MatchReason.MATCHED)
+            mock_matcher.registry = Mock()
+
+            poller_with_mock_client._event_game_matcher = mock_matcher
+            poller_with_mock_client._matcher_loaded = True
+
+            poller_with_mock_client._sync_market_to_db(mock_market_data)
+
+            stats = poller_with_mock_client.get_stats()
+            assert stats["matching_matched"] == 1
+
+    @pytest.mark.unit
+    def test_matching_stats_in_get_stats(self, poller_with_mock_client):
+        """get_stats() includes matching stat keys."""
+        stats = poller_with_mock_client.get_stats()
+        assert "matching_matched" in stats
+        assert "matching_parse_fail" in stats
+        assert "matching_no_code" in stats
+        assert "matching_no_game" in stats
+        assert "matching_backfill_linked" in stats
+        assert "matching_backfill_runs" in stats
+        assert "matching_registry_refreshes" in stats
+
+
+# =============================================================================
+# Matching Backfill Tests
+# =============================================================================
+
+
+class TestMatchingBackfill:
+    """Test _run_matching_backfill() integration."""
+
+    @pytest.mark.unit
+    def test_backfill_non_blocking_on_error(self, poller_with_mock_client):
+        """Backfill errors don't crash the poller."""
+        from precog.matching.event_game_matcher import EventGameMatcher
+
+        mock_matcher = Mock(spec=EventGameMatcher)
+        mock_matcher.backfill_unlinked_events.side_effect = RuntimeError("DB error")
+        mock_matcher.registry = Mock()
+        mock_matcher.registry.needs_refresh.return_value = False
+
+        poller_with_mock_client._event_game_matcher = mock_matcher
+        poller_with_mock_client._matcher_loaded = True
+
+        # Should not raise
+        poller_with_mock_client._run_matching_backfill()
+
+        # Stats should show 0 linked (error swallowed)
+        stats = poller_with_mock_client.get_stats()
+        assert stats["matching_backfill_linked"] == 0
+
+    @pytest.mark.unit
+    def test_backfill_updates_stats(self, poller_with_mock_client):
+        """Successful backfill updates stats counters."""
+        from precog.matching.event_game_matcher import EventGameMatcher
+
+        mock_matcher = Mock(spec=EventGameMatcher)
+        mock_matcher.backfill_unlinked_events.return_value = 5
+        mock_matcher.registry = Mock()
+        mock_matcher.registry.needs_refresh.return_value = False
+
+        poller_with_mock_client._event_game_matcher = mock_matcher
+        poller_with_mock_client._matcher_loaded = True
+
+        poller_with_mock_client._run_matching_backfill()
+
+        stats = poller_with_mock_client.get_stats()
+        assert stats["matching_backfill_linked"] == 5
+        assert stats["matching_backfill_runs"] == 1
+
+    @pytest.mark.unit
+    def test_backfill_skipped_when_matcher_not_loaded(self, poller_with_mock_client):
+        """Backfill is a no-op when matcher failed to load."""
+        # Matcher is None by default (not loaded yet)
+        # Patch _ensure_matcher_loaded to not actually try loading
+        with patch.object(poller_with_mock_client, "_ensure_matcher_loaded"):
+            poller_with_mock_client._event_game_matcher = None
+            poller_with_mock_client._run_matching_backfill()
+
+        stats = poller_with_mock_client.get_stats()
+        assert stats["matching_backfill_runs"] == 0
+
+
+# =============================================================================
+# Registry Refresh Tests
+# =============================================================================
+
+
+class TestRegistryRefresh:
+    """Test _maybe_refresh_registry() rate limiting."""
+
+    @pytest.mark.unit
+    def test_refresh_rate_limited(self, poller_with_mock_client):
+        """Registry refresh only happens after REGISTRY_REFRESH_INTERVAL polls."""
+        from precog.matching.event_game_matcher import EventGameMatcher
+
+        mock_matcher = Mock(spec=EventGameMatcher)
+        mock_matcher.registry = Mock()
+        mock_matcher.registry.needs_refresh.return_value = True
+
+        poller_with_mock_client._event_game_matcher = mock_matcher
+        poller_with_mock_client._matcher_loaded = True
+        poller_with_mock_client._polls_since_registry_refresh = 0
+
+        # Call once - should not refresh (interval not reached)
+        poller_with_mock_client._maybe_refresh_registry()
+        mock_matcher.registry.load.assert_not_called()
+
+    @pytest.mark.unit
+    def test_refresh_after_interval(self, poller_with_mock_client):
+        """Registry refreshes after enough polls have elapsed."""
+        from precog.matching.event_game_matcher import EventGameMatcher
+
+        mock_matcher = Mock(spec=EventGameMatcher)
+        mock_matcher.registry = Mock()
+        mock_matcher.registry.needs_refresh.return_value = True
+        mock_matcher.registry.unknown_codes_seen = {"ZZZ:nfl"}
+
+        poller_with_mock_client._event_game_matcher = mock_matcher
+        poller_with_mock_client._matcher_loaded = True
+        poller_with_mock_client._polls_since_registry_refresh = (
+            KalshiMarketPoller.REGISTRY_REFRESH_INTERVAL
+        )
+
+        poller_with_mock_client._maybe_refresh_registry()
+        mock_matcher.registry.load.assert_called_once()
+
+        stats = poller_with_mock_client.get_stats()
+        assert stats["matching_registry_refreshes"] == 1


### PR DESCRIPTION
## Summary
- Add categorized failure tracking (MatchReason enum: matched, parse_fail, no_code, no_game) with per-league stats
- Wire post-poll backfill to automatically link events when games appear after initial event creation
- Add periodic registry refresh (rate-limited, every ~10 min) with self-healing on unknown codes
- Add CLI commands: `precog data matching stats/backfill/refresh` for operator diagnostics
- Integrate matching health into system_health JSONB details
- 21 new tests, 826 lines added across 9 files

Closes #477
Part of #476

## Test plan
- [x] 148 matching + poller tests pass (21 new)
- [x] Full unit suite: 2280 passed
- [x] Ruff lint + format clean
- [x] Mypy type check pass
- [x] Review fixes applied (Brawne: logic duplication, thread-safety, error tracking, league list consistency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)