### PR TITLE
fix: Read settlement_value_dollars from Kalshi API (#513)

### DIFF
--- a/src/precog/api_connectors/kalshi_client.py
+++ b/src/precog/api_connectors/kalshi_client.py
@@ -538,6 +538,7 @@ class KalshiClient:
             # Other market fields with *_dollars suffix
             "liquidity_dollars",
             "notional_value_dollars",
+            "settlement_value_dollars",
             # Position/portfolio fields (various formats)
             "user_average_price",
             "realized_pnl",

--- a/src/precog/api_connectors/types.py
+++ b/src/precog/api_connectors/types.py
@@ -32,7 +32,15 @@ class MarketData(TypedDict):
     expiration_time: str
     status: Literal["open", "closed", "settled"]
     can_close_early: bool
-    result: Literal["yes", "no"] | None
+    result: (
+        Literal["yes", "no", "scalar", ""] | None
+    )  # 'scalar' for non-binary, '' when undetermined
+    # Settlement payout per $1 contract in dollars (e.g., "1.0000" for YES win, "0.0000" for NO win).
+    # Only populated after market settles. Range [0.0000, 1.0000].
+    # For binary markets: 1.0000 (yes) or 0.0000 (no).
+    # For scalar markets: fractional value based on outcome.
+    # This is the authoritative settlement value from the API -- do not derive from result.
+    settlement_value_dollars: str | None
     # Price fields as strings (will be converted to Decimal)
     # These are order book prices, NOT implied probabilities.
     # yes_ask + no_ask > 1.0 is expected (the difference is the spread/vigorish).
@@ -195,7 +203,9 @@ class ProcessedMarketData(TypedDict, total=False):
     expiration_time: str
     status: Literal["open", "closed", "settled"]
     can_close_early: bool
-    result: Literal["yes", "no"] | None
+    result: (
+        Literal["yes", "no", "scalar", ""] | None
+    )  # 'scalar' for non-binary, '' when undetermined
 
     # Legacy integer cent fields (kept as-is from API)
     # These are order book prices in cents, NOT implied probabilities.
@@ -219,6 +229,10 @@ class ProcessedMarketData(TypedDict, total=False):
     no_ask_dollars: Decimal  # Lowest NO sell order / cost to buy NO (stored as no_price)
     last_price_dollars: Decimal
     liquidity_dollars: Decimal
+    # Settlement payout per $1 contract (e.g., Decimal("1.0000") for YES win).
+    # Only present after market settles. Converted from API string by _convert_prices_to_decimal.
+    # Range [0.0000, 1.0000]. None/absent for unsettled markets.
+    settlement_value_dollars: Decimal | None
 
 
 class ProcessedPositionData(TypedDict):

--- a/src/precog/schedulers/kalshi_poller.py
+++ b/src/precog/schedulers/kalshi_poller.py
@@ -1157,21 +1157,23 @@ class KalshiMarketPoller(BasePoller):
 
             # Settlement detection on create path: if a market arrives
             # already settled (e.g., poller restart, new series backfill),
-            # compute settlement_value from the Kalshi result field.
+            # read settlement_value_dollars directly from the API response.
+            # _convert_prices_to_decimal already converts it to Decimal.
+            # This handles binary (1.0/0.0) and scalar (fractional) markets.
             create_settlement_value: Decimal | None = None
             if db_status == "settled":
-                create_result = market.get("result")
-                if create_result == "yes":
-                    create_settlement_value = Decimal("1.0000")
-                elif create_result == "no":
-                    create_settlement_value = Decimal("0.0000")
-                else:
-                    logger.warning(
-                        "Market %s settled with unexpected result=%r, "
-                        "settlement_value will be NULL",
-                        ticker,
-                        create_result,
-                    )
+                create_settlement_value = market.get("settlement_value_dollars")
+                # Fallback: legacy API may return settlement_value in cents
+                if create_settlement_value is None:
+                    sv_cents = market.get("settlement_value")
+                    if sv_cents is not None:
+                        create_settlement_value = Decimal(str(sv_cents)) / Decimal("100")
+                    else:
+                        logger.warning(
+                            "Market %s settled but settlement_value_dollars is absent, "
+                            "settlement_value will be NULL",
+                            ticker,
+                        )
 
             # Migration 0022: create_market returns int PK
             # Migration 0033: subtitle, open_time, close_time, expiration_time
@@ -1237,23 +1239,24 @@ class KalshiMarketPoller(BasePoller):
         status_changed = existing["status"] != db_status
 
         if price_changed or status_changed:
-            # Settlement detection: when a market settles, record the
-            # settlement_value derived from the Kalshi 'result' field.
-            # "yes" -> 1.0000, "no" -> 0.0000.  Only set on settled markets.
+            # Settlement detection: when a market transitions to settled,
+            # read settlement_value_dollars directly from the API response.
+            # _convert_prices_to_decimal already converts it to Decimal.
+            # This handles binary (1.0/0.0) and scalar (fractional) markets.
             settlement_value: Decimal | None = None
             if db_status == "settled":
-                result = market.get("result")
-                if result == "yes":
-                    settlement_value = Decimal("1.0000")
-                elif result == "no":
-                    settlement_value = Decimal("0.0000")
-                else:
-                    logger.warning(
-                        "Market %s settled with unexpected result=%r, "
-                        "settlement_value will be NULL",
-                        ticker,
-                        result,
-                    )
+                settlement_value = market.get("settlement_value_dollars")
+                # Fallback: legacy API may return settlement_value in cents
+                if settlement_value is None:
+                    sv_cents = market.get("settlement_value")
+                    if sv_cents is not None:
+                        settlement_value = Decimal(str(sv_cents)) / Decimal("100")
+                    else:
+                        logger.warning(
+                            "Market %s settled but settlement_value_dollars is absent, "
+                            "settlement_value will be NULL",
+                            ticker,
+                        )
 
             # Migration 0033: pass enrichment columns on update path too,
             # so lifecycle timestamps are refreshed when prices change.

--- a/tests/unit/schedulers/test_kalshi_poller.py
+++ b/tests/unit/schedulers/test_kalshi_poller.py
@@ -1280,14 +1280,15 @@ class TestSettlementDetection:
     """Test market settlement detection and event propagation."""
 
     @pytest.mark.unit
-    def test_settled_market_yes_sets_settlement_value(self, poller_with_mock_client):
-        """When a market settles with result='yes', settlement_value=1.0000 is passed."""
+    def test_settled_market_yes_reads_settlement_value_dollars(self, poller_with_mock_client):
+        """When a market settles with settlement_value_dollars=1.0000, it is passed through."""
         settled_market = {
             "ticker": "KXNFLGAME-25NOV29-NEBUF-B250",
             "event_ticker": "KXNFLGAME-25NOV29-NEBUF",
             "title": "Bills win by 25+ points?",
             "status": "settled",
             "result": "yes",
+            "settlement_value_dollars": Decimal("1.0000"),
             "yes_ask_dollars": Decimal("1.0000"),
             "no_ask_dollars": Decimal("1.0000"),
             "volume": 1500,
@@ -1324,14 +1325,15 @@ class TestSettlementDetection:
             assert call_kwargs["status"] == "settled"
 
     @pytest.mark.unit
-    def test_settled_market_no_sets_settlement_value(self, poller_with_mock_client):
-        """When a market settles with result='no', settlement_value=0.0000 is passed."""
+    def test_settled_market_no_reads_settlement_value_dollars(self, poller_with_mock_client):
+        """When a market settles with settlement_value_dollars=0.0000, it is passed through."""
         settled_market = {
             "ticker": "KXNFLGAME-25NOV29-NEBUF-B250",
             "event_ticker": "KXNFLGAME-25NOV29-NEBUF",
             "title": "Bills win by 25+ points?",
             "status": "settled",
             "result": "no",
+            "settlement_value_dollars": Decimal("0.0000"),
             "yes_ask_dollars": Decimal("1.0000"),
             "no_ask_dollars": Decimal("1.0000"),
             "volume": 1500,
@@ -1366,14 +1368,60 @@ class TestSettlementDetection:
             assert call_kwargs["settlement_value"] == Decimal("0.0000")
 
     @pytest.mark.unit
-    def test_settled_market_no_result_passes_none(self, poller_with_mock_client):
-        """When a market settles without a result field, settlement_value is None."""
+    def test_settled_market_scalar_reads_fractional_settlement(self, poller_with_mock_client):
+        """Scalar markets pass through fractional settlement_value_dollars directly."""
+        settled_market = {
+            "ticker": "KXNFLGAME-25NOV29-NEBUF-B250",
+            "event_ticker": "KXNFLGAME-25NOV29-NEBUF",
+            "title": "Bills total points 25-30?",
+            "status": "settled",
+            "result": "scalar",
+            "settlement_value_dollars": Decimal("0.7500"),
+            "yes_ask_dollars": Decimal("1.0000"),
+            "no_ask_dollars": Decimal("1.0000"),
+            "volume": 1500,
+            "open_interest": 800,
+        }
+
+        existing = {
+            "ticker": "KXNFLGAME-25NOV29-NEBUF-B250",
+            "yes_ask_price": Decimal("0.4800"),
+            "no_ask_price": Decimal("0.5500"),
+            "status": "open",
+            "event_internal_id": 42,
+        }
+
+        with (
+            patch(
+                "precog.schedulers.kalshi_poller.get_current_market",
+                return_value=existing,
+            ),
+            patch(
+                "precog.schedulers.kalshi_poller.update_market_with_versioning",
+                return_value=1,
+            ) as mock_update,
+            patch(
+                "precog.schedulers.kalshi_poller.check_event_fully_settled",
+                return_value=False,
+            ),
+        ):
+            poller_with_mock_client._sync_market_to_db(settled_market)
+
+            call_kwargs = mock_update.call_args.kwargs
+            assert call_kwargs["settlement_value"] == Decimal("0.7500")
+
+    @pytest.mark.unit
+    def test_settled_market_missing_settlement_value_dollars_passes_none(
+        self, poller_with_mock_client, caplog
+    ):
+        """When both settlement_value_dollars and settlement_value are absent, result is None with warning."""
         settled_market = {
             "ticker": "KXNFLGAME-25NOV29-NEBUF-B250",
             "event_ticker": "KXNFLGAME-25NOV29-NEBUF",
             "title": "Bills win by 25+ points?",
             "status": "settled",
-            # No 'result' key
+            "result": "yes",
+            # No 'settlement_value_dollars' or 'settlement_value' key
             "yes_ask_dollars": Decimal("1.0000"),
             "no_ask_dollars": Decimal("1.0000"),
             "volume": 1500,
@@ -1406,6 +1454,51 @@ class TestSettlementDetection:
 
             call_kwargs = mock_update.call_args.kwargs
             assert call_kwargs["settlement_value"] is None
+            assert "settlement_value_dollars is absent" in caplog.text
+
+    @pytest.mark.unit
+    def test_settled_market_falls_back_to_cents(self, poller_with_mock_client):
+        """When settlement_value_dollars is absent but settlement_value (cents) exists, convert it."""
+        settled_market = {
+            "ticker": "KXNFLGAME-25NOV29-NEBUF-B250",
+            "event_ticker": "KXNFLGAME-25NOV29-NEBUF",
+            "title": "Bills win by 25+ points?",
+            "status": "settled",
+            "result": "yes",
+            # No 'settlement_value_dollars', but legacy cents field present
+            "settlement_value": Decimal("100"),  # 100 cents = $1.00
+            "yes_ask_dollars": Decimal("1.0000"),
+            "no_ask_dollars": Decimal("0.0000"),
+            "volume": 1500,
+            "open_interest": 800,
+        }
+
+        existing = {
+            "ticker": "KXNFLGAME-25NOV29-NEBUF-B250",
+            "yes_ask_price": Decimal("0.4800"),
+            "no_ask_price": Decimal("0.5500"),
+            "status": "open",
+            "event_internal_id": 42,
+        }
+
+        with (
+            patch(
+                "precog.schedulers.kalshi_poller.get_current_market",
+                return_value=existing,
+            ),
+            patch(
+                "precog.schedulers.kalshi_poller.update_market_with_versioning",
+                return_value=1,
+            ) as mock_update,
+            patch(
+                "precog.schedulers.kalshi_poller.check_event_fully_settled",
+                return_value=False,
+            ),
+        ):
+            poller_with_mock_client._sync_market_to_db(settled_market)
+
+            call_kwargs = mock_update.call_args.kwargs
+            assert call_kwargs["settlement_value"] == Decimal("1")
 
     @pytest.mark.unit
     def test_non_settled_market_has_no_settlement_value(self, poller_with_mock_client):
@@ -1454,6 +1547,7 @@ class TestSettlementDetection:
             "title": "Bills win by 25+ points?",
             "status": "settled",
             "result": "yes",
+            "settlement_value_dollars": Decimal("1.0000"),
             "yes_ask_dollars": Decimal("1.0000"),
             "no_ask_dollars": Decimal("1.0000"),
             "volume": 1500,
@@ -1500,6 +1594,7 @@ class TestSettlementDetection:
             "title": "Bills win by 25+ points?",
             "status": "settled",
             "result": "no",
+            "settlement_value_dollars": Decimal("0.0000"),
             "yes_ask_dollars": Decimal("1.0000"),
             "no_ask_dollars": Decimal("1.0000"),
             "volume": 1500,
@@ -1545,6 +1640,7 @@ class TestSettlementDetection:
             "title": "Bills win by 25+ points?",
             "status": "settled",
             "result": "yes",
+            "settlement_value_dollars": Decimal("1.0000"),
             "yes_ask_dollars": Decimal("1.0000"),
             "no_ask_dollars": Decimal("1.0000"),
             "volume": 1500,
@@ -1615,3 +1711,202 @@ class TestSettlementDetection:
             poller_with_mock_client._sync_market_to_db(closing_market)
 
             mock_check.assert_not_called()
+
+    # --- Create path settlement tests ---
+
+    @pytest.mark.unit
+    def test_create_path_settled_market_reads_settlement_value_dollars(
+        self, poller_with_mock_client
+    ):
+        """Create path: settled market reads settlement_value_dollars from API."""
+        settled_market = {
+            "ticker": "KXNFLGAME-25NOV29-NEBUF-B250",
+            "event_ticker": "KXNFLGAME-25NOV29-NEBUF",
+            "title": "Bills win by 25+ points?",
+            "status": "settled",
+            "result": "yes",
+            "settlement_value_dollars": Decimal("1.0000"),
+            "yes_ask_dollars": Decimal("1.0000"),
+            "no_ask_dollars": Decimal("0.0000"),
+            "volume": 1500,
+            "open_interest": 800,
+        }
+
+        with (
+            patch(
+                "precog.schedulers.kalshi_poller.get_current_market",
+                return_value=None,
+            ),
+            patch(
+                "precog.schedulers.kalshi_poller.get_or_create_event",
+                return_value=(1, True),
+            ),
+            patch(
+                "precog.schedulers.kalshi_poller.create_market",
+                return_value=1,
+            ) as mock_create,
+            patch(
+                "precog.schedulers.kalshi_poller.check_event_fully_settled",
+                return_value=False,
+            ),
+        ):
+            poller_with_mock_client._sync_market_to_db(settled_market)
+
+            mock_create.assert_called_once()
+            call_kwargs = mock_create.call_args.kwargs
+            assert call_kwargs["settlement_value"] == Decimal("1.0000")
+
+    @pytest.mark.unit
+    def test_create_path_settled_scalar_reads_fractional_settlement(self, poller_with_mock_client):
+        """Create path: scalar market passes fractional settlement_value_dollars."""
+        settled_market = {
+            "ticker": "KXNFLGAME-25NOV29-NEBUF-B250",
+            "event_ticker": "KXNFLGAME-25NOV29-NEBUF",
+            "title": "Bills total points 25-30?",
+            "status": "settled",
+            "result": "scalar",
+            "settlement_value_dollars": Decimal("0.4200"),
+            "yes_ask_dollars": Decimal("1.0000"),
+            "no_ask_dollars": Decimal("0.0000"),
+            "volume": 1500,
+            "open_interest": 800,
+        }
+
+        with (
+            patch(
+                "precog.schedulers.kalshi_poller.get_current_market",
+                return_value=None,
+            ),
+            patch(
+                "precog.schedulers.kalshi_poller.get_or_create_event",
+                return_value=(1, True),
+            ),
+            patch(
+                "precog.schedulers.kalshi_poller.create_market",
+                return_value=1,
+            ) as mock_create,
+            patch(
+                "precog.schedulers.kalshi_poller.check_event_fully_settled",
+                return_value=False,
+            ),
+        ):
+            poller_with_mock_client._sync_market_to_db(settled_market)
+
+            call_kwargs = mock_create.call_args.kwargs
+            assert call_kwargs["settlement_value"] == Decimal("0.4200")
+
+    @pytest.mark.unit
+    def test_create_path_settled_missing_settlement_value_dollars_passes_none(
+        self, poller_with_mock_client, caplog
+    ):
+        """Create path: missing both settlement fields results in None with warning."""
+        settled_market = {
+            "ticker": "KXNFLGAME-25NOV29-NEBUF-B250",
+            "event_ticker": "KXNFLGAME-25NOV29-NEBUF",
+            "title": "Bills win by 25+ points?",
+            "status": "settled",
+            "result": "yes",
+            # No 'settlement_value_dollars' or 'settlement_value' key
+            "yes_ask_dollars": Decimal("1.0000"),
+            "no_ask_dollars": Decimal("0.0000"),
+            "volume": 1500,
+            "open_interest": 800,
+        }
+
+        with (
+            patch(
+                "precog.schedulers.kalshi_poller.get_current_market",
+                return_value=None,
+            ),
+            patch(
+                "precog.schedulers.kalshi_poller.get_or_create_event",
+                return_value=(1, True),
+            ),
+            patch(
+                "precog.schedulers.kalshi_poller.create_market",
+                return_value=1,
+            ) as mock_create,
+            patch(
+                "precog.schedulers.kalshi_poller.check_event_fully_settled",
+                return_value=False,
+            ),
+        ):
+            poller_with_mock_client._sync_market_to_db(settled_market)
+
+            call_kwargs = mock_create.call_args.kwargs
+            assert call_kwargs["settlement_value"] is None
+            assert "settlement_value_dollars is absent" in caplog.text
+
+    @pytest.mark.unit
+    def test_create_path_settled_falls_back_to_cents(self, poller_with_mock_client):
+        """Create path: falls back to settlement_value (cents) when _dollars absent."""
+        settled_market = {
+            "ticker": "KXNFLGAME-25NOV29-NEBUF-B250",
+            "event_ticker": "KXNFLGAME-25NOV29-NEBUF",
+            "title": "Bills win by 25+ points?",
+            "status": "settled",
+            "result": "no",
+            # No 'settlement_value_dollars', but legacy cents field present
+            "settlement_value": Decimal("0"),  # 0 cents = $0.00
+            "yes_ask_dollars": Decimal("0.0000"),
+            "no_ask_dollars": Decimal("1.0000"),
+            "volume": 1500,
+            "open_interest": 800,
+        }
+
+        with (
+            patch(
+                "precog.schedulers.kalshi_poller.get_current_market",
+                return_value=None,
+            ),
+            patch(
+                "precog.schedulers.kalshi_poller.get_or_create_event",
+                return_value=(1, True),
+            ),
+            patch(
+                "precog.schedulers.kalshi_poller.create_market",
+                return_value=1,
+            ) as mock_create,
+            patch(
+                "precog.schedulers.kalshi_poller.check_event_fully_settled",
+                return_value=False,
+            ),
+        ):
+            poller_with_mock_client._sync_market_to_db(settled_market)
+
+            call_kwargs = mock_create.call_args.kwargs
+            assert call_kwargs["settlement_value"] == Decimal("0")
+
+    @pytest.mark.unit
+    def test_create_path_non_settled_market_has_no_settlement_value(self, poller_with_mock_client):
+        """Create path: non-settled markets pass settlement_value=None."""
+        open_market = {
+            "ticker": "KXNFLGAME-25NOV29-NEBUF-B250",
+            "event_ticker": "KXNFLGAME-25NOV29-NEBUF",
+            "title": "Bills win by 25+ points?",
+            "status": "active",  # Maps to 'open'
+            "result": None,
+            "yes_ask_dollars": Decimal("0.6000"),
+            "no_ask_dollars": Decimal("0.4000"),
+            "volume": 1500,
+            "open_interest": 800,
+        }
+
+        with (
+            patch(
+                "precog.schedulers.kalshi_poller.get_current_market",
+                return_value=None,
+            ),
+            patch(
+                "precog.schedulers.kalshi_poller.get_or_create_event",
+                return_value=(1, True),
+            ),
+            patch(
+                "precog.schedulers.kalshi_poller.create_market",
+                return_value=1,
+            ) as mock_create,
+        ):
+            poller_with_mock_client._sync_market_to_db(open_market)
+
+            call_kwargs = mock_create.call_args.kwargs
+            assert call_kwargs["settlement_value"] is None


### PR DESCRIPTION
## Summary
- Read `settlement_value_dollars` directly from the Kalshi API instead of deriving from `result` field
- Fixes scalar market settlement (`result='scalar'` previously produced NULL + warning)
- Falls back to legacy `settlement_value` (cents) / 100 if `_dollars` variant absent
- Updated `MarketData` TypedDict: `result` enum now includes `'scalar'` and `''` per API spec
- Added `settlement_value_dollars` field to both `MarketData` and `ProcessedMarketData`

Closes #513 (P0 scope only — P1 enrichment fields tracked separately)

## Test plan
- [x] 15 settlement tests (was 8): yes/no/scalar/missing/cents-fallback on both create and update paths
- [x] Unit tests: 2,380 passed
- [x] Integration + E2E: 982 passed
- [x] Stress + Chaos + Race: 1,057 passed
- [x] Ruff + mypy: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)