### PR TITLE
feat: External team codes table — persistent cross-platform mapping (#516)

### DIFF
--- a/scripts/seed_external_team_codes.py
+++ b/scripts/seed_external_team_codes.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Seed the external_team_codes table from existing teams data.
+
+Populates the external_team_codes table with mappings derived from the
+teams table. Creates three categories of mappings:
+
+1. source='kalshi', confidence='manual': Teams that have an explicit
+   kalshi_team_code set (e.g., JAX -> JAC). These were human-verified.
+2. source='kalshi', confidence='heuristic': Teams without kalshi_team_code
+   where we assume the Kalshi code matches the ESPN team_code (~95% of teams).
+3. source='espn', confidence='exact': Every team gets an ESPN mapping using
+   team_code, since team_code IS the ESPN code.
+
+Uses upsert for idempotency — safe to run multiple times without duplicates.
+
+Usage:
+    # Seed from existing teams data
+    python scripts/seed_external_team_codes.py
+
+    # Dry run (show counts, don't write)
+    python scripts/seed_external_team_codes.py --dry-run
+
+    # Filter to specific league
+    python scripts/seed_external_team_codes.py --league nfl
+
+Environment:
+    Uses PRECOG_ENV to determine database connection (dev/test/staging/prod).
+    Defaults to 'dev' if not set.
+
+Related:
+    - Issue #516: External team codes table
+    - Migration 0045: CREATE TABLE external_team_codes
+    - crud_operations.upsert_external_team_code(): Write function
+    - crud_operations.get_teams_with_kalshi_codes(): Data source
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Ensure src/ is on the path when running as a script
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from precog.database.crud_operations import (
+    get_teams_with_kalshi_codes,
+    upsert_external_team_code,
+)
+from precog.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def seed_external_team_codes(
+    league: str | None = None,
+    dry_run: bool = False,
+) -> dict[str, int]:
+    """Seed external_team_codes from teams table data.
+
+    Args:
+        league: Optional league filter. If None, seeds all leagues.
+        dry_run: If True, compute and print counts without writing.
+
+    Returns:
+        Dict with counts: {
+            'kalshi_manual': N,
+            'kalshi_heuristic': N,
+            'espn_exact': N,
+            'total': N,
+        }
+    """
+    teams = get_teams_with_kalshi_codes(league=league)
+
+    if not teams:
+        logger.warning("No teams found%s", f" for league={league}" if league else "")
+        return {"kalshi_manual": 0, "kalshi_heuristic": 0, "espn_exact": 0, "total": 0}
+
+    kalshi_manual = 0
+    kalshi_heuristic = 0
+    espn_exact = 0
+    skipped = 0
+
+    for team in teams:
+        team_id = team["team_id"]
+        team_code = team["team_code"]
+        team_league = team["league"]
+        kalshi_code = team.get("kalshi_team_code")
+
+        if not team_code or not team_league:
+            logger.warning(
+                "Skipping team_id=%d: missing team_code or league",
+                team["team_id"],
+            )
+            skipped += 1
+            continue
+
+        # --- Kalshi mapping ---
+        if kalshi_code:
+            # Explicit kalshi_team_code: human-verified mapping
+            if not dry_run:
+                upsert_external_team_code(
+                    team_id=team_id,
+                    source="kalshi",
+                    source_team_code=kalshi_code,
+                    league=team_league,
+                    confidence="manual",
+                    notes=f"From teams.kalshi_team_code (ESPN code: {team_code})",
+                )
+            kalshi_manual += 1
+        else:
+            # No explicit Kalshi code: assume Kalshi code = ESPN code
+            if not dry_run:
+                upsert_external_team_code(
+                    team_id=team_id,
+                    source="kalshi",
+                    source_team_code=team_code,
+                    league=team_league,
+                    confidence="heuristic",
+                    notes="Assumed Kalshi code matches ESPN team_code",
+                )
+            kalshi_heuristic += 1
+
+        # --- ESPN mapping ---
+        # team_code IS the ESPN code, so this is always exact
+        if not dry_run:
+            upsert_external_team_code(
+                team_id=team_id,
+                source="espn",
+                source_team_code=team_code,
+                league=team_league,
+                confidence="exact",
+                notes="ESPN team_code from teams table",
+            )
+        espn_exact += 1
+
+    total = kalshi_manual + kalshi_heuristic + espn_exact
+    return {
+        "kalshi_manual": kalshi_manual,
+        "kalshi_heuristic": kalshi_heuristic,
+        "espn_exact": espn_exact,
+        "skipped": skipped,
+        "total": total,
+    }
+
+
+def main() -> None:
+    """CLI entry point for seeding external team codes."""
+    parser = argparse.ArgumentParser(
+        description="Seed external_team_codes table from existing teams data.",
+        epilog=(
+            "Examples:\n"
+            "  python scripts/seed_external_team_codes.py\n"
+            "  python scripts/seed_external_team_codes.py --dry-run\n"
+            "  python scripts/seed_external_team_codes.py --league nfl\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be seeded without writing to the database.",
+    )
+    parser.add_argument(
+        "--league",
+        type=str,
+        default=None,
+        help="Seed only a specific league (e.g., nfl, ncaaf). Default: all leagues.",
+    )
+    args = parser.parse_args()
+
+    env = os.getenv("PRECOG_ENV", "dev")
+    mode = "DRY RUN" if args.dry_run else "LIVE"
+    league_label = args.league or "all"
+
+    print(f"Seeding external_team_codes [{mode}] (env={env}, league={league_label})")
+    print("-" * 60)
+
+    counts = seed_external_team_codes(league=args.league, dry_run=args.dry_run)
+
+    print(f"  Kalshi codes: {counts['kalshi_manual'] + counts['kalshi_heuristic']}")
+    print(f"    - manual (explicit kalshi_team_code):  {counts['kalshi_manual']}")
+    print(f"    - heuristic (assumed = ESPN code):     {counts['kalshi_heuristic']}")
+    print(f"  ESPN codes:   {counts['espn_exact']}")
+    print(f"  Total:        {counts['total']}")
+    print("-" * 60)
+
+    if args.dry_run:
+        print("DRY RUN complete. No rows were written.")
+    else:
+        print("Seeding complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/precog/database/alembic/versions/0045_create_external_team_codes.py
+++ b/src/precog/database/alembic/versions/0045_create_external_team_codes.py
@@ -1,0 +1,88 @@
+"""Create external_team_codes table for persistent cross-platform team mapping.
+
+Replaces the fragile in-memory collision resolution with a persistent,
+auditable, multi-source team code mapping table. Each row maps a source
+platform's team code to the canonical team_id in our teams table.
+
+Table Design:
+    - (source, source_team_code, league) is UNIQUE — each platform can only
+      map a given code+league to one team
+    - team_id FK to teams(team_id) — every external code must resolve to
+      a known team
+    - confidence tracks how the mapping was established:
+      'exact'     = verified by API or manual human check
+      'manual'    = set by a human but not independently verified
+      'heuristic' = inferred (e.g., Kalshi code assumed to match ESPN code)
+
+Indexes:
+    - idx_external_team_codes_team   — fast lookup by team_id
+    - idx_external_team_codes_source — fast lookup by (source, league)
+
+Revision ID: 0045
+Revises: 0044
+Create Date: 2026-03-29
+
+Related:
+    - Issue #516: External team codes table
+    - Issue #495: Polymarket integration (needs this table)
+    - Issue #496: Cross-platform event matching (needs this table)
+    - Issue #502: MLB enablement (needs this table)
+    - Migration 0041: teams.kalshi_team_code column (predecessor approach)
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0045"
+down_revision: str = "0044"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create external_team_codes table with indexes.
+
+    Educational Note:
+        The UNIQUE constraint on (source, source_team_code, league) ensures
+        that a given platform can only map a code+league combination to one
+        team. For example, Kalshi's "JAC" in "nfl" can only point to one
+        team_id. If Kalshi starts using "JAC" for a different sport, that's
+        a separate row because the league differs.
+
+        The ON DELETE CASCADE is intentionally NOT used — if a team is
+        deleted, we want the FK violation to alert us rather than silently
+        cascading. Team deletions are rare and should be handled manually.
+    """
+    op.execute(
+        """
+        CREATE TABLE external_team_codes (
+            id SERIAL PRIMARY KEY,
+            team_id INTEGER NOT NULL REFERENCES teams(team_id),
+            source VARCHAR(30) NOT NULL,
+            source_team_code VARCHAR(30) NOT NULL,
+            league VARCHAR(20) NOT NULL,
+            confidence VARCHAR(20) NOT NULL DEFAULT 'heuristic',
+            verified_at TIMESTAMP WITH TIME ZONE,
+            notes TEXT,
+            created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+            UNIQUE (source, source_team_code, league)
+        )
+        """
+    )
+
+    # Index for lookups by team_id (e.g., "what codes does team X have?")
+    op.execute("CREATE INDEX idx_external_team_codes_team ON external_team_codes(team_id)")
+
+    # Index for lookups by source + league (e.g., "all Kalshi NFL codes")
+    op.execute("CREATE INDEX idx_external_team_codes_source ON external_team_codes(source, league)")
+
+
+def downgrade() -> None:
+    """Drop external_team_codes table and its indexes.
+
+    Indexes are dropped automatically when the table is dropped.
+    """
+    op.execute("DROP TABLE IF EXISTS external_team_codes")

--- a/src/precog/database/crud_operations.py
+++ b/src/precog/database/crud_operations.py
@@ -9395,3 +9395,270 @@ def find_game_by_matchup(
     if result:
         return cast("int", result["id"])
     return None
+
+
+# =============================================================================
+# EXTERNAL TEAM CODES CRUD (Migration 0045)
+# =============================================================================
+# These functions manage the external_team_codes table, which maps team codes
+# from external platforms (Kalshi, Polymarket, ESPN, etc.) to the canonical
+# team_id in our teams table. This replaces the fragile in-memory collision
+# resolution with a persistent, auditable, multi-source mapping.
+#
+# Related:
+#   - Issue #516: External team codes table
+#   - Migration 0045: CREATE TABLE external_team_codes
+#   - TeamCodeRegistry.load_from_external_codes(): Primary consumer
+
+
+def create_external_team_code(
+    team_id: int,
+    source: str,
+    source_team_code: str,
+    league: str,
+    confidence: str = "heuristic",
+    verified_at: str | None = None,
+    notes: str | None = None,
+) -> int:
+    """Create a new external team code mapping.
+
+    Maps a source platform's team code to a canonical team_id. For example,
+    Kalshi's "JAC" in NFL maps to team_id for Jacksonville Jaguars.
+
+    Args:
+        team_id: FK to teams.team_id (the canonical team).
+        source: Platform name ('kalshi', 'polymarket', 'espn', 'odds_api', 'cfbd').
+        source_team_code: The code that platform uses for the team.
+        league: League code ('nfl', 'nba', 'ncaaf', etc.).
+        confidence: How the mapping was established.
+            'exact' = verified by API or human check.
+            'manual' = set by a human but not independently verified.
+            'heuristic' = inferred (e.g., assumed Kalshi code = ESPN code).
+        verified_at: ISO 8601 timestamp of when the mapping was verified.
+            None if not yet verified.
+        notes: Optional human-readable notes about this mapping.
+
+    Returns:
+        The new row's id (SERIAL PK).
+
+    Raises:
+        psycopg2.errors.UniqueViolation: If (source, source_team_code, league)
+            already exists. Use upsert_external_team_code() for idempotent writes.
+        psycopg2.errors.ForeignKeyViolation: If team_id does not exist in teams.
+
+    Example:
+        >>> code_id = create_external_team_code(
+        ...     team_id=42,
+        ...     source="kalshi",
+        ...     source_team_code="JAC",
+        ...     league="nfl",
+        ...     confidence="manual",
+        ...     notes="Kalshi uses JAC for Jacksonville, ESPN uses JAX",
+        ... )
+        >>> print(code_id)  # 1
+
+    Related:
+        - Issue #516: External team codes table
+        - Migration 0045: CREATE TABLE external_team_codes
+    """
+    query = """
+        INSERT INTO external_team_codes
+            (team_id, source, source_team_code, league, confidence, verified_at, notes)
+        VALUES (%s, %s, %s, %s, %s, %s, %s)
+        RETURNING id
+    """
+    with get_cursor(commit=True) as cur:
+        cur.execute(
+            query,
+            (team_id, source, source_team_code, league, confidence, verified_at, notes),
+        )
+        row = cur.fetchone()
+        return cast("int", row["id"])
+
+
+def get_external_team_codes(
+    source: str | None = None,
+    league: str | None = None,
+    team_id: int | None = None,
+) -> list[dict[str, Any]]:
+    """Get external team codes with optional filters.
+
+    Returns all external team code mappings, optionally filtered by any
+    combination of source, league, and team_id.
+
+    Args:
+        source: Filter by platform name (e.g., 'kalshi', 'espn').
+        league: Filter by league code (e.g., 'nfl', 'ncaaf').
+        team_id: Filter by canonical team_id.
+
+    Returns:
+        List of dicts with all columns from external_team_codes.
+        Empty list if no matches.
+
+    Example:
+        >>> # All Kalshi NFL codes
+        >>> codes = get_external_team_codes(source="kalshi", league="nfl")
+        >>> len(codes)  # 32 (one per NFL team)
+
+        >>> # All codes for a specific team
+        >>> codes = get_external_team_codes(team_id=42)
+        >>> for c in codes:
+        ...     print(f"{c['source']}: {c['source_team_code']}")
+        ...     # kalshi: JAC
+        ...     # espn: JAX
+
+    Related:
+        - Issue #516: External team codes table
+    """
+    conditions: list[str] = []
+    params: list[Any] = []
+
+    if source is not None:
+        conditions.append("source = %s")
+        params.append(source)
+    if league is not None:
+        conditions.append("league = %s")
+        params.append(league)
+    if team_id is not None:
+        conditions.append("team_id = %s")
+        params.append(team_id)
+
+    where_clause = ""
+    if conditions:
+        where_clause = "WHERE " + " AND ".join(conditions)
+
+    query = f"""
+        SELECT id, team_id, source, source_team_code, league,
+               confidence, verified_at, notes, created_at, updated_at
+        FROM external_team_codes
+        {where_clause}
+        ORDER BY source, league, source_team_code
+    """  # noqa: S608
+    return fetch_all(query, tuple(params) if params else None)
+
+
+def find_team_by_external_code(
+    source: str,
+    source_team_code: str,
+    league: str,
+) -> dict[str, Any] | None:
+    """Look up a team by its external platform code.
+
+    The key lookup function: given a source platform's code and league,
+    resolve to the canonical team row from the teams table. Joins
+    external_team_codes with teams to return the full team record.
+
+    Args:
+        source: Platform name ('kalshi', 'polymarket', 'espn', etc.).
+        source_team_code: The code that platform uses for the team.
+        league: League code ('nfl', 'nba', 'ncaaf', etc.).
+
+    Returns:
+        Dictionary with the full team row (from teams table) plus the
+        external code's confidence level, or None if no mapping exists.
+
+    Example:
+        >>> team = find_team_by_external_code("kalshi", "JAC", "nfl")
+        >>> if team:
+        ...     print(f"{team['team_name']} ({team['team_code']})")
+        ...     # Jacksonville Jaguars (JAX)
+        ...     print(f"Confidence: {team['confidence']}")
+        ...     # Confidence: manual
+
+    Related:
+        - Issue #516: External team codes table
+        - get_team_by_kalshi_code(): Legacy equivalent (teams table only)
+    """
+    query = """
+        SELECT t.*, etc.confidence, etc.source_team_code AS external_code
+        FROM external_team_codes etc
+        JOIN teams t ON t.team_id = etc.team_id
+        WHERE etc.source = %s
+          AND etc.source_team_code = %s
+          AND etc.league = %s
+    """
+    return fetch_one(query, (source, source_team_code, league))
+
+
+def upsert_external_team_code(
+    team_id: int,
+    source: str,
+    source_team_code: str,
+    league: str,
+    confidence: str = "heuristic",
+    notes: str | None = None,
+) -> int:
+    """Insert or update an external team code mapping (idempotent).
+
+    Uses PostgreSQL's INSERT ... ON CONFLICT ... DO UPDATE to either
+    create a new mapping or update an existing one. The conflict key is
+    (source, source_team_code, league).
+
+    On conflict (existing mapping): updates team_id, confidence, notes,
+    and updated_at. This allows bulk seeding to be run repeatedly without
+    duplicates.
+
+    Args:
+        team_id: FK to teams.team_id (the canonical team).
+        source: Platform name ('kalshi', 'polymarket', 'espn', etc.).
+        source_team_code: The code that platform uses for the team.
+        league: League code ('nfl', 'nba', 'ncaaf', etc.).
+        confidence: How the mapping was established ('exact', 'manual',
+            'heuristic').
+        notes: Optional human-readable notes about this mapping.
+
+    Returns:
+        The row's id (either newly created or existing).
+
+    Raises:
+        psycopg2.errors.ForeignKeyViolation: If team_id does not exist.
+
+    Example:
+        >>> # First call creates the row
+        >>> id1 = upsert_external_team_code(42, "kalshi", "JAC", "nfl", "manual")
+        >>> # Second call updates (idempotent)
+        >>> id2 = upsert_external_team_code(42, "kalshi", "JAC", "nfl", "exact")
+        >>> assert id1 == id2  # Same row updated
+
+    Related:
+        - Issue #516: External team codes table
+        - scripts/seed_external_team_codes.py: Primary consumer
+    """
+    query = """
+        INSERT INTO external_team_codes
+            (team_id, source, source_team_code, league, confidence, notes)
+        VALUES (%s, %s, %s, %s, %s, %s)
+        ON CONFLICT (source, source_team_code, league)
+        DO UPDATE SET
+            team_id = EXCLUDED.team_id,
+            confidence = EXCLUDED.confidence,
+            notes = EXCLUDED.notes,
+            updated_at = NOW()
+        RETURNING id
+    """
+    with get_cursor(commit=True) as cur:
+        cur.execute(query, (team_id, source, source_team_code, league, confidence, notes))
+        row = cur.fetchone()
+        return cast("int", row["id"])
+
+
+def delete_external_team_code(code_id: int) -> bool:
+    """Delete an external team code mapping by its PK.
+
+    Args:
+        code_id: The external_team_codes.id to delete.
+
+    Returns:
+        True if a row was deleted, False if no row with that id existed.
+
+    Example:
+        >>> deleted = delete_external_team_code(42)
+        >>> print(deleted)  # True
+
+    Related:
+        - Issue #516: External team codes table
+    """
+    query = "DELETE FROM external_team_codes WHERE id = %s"
+    with get_cursor(commit=True) as cur:
+        cur.execute(query, (code_id,))
+        return bool(cur.rowcount > 0)

--- a/src/precog/matching/team_code_registry.py
+++ b/src/precog/matching/team_code_registry.py
@@ -142,9 +142,9 @@ class TeamCodeRegistry:
     def load(self, league: str | None = None) -> None:
         """Load team codes from DB into in-memory cache.
 
-        Queries the teams table for all teams (or a specific league) and
-        builds the mapping dictionaries. Safe to call multiple times
-        (replaces existing data for reloaded leagues).
+        Attempts to load from external_team_codes table first (persistent
+        multi-source mappings). Falls back to the legacy teams table if the
+        external table is empty, doesn't exist, or encounters an error.
 
         Args:
             league: Optional league filter. If None, loads all leagues.
@@ -153,6 +153,23 @@ class TeamCodeRegistry:
             >>> registry = TeamCodeRegistry()
             >>> registry.load()           # Load all leagues
             >>> registry.load("nfl")      # Refresh NFL only
+        """
+        # Try external_team_codes first (new persistent approach)
+        if self._try_load_from_external_codes(league=league):
+            return
+
+        # Fall back to legacy teams table approach
+        self._load_from_teams_table(league=league)
+
+    def _load_from_teams_table(self, league: str | None = None) -> None:
+        """Load from teams table (legacy mode).
+
+        This is the original load path, reading directly from the teams
+        table's kalshi_team_code column. Used as a fallback when the
+        external_team_codes table is empty or unavailable.
+
+        Args:
+            league: Optional league filter. If None, loads all leagues.
         """
         # Import here to avoid circular imports at module level
         from precog.database.crud_operations import get_teams_with_kalshi_codes
@@ -166,17 +183,159 @@ class TeamCodeRegistry:
         total_codes = sum(len(codes) for codes in self._kalshi_codes.values())
         if collisions:
             logger.info(
-                "TeamCodeRegistry loaded: %d leagues, %d total codes (%d code collisions resolved, see DEBUG for details)",
+                "TeamCodeRegistry loaded from teams table (legacy mode): "
+                "%d leagues, %d total codes (%d code collisions resolved, see DEBUG for details)",
                 len(self._kalshi_codes),
                 total_codes,
                 collisions,
             )
         else:
             logger.info(
-                "TeamCodeRegistry loaded: %d leagues, %d total codes",
+                "TeamCodeRegistry loaded from teams table (legacy mode): "
+                "%d leagues, %d total codes",
                 len(self._kalshi_codes),
                 total_codes,
             )
+
+    def _try_load_from_external_codes(
+        self,
+        source: str = "kalshi",
+        league: str | None = None,
+    ) -> bool:
+        """Try to load from external_team_codes table.
+
+        Reads Kalshi code mappings from external_team_codes and resolves
+        each to the corresponding ESPN code by looking up the same team_id
+        with source='espn'.
+
+        Args:
+            source: The source platform to load codes for. Default 'kalshi'.
+            league: Optional league filter.
+
+        Returns:
+            True if successfully loaded (at least one code found).
+            False if the table is empty, doesn't exist, or errors occur
+            (caller should fall back to legacy load).
+        """
+        try:
+            from precog.database.crud_operations import get_external_team_codes
+
+            # Get all codes for the requested source
+            kalshi_codes = get_external_team_codes(source=source, league=league)
+            if not kalshi_codes:
+                logger.debug(
+                    "external_team_codes table empty for source=%s league=%s, "
+                    "falling back to legacy load",
+                    source,
+                    league,
+                )
+                return False
+
+            # Get ESPN codes for cross-referencing (team_id -> ESPN code)
+            espn_codes = get_external_team_codes(source="espn", league=league)
+            espn_by_team: dict[int, str] = {}
+            for ec in espn_codes:
+                espn_by_team[ec["team_id"]] = ec["source_team_code"]
+
+            # Build team data in the format _build_cache expects
+            teams: list[dict[str, Any]] = []
+            for kc in kalshi_codes:
+                team_id = kc["team_id"]
+                kalshi_code_val = kc["source_team_code"]
+                code_league = kc["league"]
+
+                # Look up the ESPN code for this team
+                espn_code = espn_by_team.get(team_id)
+                if espn_code is None:
+                    # No ESPN mapping — use the Kalshi code as both
+                    # (same behavior as teams without kalshi_team_code in legacy)
+                    logger.debug(
+                        "No ESPN code for team_id=%d (kalshi=%s:%s), "
+                        "using Kalshi code as team_code",
+                        team_id,
+                        kalshi_code_val,
+                        code_league,
+                    )
+                    espn_code = kalshi_code_val
+
+                # If Kalshi code differs from ESPN code, set kalshi_team_code
+                # Otherwise, leave it None (same code on both platforms)
+                if kalshi_code_val.upper() != espn_code.upper():
+                    kalshi_team_code = kalshi_code_val
+                else:
+                    kalshi_team_code = None
+
+                teams.append(
+                    {
+                        "team_code": espn_code,
+                        "league": code_league,
+                        "kalshi_team_code": kalshi_team_code,
+                        # Classification not needed: UNIQUE(source, source_team_code,
+                        # league) on external_team_codes means code collisions are
+                        # impossible — each code maps to exactly one team.
+                    }
+                )
+
+            collisions = self._build_cache(teams, league)
+            self._loaded = True
+            self._last_loaded_at = datetime.now(UTC)
+            self._unknown_codes_seen.clear()
+
+            total_codes = sum(len(codes) for codes in self._kalshi_codes.values())
+            if collisions:
+                logger.info(
+                    "TeamCodeRegistry loaded from external_team_codes (%d codes): "
+                    "%d leagues, %d total codes (%d collisions resolved)",
+                    len(kalshi_codes),
+                    len(self._kalshi_codes),
+                    total_codes,
+                    collisions,
+                )
+            else:
+                logger.info(
+                    "TeamCodeRegistry loaded from external_team_codes (%d codes): "
+                    "%d leagues, %d total codes",
+                    len(kalshi_codes),
+                    len(self._kalshi_codes),
+                    total_codes,
+                )
+            return True
+
+        except Exception:
+            # Table might not exist yet (pre-migration), or other DB error.
+            # Fall back to legacy load gracefully.
+            logger.debug(
+                "Failed to load from external_team_codes, falling back to legacy load",
+                exc_info=True,
+            )
+            return False
+
+    def load_from_external_codes(
+        self,
+        source: str = "kalshi",
+        league: str | None = None,
+    ) -> None:
+        """Load team codes from external_team_codes table.
+
+        Public method to explicitly load from the external_team_codes table
+        instead of the legacy teams table. Falls back to legacy load() if
+        the external table is empty or doesn't exist.
+
+        Args:
+            source: The source platform to load codes for. Default 'kalshi'.
+            league: Optional league filter. If None, loads all leagues.
+
+        Example:
+            >>> registry = TeamCodeRegistry()
+            >>> registry.load_from_external_codes()  # Load Kalshi codes
+            >>> registry.load_from_external_codes(source="polymarket")
+        """
+        if not self._try_load_from_external_codes(source=source, league=league):
+            logger.info(
+                "external_team_codes empty/unavailable for source=%s, falling back to legacy load",
+                source,
+            )
+            self._load_from_teams_table(league=league)
 
     def load_from_data(self, teams: list[dict[str, Any]]) -> None:
         """Load registry from pre-fetched team data (for testing).

--- a/tests/unit/database/test_external_team_codes_crud.py
+++ b/tests/unit/database/test_external_team_codes_crud.py
@@ -1,0 +1,367 @@
+"""
+Unit Tests for External Team Codes CRUD Operations (Migration 0045).
+
+Tests the CRUD lifecycle for external_team_codes: create, get (with filters),
+find_by_external_code (JOIN lookup), upsert (insert + update), and delete.
+
+All tests use mock DB cursors matching existing test patterns in this project.
+
+Related:
+    - Migration 0045: CREATE TABLE external_team_codes
+    - Issue #516: External team codes table
+    - crud_operations.py: Implementation
+
+Usage:
+    pytest tests/unit/database/test_external_team_codes_crud.py -v
+    pytest tests/unit/database/test_external_team_codes_crud.py -v -m unit
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from precog.database.crud_operations import (
+    create_external_team_code,
+    delete_external_team_code,
+    find_team_by_external_code,
+    get_external_team_codes,
+    upsert_external_team_code,
+)
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+
+def _mock_cursor_context(mock_get_cursor, mock_cursor=None):
+    """Set up mock_get_cursor to return a context manager yielding mock_cursor."""
+    if mock_cursor is None:
+        mock_cursor = MagicMock()
+    mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_cursor
+
+
+# =============================================================================
+# CREATE TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestCreateExternalTeamCode:
+    """Unit tests for create_external_team_code."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_returns_id(self, mock_get_cursor):
+        """Creating a new code returns the SERIAL PK."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        result = create_external_team_code(
+            team_id=42,
+            source="kalshi",
+            source_team_code="JAC",
+            league="nfl",
+            confidence="manual",
+            notes="Kalshi uses JAC for Jacksonville",
+        )
+
+        assert result == 1
+        mock_cursor.execute.assert_called_once()
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "INSERT INTO external_team_codes" in sql
+        assert "RETURNING id" in sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_with_defaults(self, mock_get_cursor):
+        """Creating with only required params uses default confidence='heuristic'."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 5}
+
+        result = create_external_team_code(
+            team_id=10,
+            source="espn",
+            source_team_code="HOU",
+            league="nfl",
+        )
+
+        assert result == 5
+        # Verify params passed include default confidence
+        params = mock_cursor.execute.call_args[0][1]
+        assert params[0] == 10  # team_id
+        assert params[1] == "espn"  # source
+        assert params[2] == "HOU"  # source_team_code
+        assert params[3] == "nfl"  # league
+        assert params[4] == "heuristic"  # default confidence
+        assert params[5] is None  # verified_at
+        assert params[6] is None  # notes
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_with_verified_at(self, mock_get_cursor):
+        """Creating with a verified_at timestamp passes it through."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 7}
+
+        create_external_team_code(
+            team_id=42,
+            source="kalshi",
+            source_team_code="JAC",
+            league="nfl",
+            confidence="exact",
+            verified_at="2026-03-29T12:00:00Z",
+        )
+
+        params = mock_cursor.execute.call_args[0][1]
+        assert params[4] == "exact"
+        assert params[5] == "2026-03-29T12:00:00Z"
+
+
+# =============================================================================
+# GET (WITH FILTERS) TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestGetExternalTeamCodes:
+    """Unit tests for get_external_team_codes."""
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_all_no_filters(self, mock_fetch_all):
+        """Getting all codes with no filters returns everything."""
+        mock_fetch_all.return_value = [
+            {"id": 1, "source": "kalshi", "source_team_code": "JAC", "league": "nfl"},
+            {"id": 2, "source": "espn", "source_team_code": "JAX", "league": "nfl"},
+        ]
+
+        result = get_external_team_codes()
+
+        assert len(result) == 2
+        sql = mock_fetch_all.call_args[0][0]
+        assert "WHERE" not in sql
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_filtered_by_source(self, mock_fetch_all):
+        """Filtering by source adds WHERE clause."""
+        mock_fetch_all.return_value = [
+            {"id": 1, "source": "kalshi", "source_team_code": "JAC", "league": "nfl"},
+        ]
+
+        get_external_team_codes(source="kalshi")
+
+        sql = mock_fetch_all.call_args[0][0]
+        assert "WHERE" in sql
+        assert "source = %s" in sql
+        params = mock_fetch_all.call_args[0][1]
+        assert params == ("kalshi",)
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_filtered_by_league(self, mock_fetch_all):
+        """Filtering by league adds WHERE clause."""
+        mock_fetch_all.return_value = []
+
+        get_external_team_codes(league="nba")
+
+        sql = mock_fetch_all.call_args[0][0]
+        assert "league = %s" in sql
+        params = mock_fetch_all.call_args[0][1]
+        assert params == ("nba",)
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_filtered_by_team_id(self, mock_fetch_all):
+        """Filtering by team_id adds WHERE clause."""
+        mock_fetch_all.return_value = []
+
+        get_external_team_codes(team_id=42)
+
+        sql = mock_fetch_all.call_args[0][0]
+        assert "team_id = %s" in sql
+        params = mock_fetch_all.call_args[0][1]
+        assert params == (42,)
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_multiple_filters(self, mock_fetch_all):
+        """Multiple filters are combined with AND."""
+        mock_fetch_all.return_value = []
+
+        get_external_team_codes(source="kalshi", league="nfl", team_id=42)
+
+        sql = mock_fetch_all.call_args[0][0]
+        assert "source = %s" in sql
+        assert "league = %s" in sql
+        assert "team_id = %s" in sql
+        assert "AND" in sql
+        params = mock_fetch_all.call_args[0][1]
+        assert params == ("kalshi", "nfl", 42)
+
+    @patch("precog.database.crud_operations.fetch_all")
+    def test_get_empty_result(self, mock_fetch_all):
+        """No matching codes returns empty list."""
+        mock_fetch_all.return_value = []
+
+        result = get_external_team_codes(source="polymarket")
+
+        assert result == []
+
+
+# =============================================================================
+# FIND BY EXTERNAL CODE (JOIN LOOKUP) TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestFindTeamByExternalCode:
+    """Unit tests for find_team_by_external_code."""
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_find_returns_team_with_confidence(self, mock_fetch_one):
+        """Finding a team returns the full team row plus confidence."""
+        mock_fetch_one.return_value = {
+            "team_id": 42,
+            "team_code": "JAX",
+            "team_name": "Jacksonville Jaguars",
+            "league": "nfl",
+            "confidence": "manual",
+            "external_code": "JAC",
+        }
+
+        result = find_team_by_external_code("kalshi", "JAC", "nfl")
+
+        assert result is not None
+        assert result["team_code"] == "JAX"
+        assert result["confidence"] == "manual"
+        assert result["external_code"] == "JAC"
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_find_nonexistent_returns_none(self, mock_fetch_one):
+        """Looking up a code that doesn't exist returns None."""
+        mock_fetch_one.return_value = None
+
+        result = find_team_by_external_code("kalshi", "ZZZ", "nfl")
+
+        assert result is None
+
+    @patch("precog.database.crud_operations.fetch_one")
+    def test_find_uses_join_query(self, mock_fetch_one):
+        """The query JOINs external_team_codes with teams."""
+        mock_fetch_one.return_value = None
+
+        find_team_by_external_code("kalshi", "JAC", "nfl")
+
+        sql = mock_fetch_one.call_args[0][0]
+        assert "JOIN teams" in sql
+        assert "external_team_codes" in sql
+        params = mock_fetch_one.call_args[0][1]
+        assert params == ("kalshi", "JAC", "nfl")
+
+
+# =============================================================================
+# UPSERT TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestUpsertExternalTeamCode:
+    """Unit tests for upsert_external_team_code."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_upsert_returns_id(self, mock_get_cursor):
+        """Upsert returns the row id (new or existing)."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        result = upsert_external_team_code(
+            team_id=42,
+            source="kalshi",
+            source_team_code="JAC",
+            league="nfl",
+            confidence="manual",
+        )
+
+        assert result == 1
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_upsert_uses_on_conflict(self, mock_get_cursor):
+        """Upsert SQL uses ON CONFLICT for idempotency."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        upsert_external_team_code(
+            team_id=42,
+            source="kalshi",
+            source_team_code="JAC",
+            league="nfl",
+        )
+
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "ON CONFLICT" in sql
+        assert "source, source_team_code, league" in sql
+        assert "DO UPDATE SET" in sql
+        assert "updated_at = NOW()" in sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_upsert_updates_team_id_on_conflict(self, mock_get_cursor):
+        """On conflict, team_id is updated (handles reassignment)."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 1}
+
+        upsert_external_team_code(
+            team_id=99,
+            source="kalshi",
+            source_team_code="JAC",
+            league="nfl",
+            confidence="exact",
+        )
+
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "team_id = EXCLUDED.team_id" in sql
+        assert "confidence = EXCLUDED.confidence" in sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_upsert_with_notes(self, mock_get_cursor):
+        """Notes are passed through to the upsert."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.fetchone.return_value = {"id": 3}
+
+        upsert_external_team_code(
+            team_id=42,
+            source="kalshi",
+            source_team_code="JAC",
+            league="nfl",
+            notes="Verified manually",
+        )
+
+        params = mock_cursor.execute.call_args[0][1]
+        assert "Verified manually" in params
+
+
+# =============================================================================
+# DELETE TESTS
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestDeleteExternalTeamCode:
+    """Unit tests for delete_external_team_code."""
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_delete_existing_returns_true(self, mock_get_cursor):
+        """Deleting an existing row returns True."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        result = delete_external_team_code(42)
+
+        assert result is True
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "DELETE FROM external_team_codes" in sql
+        assert "WHERE id = %s" in sql
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_delete_nonexistent_returns_false(self, mock_get_cursor):
+        """Deleting a non-existent row returns False."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 0
+
+        result = delete_external_team_code(999)
+
+        assert result is False

--- a/tests/unit/matching/test_team_code_registry.py
+++ b/tests/unit/matching/test_team_code_registry.py
@@ -2,13 +2,16 @@
 
 Tests the in-memory cache of team code mappings used for matching
 Kalshi events to games. Uses load_from_data() to avoid DB dependency.
+New tests (#516) cover loading from external_team_codes table.
 
 Related:
     - Issue #462: Event-to-game matching
+    - Issue #516: External team codes table
     - src/precog/matching/team_code_registry.py
 """
 
 from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
 
 from precog.matching.team_code_registry import TeamCodeRegistry
 
@@ -495,3 +498,316 @@ class TestClassificationCollision:
         registry.load_from_data(NFL_TEAMS)  # No classification field
         assert registry.resolve_kalshi_to_espn("JAC", "nfl") == "JAX"
         assert registry.resolve_kalshi_to_espn("HOU", "nfl") == "HOU"
+
+
+# =============================================================================
+# External Team Codes Loading Tests (#516)
+# =============================================================================
+
+
+# Mock data matching the external_team_codes table format
+EXTERNAL_KALSHI_CODES: list[dict] = [
+    {
+        "id": 1,
+        "team_id": 42,
+        "source": "kalshi",
+        "source_team_code": "JAC",
+        "league": "nfl",
+        "confidence": "manual",
+    },
+    {
+        "id": 2,
+        "team_id": 43,
+        "source": "kalshi",
+        "source_team_code": "LA",
+        "league": "nfl",
+        "confidence": "manual",
+    },
+    {
+        "id": 3,
+        "team_id": 44,
+        "source": "kalshi",
+        "source_team_code": "HOU",
+        "league": "nfl",
+        "confidence": "heuristic",
+    },
+    {
+        "id": 4,
+        "team_id": 45,
+        "source": "kalshi",
+        "source_team_code": "NE",
+        "league": "nfl",
+        "confidence": "heuristic",
+    },
+    {
+        "id": 5,
+        "team_id": 46,
+        "source": "kalshi",
+        "source_team_code": "KC",
+        "league": "nfl",
+        "confidence": "heuristic",
+    },
+]
+
+EXTERNAL_ESPN_CODES: list[dict] = [
+    {
+        "id": 10,
+        "team_id": 42,
+        "source": "espn",
+        "source_team_code": "JAX",
+        "league": "nfl",
+        "confidence": "exact",
+    },
+    {
+        "id": 11,
+        "team_id": 43,
+        "source": "espn",
+        "source_team_code": "LAR",
+        "league": "nfl",
+        "confidence": "exact",
+    },
+    {
+        "id": 12,
+        "team_id": 44,
+        "source": "espn",
+        "source_team_code": "HOU",
+        "league": "nfl",
+        "confidence": "exact",
+    },
+    {
+        "id": 13,
+        "team_id": 45,
+        "source": "espn",
+        "source_team_code": "NE",
+        "league": "nfl",
+        "confidence": "exact",
+    },
+    {
+        "id": 14,
+        "team_id": 46,
+        "source": "espn",
+        "source_team_code": "KC",
+        "league": "nfl",
+        "confidence": "exact",
+    },
+]
+
+
+class TestLoadFromExternalCodes:
+    """Tests for loading registry from external_team_codes table (#516).
+
+    These tests patch the CRUD functions at their source module because
+    the registry uses lazy imports (inside methods) to avoid circular
+    dependencies. The patch target is precog.database.crud_operations.
+    """
+
+    @patch("precog.database.crud_operations.get_external_team_codes")
+    def test_load_from_external_codes_resolves_mismatches(self, mock_get_codes) -> None:
+        """External codes correctly map Kalshi mismatches (JAC->JAX, LA->LAR)."""
+
+        # Return different data depending on the source param
+        def side_effect(source=None, league=None):
+            if source == "kalshi":
+                return EXTERNAL_KALSHI_CODES
+            if source == "espn":
+                return EXTERNAL_ESPN_CODES
+            return []
+
+        mock_get_codes.side_effect = side_effect
+
+        registry = TeamCodeRegistry()
+        registry.load_from_external_codes(source="kalshi")
+
+        assert registry.is_loaded
+        assert registry.resolve_kalshi_to_espn("JAC", "nfl") == "JAX"
+        assert registry.resolve_kalshi_to_espn("LA", "nfl") == "LAR"
+        assert registry.resolve_kalshi_to_espn("HOU", "nfl") == "HOU"
+        assert registry.resolve_kalshi_to_espn("NE", "nfl") == "NE"
+        assert registry.resolve_kalshi_to_espn("KC", "nfl") == "KC"
+
+    @patch("precog.database.crud_operations.get_external_team_codes")
+    def test_load_from_external_codes_builds_kalshi_codes_set(self, mock_get_codes) -> None:
+        """get_kalshi_codes returns all Kalshi codes after external load."""
+
+        def side_effect(source=None, league=None):
+            if source == "kalshi":
+                return EXTERNAL_KALSHI_CODES
+            if source == "espn":
+                return EXTERNAL_ESPN_CODES
+            return []
+
+        mock_get_codes.side_effect = side_effect
+
+        registry = TeamCodeRegistry()
+        registry.load_from_external_codes(source="kalshi")
+
+        codes = registry.get_kalshi_codes("nfl")
+        assert "JAC" in codes
+        assert "LA" in codes
+        assert "HOU" in codes
+        assert "NE" in codes
+        assert "KC" in codes
+        # ESPN codes for mismatched teams should NOT be in the set
+        assert "JAX" not in codes
+        assert "LAR" not in codes
+
+    @patch("precog.database.crud_operations.get_teams_with_kalshi_codes")
+    @patch("precog.database.crud_operations.get_external_team_codes")
+    def test_fallback_to_legacy_when_external_empty(self, mock_get_codes, mock_get_teams) -> None:
+        """Falls back to teams table when external_team_codes is empty."""
+        # External codes return empty
+        mock_get_codes.return_value = []
+        # Legacy load returns teams data
+        mock_get_teams.return_value = NFL_TEAMS
+
+        registry = TeamCodeRegistry()
+        registry.load_from_external_codes(source="kalshi")
+
+        # Should have loaded from legacy
+        assert registry.is_loaded
+        assert registry.resolve_kalshi_to_espn("JAC", "nfl") == "JAX"
+        mock_get_teams.assert_called_once()
+
+    @patch("precog.database.crud_operations.get_teams_with_kalshi_codes")
+    @patch("precog.database.crud_operations.get_external_team_codes")
+    def test_fallback_to_legacy_on_exception(self, mock_get_codes, mock_get_teams) -> None:
+        """Falls back to teams table when external_team_codes raises an error."""
+        mock_get_codes.side_effect = Exception("Table does not exist")
+        mock_get_teams.return_value = NFL_TEAMS
+
+        registry = TeamCodeRegistry()
+        registry.load_from_external_codes(source="kalshi")
+
+        # Should have loaded from legacy despite the error
+        assert registry.is_loaded
+        assert registry.resolve_kalshi_to_espn("JAC", "nfl") == "JAX"
+
+    @patch("precog.database.crud_operations.get_external_team_codes")
+    def test_external_code_without_espn_mapping(self, mock_get_codes) -> None:
+        """Kalshi code without ESPN mapping uses Kalshi code as team_code."""
+        # Kalshi code exists but no ESPN mapping for team_id=99
+        kalshi_only = [
+            {
+                "id": 50,
+                "team_id": 99,
+                "source": "kalshi",
+                "source_team_code": "XYZ",
+                "league": "nfl",
+                "confidence": "heuristic",
+            },
+        ]
+
+        def side_effect(source=None, league=None):
+            if source == "kalshi":
+                return kalshi_only
+            if source == "espn":
+                return []  # No ESPN codes
+            return []
+
+        mock_get_codes.side_effect = side_effect
+
+        registry = TeamCodeRegistry()
+        registry.load_from_external_codes(source="kalshi")
+
+        # XYZ should resolve to XYZ (same code, no mismatch)
+        assert registry.resolve_kalshi_to_espn("XYZ", "nfl") == "XYZ"
+
+    @patch("precog.database.crud_operations.get_external_team_codes")
+    def test_load_clears_unknown_codes(self, mock_get_codes) -> None:
+        """Loading from external codes clears the unknown_codes_seen set."""
+
+        def side_effect(source=None, league=None):
+            if source == "kalshi":
+                return EXTERNAL_KALSHI_CODES
+            if source == "espn":
+                return EXTERNAL_ESPN_CODES
+            return []
+
+        mock_get_codes.side_effect = side_effect
+
+        registry = TeamCodeRegistry()
+        registry.load_from_data(NFL_TEAMS)
+        registry.record_unknown_code("ZZZ", "nfl")
+        assert len(registry.unknown_codes_seen) == 1
+
+        registry.load_from_external_codes(source="kalshi")
+        assert len(registry.unknown_codes_seen) == 0
+
+    @patch("precog.database.crud_operations.get_external_team_codes")
+    def test_load_sets_last_loaded_at(self, mock_get_codes) -> None:
+        """Loading from external codes sets last_loaded_at."""
+
+        def side_effect(source=None, league=None):
+            if source == "kalshi":
+                return EXTERNAL_KALSHI_CODES
+            if source == "espn":
+                return EXTERNAL_ESPN_CODES
+            return []
+
+        mock_get_codes.side_effect = side_effect
+
+        registry = TeamCodeRegistry()
+        assert registry.last_loaded_at is None
+
+        before = datetime.now(UTC)
+        registry.load_from_external_codes(source="kalshi")
+        after = datetime.now(UTC)
+
+        assert registry.last_loaded_at is not None
+        assert before <= registry.last_loaded_at <= after
+
+
+class TestLoadAutoFallback:
+    """Tests for load() auto-fallback behavior (#516).
+
+    Tests that load() tries external_team_codes first and falls back
+    to the legacy teams table approach when needed.
+    """
+
+    @patch("precog.database.crud_operations.get_external_team_codes")
+    def test_load_tries_external_first(self, mock_get_codes) -> None:
+        """load() attempts external_team_codes before legacy."""
+
+        def side_effect(source=None, league=None):
+            if source == "kalshi":
+                return EXTERNAL_KALSHI_CODES
+            if source == "espn":
+                return EXTERNAL_ESPN_CODES
+            return []
+
+        mock_get_codes.side_effect = side_effect
+
+        registry = TeamCodeRegistry()
+        registry.load()
+
+        assert registry.is_loaded
+        assert registry.resolve_kalshi_to_espn("JAC", "nfl") == "JAX"
+        # External codes were used (not legacy)
+        mock_get_codes.assert_called()
+
+    @patch("precog.database.crud_operations.get_teams_with_kalshi_codes")
+    @patch("precog.database.crud_operations.get_external_team_codes")
+    def test_load_falls_back_when_external_empty(self, mock_get_codes, mock_get_teams) -> None:
+        """load() falls back to legacy when external table is empty."""
+        mock_get_codes.return_value = []
+        mock_get_teams.return_value = NFL_TEAMS
+
+        registry = TeamCodeRegistry()
+        registry.load()
+
+        assert registry.is_loaded
+        assert registry.resolve_kalshi_to_espn("JAC", "nfl") == "JAX"
+        mock_get_teams.assert_called_once()
+
+    @patch("precog.database.crud_operations.get_teams_with_kalshi_codes")
+    @patch("precog.database.crud_operations.get_external_team_codes")
+    def test_load_falls_back_on_error(self, mock_get_codes, mock_get_teams) -> None:
+        """load() falls back to legacy when external table errors."""
+        mock_get_codes.side_effect = Exception("relation does not exist")
+        mock_get_teams.return_value = NFL_TEAMS
+
+        registry = TeamCodeRegistry()
+        registry.load()
+
+        assert registry.is_loaded
+        assert registry.resolve_kalshi_to_espn("JAC", "nfl") == "JAX"


### PR DESCRIPTION
## Summary
- **Migration 0045**: `external_team_codes` table with `UNIQUE(source, source_team_code, league)`, FK to `teams(team_id)`, indexes on `team_id` and `(source, league)`
- **5 CRUD functions**: create, get (with filters), find_team_by_external_code (JOIN), upsert (ON CONFLICT), delete
- **Seed script** (`scripts/seed_external_team_codes.py`): populates from existing teams data — Kalshi mappings (manual/heuristic) + ESPN mappings (exact). Idempotent via upsert. `--dry-run` and `--league` flags.
- **TeamCodeRegistry update**: `load()` now tries `external_team_codes` first, falls back to legacy `teams` table gracefully. Public API unchanged.

Closes #516

## Context
The TeamCodeRegistry currently builds in-memory `{kalshi_code -> espn_code}` mappings by runtime collision resolution. This produces ~17 collision log messages on every start, is non-persistent, and has no path for additional sources. The new table provides persistent, auditable, multi-source team code mappings — prerequisite for #495 (Polymarket), #496 (cross-platform matching), #502 (MLB).

## Agent Review Trail
| Agent | Role | Verdict | Key Finding |
|-------|------|---------|-------------|
| Samwise | Builder | Implemented | Migration + CRUD + seed + registry update, 1399 lines |
| Glokta | Reviewer | APPROVE | Silent skip logging (fixed), misleading collision comment (fixed) |

## Test plan
- [x] 28 new unit tests (18 CRUD + 10 registry)
- [x] 2422/2422 unit tests passing
- [x] Ruff lint + format + mypy clean
- [ ] Apply migration: `alembic upgrade head`
- [ ] Run seed: `python scripts/seed_external_team_codes.py --dry-run` then live
- [ ] Verify registry loads from external table (check logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)