### PR TITLE
feat: Kalshi API enrichment P1 — depth signals + daily movement (#513)

### DIFF
--- a/src/precog/api_connectors/types.py
+++ b/src/precog/api_connectors/types.py
@@ -20,7 +20,11 @@ from typing import Literal, TypedDict
 
 
 class MarketData(TypedDict):
-    """Single market data from Kalshi API."""
+    """Single market data from Kalshi API.
+
+    Includes both legacy integer cent fields and sub-penny dollar string fields.
+    The _dollars fields are converted to Decimal by _convert_prices_to_decimal().
+    """
 
     ticker: str
     event_ticker: str
@@ -53,6 +57,21 @@ class MarketData(TypedDict):
     volume: int
     open_interest: int
     liquidity: int
+
+    # -- Enrichment fields (Issue #513 P1) --
+    # 24-hour rolling trading volume in contracts. Integer count, not dollar value.
+    # May be absent from some API responses (e.g., newly listed markets).
+    volume_24h: int
+    # Number of contracts resting at the best YES bid price. Depth signal for
+    # liquidity assessment. Integer count. May be 0 for illiquid markets.
+    yes_bid_size: int
+    # Number of contracts resting at the best YES ask price. Depth signal for
+    # liquidity assessment. Integer count. May be 0 for illiquid markets.
+    yes_ask_size: int
+    # Free-text settlement outcome description from Kalshi (e.g., "above 42.5",
+    # "yes", "Chiefs"). Describes what outcome this market represents.
+    # Distinct from settlement_value_dollars (which is the payout amount).
+    expiration_value: str
 
 
 class MarketsResponse(TypedDict):
@@ -233,6 +252,27 @@ class ProcessedMarketData(TypedDict, total=False):
     # Only present after market settles. Converted from API string by _convert_prices_to_decimal.
     # Range [0.0000, 1.0000]. None/absent for unsettled markets.
     settlement_value_dollars: Decimal | None
+
+    # -- Enrichment fields (Issue #513 P1) --
+    # Daily price movement: yesterday's prices converted to Decimal by _convert_prices_to_decimal.
+    # Used for computing daily deltas (e.g., today's yes_bid - previous_yes_bid).
+    # Range: [0.0000, 1.0000]. None/absent for newly listed markets with no prior day data.
+    previous_yes_bid_dollars: Decimal  # Yesterday's YES bid in dollars
+    previous_yes_ask_dollars: Decimal  # Yesterday's YES ask in dollars
+    previous_price_dollars: Decimal  # Yesterday's last trade price in dollars
+    # Dollar notional value of the contract, converted to Decimal by _convert_prices_to_decimal.
+    # Represents the total dollar exposure per contract. None for markets where API omits it.
+    notional_value_dollars: Decimal
+    # 24-hour rolling trading volume in contracts. Integer count, not dollar value.
+    # May be absent from some API responses (e.g., newly listed markets).
+    volume_24h: int
+    # Number of contracts resting at the best YES bid/ask price. Depth signals
+    # for liquidity assessment. Integer counts. May be 0 for illiquid markets.
+    yes_bid_size: int
+    yes_ask_size: int
+    # Free-text settlement outcome description (e.g., "above 42.5", "yes").
+    # Describes what outcome this market represents. Not a price.
+    expiration_value: str
 
 
 class ProcessedPositionData(TypedDict):

--- a/src/precog/database/alembic/versions/0046_market_depth_and_daily_movement.py
+++ b/src/precog/database/alembic/versions/0046_market_depth_and_daily_movement.py
@@ -1,0 +1,198 @@
+"""Add depth signals and daily price movement columns to markets schema.
+
+Captures high-value Kalshi API fields that are currently returned but not
+stored. These are prerequisites for future edge-detection models:
+
+Dimension table (markets) -- per-market constants:
+    - expiration_value: Settlement outcome description (e.g., "above 42.5")
+    - notional_value: Dollar notional value of the contract
+
+Fact table (market_snapshots) -- per-poll observations:
+    - volume_24h: 24-hour trading volume in contracts
+    - previous_yes_bid: Yesterday's YES bid price
+    - previous_yes_ask: Yesterday's YES ask price
+    - previous_price: Yesterday's last trade price
+    - yes_bid_size: Size (depth) at best YES bid
+    - yes_ask_size: Size (depth) at best YES ask
+
+All columns are nullable -- existing rows won't have these values, and not
+all API responses include them.
+
+Steps:
+    1. ADD columns to markets dimension table
+    2. ADD columns to market_snapshots fact table
+    3. DROP/RECREATE current_markets view to include new columns
+
+Revision ID: 0046
+Revises: 0045
+Create Date: 2026-03-30
+
+Related:
+- Issue #513: Kalshi API enrichment (P1)
+- Migration 0033: Market enrichment columns (predecessor)
+- Migration 0037: Last view definition (subcategory rename)
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0046"
+down_revision: str = "0045"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add depth and daily movement columns to markets + market_snapshots.
+
+    Educational Note:
+        Dimension vs Fact placement:
+        - expiration_value and notional_value are per-market constants that
+          don't change between polls -> dimension table (markets).
+        - volume_24h, previous_*, and *_size fields are per-poll observations
+          that change over time -> fact table (market_snapshots).
+
+        INTEGER vs DECIMAL:
+        - volume_24h, yes_bid_size, yes_ask_size are contract counts -> INTEGER.
+        - previous_* and notional_value are dollar prices -> DECIMAL(10,4).
+    """
+    # -- Step 1: Add dimension columns to markets table --
+    #
+    # expiration_value: free-text settlement outcome description from Kalshi API
+    # (e.g., "above 42.5", "yes"). Not a price -- VARCHAR(100).
+    op.execute("ALTER TABLE markets ADD COLUMN expiration_value VARCHAR(100)")
+
+    # notional_value: dollar notional value of the contract. Decimal for
+    # precision consistency with other price columns.
+    op.execute("ALTER TABLE markets ADD COLUMN notional_value DECIMAL(10,4)")
+
+    # -- Step 2: Add fact columns to market_snapshots table --
+    #
+    # Daily movement columns: yesterday's prices for computing daily deltas.
+    # Already converted to Decimal by _convert_prices_to_decimal in the client.
+    op.execute("ALTER TABLE market_snapshots ADD COLUMN volume_24h INTEGER")
+    op.execute("ALTER TABLE market_snapshots ADD COLUMN previous_yes_bid DECIMAL(10,4)")
+    op.execute("ALTER TABLE market_snapshots ADD COLUMN previous_yes_ask DECIMAL(10,4)")
+    op.execute("ALTER TABLE market_snapshots ADD COLUMN previous_price DECIMAL(10,4)")
+
+    # Depth signals: number of contracts at the best bid/ask.
+    # These are integers (contract counts), not dollar values.
+    op.execute("ALTER TABLE market_snapshots ADD COLUMN yes_bid_size INTEGER")
+    op.execute("ALTER TABLE market_snapshots ADD COLUMN yes_ask_size INTEGER")
+
+    # -- Step 3: Recreate current_markets view --
+    #
+    # Must include ALL new columns from both tables so downstream queries
+    # (web GUI, analytics, strategy logic) see them without raw table joins.
+    # View definition matches migration 0037 (last to touch this view) plus
+    # the new columns from this migration.
+    op.execute("DROP VIEW IF EXISTS current_markets")
+    op.execute("""
+        CREATE OR REPLACE VIEW current_markets AS
+        SELECT
+            m.id,
+            m.platform_id,
+            m.event_internal_id,
+            m.external_id,
+            m.ticker,
+            m.title,
+            m.subtitle,
+            m.market_type,
+            m.status,
+            m.settlement_value,
+            m.open_time,
+            m.close_time,
+            m.expiration_time,
+            m.outcome_label,
+            m.subcategory,
+            m.bracket_count,
+            m.source_url,
+            m.expiration_value,
+            m.notional_value,
+            m.metadata,
+            m.created_at,
+            m.updated_at,
+            ms.yes_ask_price,
+            ms.no_ask_price,
+            ms.yes_bid_price,
+            ms.no_bid_price,
+            ms.last_price,
+            ms.spread,
+            ms.volume,
+            ms.open_interest,
+            ms.liquidity,
+            ms.volume_24h,
+            ms.previous_yes_bid,
+            ms.previous_yes_ask,
+            ms.previous_price,
+            ms.yes_bid_size,
+            ms.yes_ask_size,
+            ms.row_start_ts,
+            ms.row_end_ts,
+            ms.row_current_ind
+        FROM markets m
+        LEFT JOIN market_snapshots ms
+            ON ms.market_id = m.id
+            AND ms.row_current_ind = TRUE
+    """)
+
+
+def downgrade() -> None:
+    """Remove depth and daily movement columns, restore previous view."""
+    # -- Step 1: Restore current_markets view to pre-0046 definition --
+    # (matches migration 0037 view definition)
+    op.execute("DROP VIEW IF EXISTS current_markets")
+    op.execute("""
+        CREATE OR REPLACE VIEW current_markets AS
+        SELECT
+            m.id,
+            m.platform_id,
+            m.event_internal_id,
+            m.external_id,
+            m.ticker,
+            m.title,
+            m.subtitle,
+            m.market_type,
+            m.status,
+            m.settlement_value,
+            m.open_time,
+            m.close_time,
+            m.expiration_time,
+            m.outcome_label,
+            m.subcategory,
+            m.bracket_count,
+            m.source_url,
+            m.metadata,
+            m.created_at,
+            m.updated_at,
+            ms.yes_ask_price,
+            ms.no_ask_price,
+            ms.yes_bid_price,
+            ms.no_bid_price,
+            ms.last_price,
+            ms.spread,
+            ms.volume,
+            ms.open_interest,
+            ms.liquidity,
+            ms.row_start_ts,
+            ms.row_end_ts,
+            ms.row_current_ind
+        FROM markets m
+        LEFT JOIN market_snapshots ms
+            ON ms.market_id = m.id
+            AND ms.row_current_ind = TRUE
+    """)
+
+    # -- Step 2: Drop fact columns from market_snapshots --
+    op.execute("ALTER TABLE market_snapshots DROP COLUMN IF EXISTS volume_24h")
+    op.execute("ALTER TABLE market_snapshots DROP COLUMN IF EXISTS previous_yes_bid")
+    op.execute("ALTER TABLE market_snapshots DROP COLUMN IF EXISTS previous_yes_ask")
+    op.execute("ALTER TABLE market_snapshots DROP COLUMN IF EXISTS previous_price")
+    op.execute("ALTER TABLE market_snapshots DROP COLUMN IF EXISTS yes_bid_size")
+    op.execute("ALTER TABLE market_snapshots DROP COLUMN IF EXISTS yes_ask_size")
+
+    # -- Step 3: Drop dimension columns from markets --
+    op.execute("ALTER TABLE markets DROP COLUMN IF EXISTS expiration_value")
+    op.execute("ALTER TABLE markets DROP COLUMN IF EXISTS notional_value")

--- a/src/precog/database/crud_operations.py
+++ b/src/precog/database/crud_operations.py
@@ -1231,6 +1231,14 @@ def create_market(
     last_price: Decimal | None = None,
     liquidity: Decimal | None = None,
     settlement_value: Decimal | None = None,
+    expiration_value: str | None = None,
+    notional_value: Decimal | None = None,
+    volume_24h: int | None = None,
+    previous_yes_bid: Decimal | None = None,
+    previous_yes_ask: Decimal | None = None,
+    previous_price: Decimal | None = None,
+    yes_bid_size: int | None = None,
+    yes_ask_size: int | None = None,
 ) -> int:
     """
     Create new market (dimension) + initial snapshot (fact).
@@ -1266,6 +1274,23 @@ def create_market(
         no_bid_price: NO bid price as DECIMAL(10,4) (keyword-only, optional)
         last_price: Last traded price as DECIMAL(10,4) (keyword-only, optional)
         liquidity: Market liquidity as DECIMAL(10,4) (keyword-only, optional)
+        settlement_value: Settlement outcome as DECIMAL(10,4) (keyword-only, optional)
+        expiration_value: Free-text settlement outcome description (keyword-only, optional).
+            e.g., "above 42.5", "yes". Dimension-level (per-market constant).
+        notional_value: Dollar notional value of the contract as DECIMAL(10,4)
+            (keyword-only, optional). Dimension-level (per-market constant).
+        volume_24h: 24-hour rolling trading volume in contracts (keyword-only, optional).
+            Integer count, not dollar value. Snapshot-level (per-poll observation).
+        previous_yes_bid: Yesterday's YES bid price as DECIMAL(10,4) (keyword-only, optional).
+            Snapshot-level (per-poll observation).
+        previous_yes_ask: Yesterday's YES ask price as DECIMAL(10,4) (keyword-only, optional).
+            Snapshot-level (per-poll observation).
+        previous_price: Yesterday's last trade price as DECIMAL(10,4) (keyword-only, optional).
+            Snapshot-level (per-poll observation).
+        yes_bid_size: Number of contracts at best YES bid (keyword-only, optional).
+            Integer count. Snapshot-level (per-poll observation).
+        yes_ask_size: Number of contracts at best YES ask (keyword-only, optional).
+            Integer count. Snapshot-level (per-poll observation).
 
     Returns:
         Integer surrogate PK (markets.id) of the newly created market.
@@ -1286,6 +1311,8 @@ def create_market(
         ...     no_ask_price=Decimal("0.4900"),
         ...     subtitle="Week 14",
         ...     close_time="2026-01-15T18:00:00Z",
+        ...     volume_24h=150,
+        ...     previous_yes_bid=Decimal("0.5100"),
         ... )
 
     Reference:
@@ -1293,6 +1320,7 @@ def create_market(
         - Migration 0022: market_id VARCHAR dropped, downstream uses integer FK
         - Migration 0033: enrichment columns added to dimension table
         - Migration 0037: league renamed to subcategory
+        - Migration 0046: depth signals + daily movement columns
     """
     # Runtime type validation (enforces Decimal precision)
     yes_ask_price = validate_decimal(yes_ask_price, "yes_ask_price")
@@ -1309,12 +1337,22 @@ def create_market(
         liquidity = validate_decimal(liquidity, "liquidity")
     if settlement_value is not None:
         settlement_value = validate_decimal(settlement_value, "settlement_value")
+    # Migration 0046: depth + daily movement enrichment fields
+    if notional_value is not None:
+        notional_value = validate_decimal(notional_value, "notional_value")
+    if previous_yes_bid is not None:
+        previous_yes_bid = validate_decimal(previous_yes_bid, "previous_yes_bid")
+    if previous_yes_ask is not None:
+        previous_yes_ask = validate_decimal(previous_yes_ask, "previous_yes_ask")
+    if previous_price is not None:
+        previous_price = validate_decimal(previous_price, "previous_price")
 
     with get_cursor(commit=True) as cur:
         # Step 1: Insert dimension row
         # Migration 0022: market_id VARCHAR dropped — no longer inserted.
         # Migration 0033: enrichment columns added (subtitle, timestamps, etc.)
         # Migration 0037: league renamed to subcategory
+        # Migration 0046: expiration_value, notional_value added
         cur.execute(
             """
             INSERT INTO markets (
@@ -1322,9 +1360,10 @@ def create_market(
                 ticker, title, market_type, status, settlement_value,
                 subtitle, open_time, close_time, expiration_time,
                 outcome_label, subcategory, bracket_count, source_url,
+                expiration_value, notional_value,
                 metadata, updated_at
             )
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
             RETURNING id
             """,
             (
@@ -1344,6 +1383,8 @@ def create_market(
                 subcategory,
                 bracket_count,
                 source_url,
+                expiration_value,
+                notional_value,
                 json.dumps(metadata) if metadata else None,
             ),
         )
@@ -1352,15 +1393,18 @@ def create_market(
 
         # Step 2: Insert initial snapshot (fact row)
         # Migration 0021: yes_bid_price, no_bid_price, last_price, liquidity
+        # Migration 0046: volume_24h, previous_*, yes_bid_size, yes_ask_size
         cur.execute(
             """
             INSERT INTO market_snapshots (
                 market_id, yes_ask_price, no_ask_price,
                 yes_bid_price, no_bid_price, last_price,
                 spread, volume, open_interest, liquidity,
+                volume_24h, previous_yes_bid, previous_yes_ask,
+                previous_price, yes_bid_size, yes_ask_size,
                 row_current_ind, updated_at
             )
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, TRUE, NOW())
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, TRUE, NOW())
             """,
             (
                 market_pk,
@@ -1373,6 +1417,12 @@ def create_market(
                 volume,
                 open_interest,
                 liquidity,
+                volume_24h,
+                previous_yes_bid,
+                previous_yes_ask,
+                previous_price,
+                yes_bid_size,
+                yes_ask_size,
             ),
         )
 
@@ -1405,6 +1455,7 @@ def get_current_market(ticker: str) -> dict[str, Any] | None:
     """
     # Migration 0022: market_id VARCHAR dropped. Use ticker for lookup.
     # Migration 0033: enrichment columns added to dimension table.
+    # Migration 0046: depth signals + daily movement columns.
     query = """
         SELECT
             m.id,
@@ -1424,6 +1475,8 @@ def get_current_market(ticker: str) -> dict[str, Any] | None:
             m.subcategory,
             m.bracket_count,
             m.source_url,
+            m.expiration_value,
+            m.notional_value,
             m.metadata,
             m.created_at,
             m.updated_at,
@@ -1436,6 +1489,12 @@ def get_current_market(ticker: str) -> dict[str, Any] | None:
             ms.volume,
             ms.open_interest,
             ms.liquidity,
+            ms.volume_24h,
+            ms.previous_yes_bid,
+            ms.previous_yes_ask,
+            ms.previous_price,
+            ms.yes_bid_size,
+            ms.yes_ask_size,
             ms.row_start_ts,
             ms.row_end_ts,
             ms.row_current_ind
@@ -1498,6 +1557,14 @@ def update_market_with_versioning(
     last_price: Decimal | None = None,
     liquidity: Decimal | None = None,
     settlement_value: Decimal | None = None,
+    expiration_value: str | None = None,
+    notional_value: Decimal | None = None,
+    volume_24h: int | None = None,
+    previous_yes_bid: Decimal | None = None,
+    previous_yes_ask: Decimal | None = None,
+    previous_price: Decimal | None = None,
+    yes_bid_size: int | None = None,
+    yes_ask_size: int | None = None,
 ) -> int:
     """
     Update market: SCD Type 2 on snapshots, direct UPDATE on dimension.
@@ -1533,6 +1600,22 @@ def update_market_with_versioning(
         liquidity: Market liquidity as DECIMAL(10,4) (keyword-only, optional)
         settlement_value: Settlement outcome as DECIMAL(10,4) (keyword-only, optional).
             Must be 0.0000 (no) or 1.0000 (yes). CHECK constraint: 0.0000-1.0000.
+        expiration_value: Free-text settlement outcome description (keyword-only, optional).
+            Dimension-level (per-market constant).
+        notional_value: Dollar notional value as DECIMAL(10,4) (keyword-only, optional).
+            Dimension-level (per-market constant).
+        volume_24h: 24-hour rolling volume in contracts (keyword-only, optional).
+            Integer count. Snapshot-level (per-poll observation).
+        previous_yes_bid: Yesterday's YES bid as DECIMAL(10,4) (keyword-only, optional).
+            Snapshot-level (per-poll observation).
+        previous_yes_ask: Yesterday's YES ask as DECIMAL(10,4) (keyword-only, optional).
+            Snapshot-level (per-poll observation).
+        previous_price: Yesterday's last trade price as DECIMAL(10,4) (keyword-only, optional).
+            Snapshot-level (per-poll observation).
+        yes_bid_size: Contracts at best YES bid (keyword-only, optional).
+            Integer count. Snapshot-level (per-poll observation).
+        yes_ask_size: Contracts at best YES ask (keyword-only, optional).
+            Integer count. Snapshot-level (per-poll observation).
 
     Returns:
         Integer surrogate PK of the market (markets.id)
@@ -1541,13 +1624,16 @@ def update_market_with_versioning(
         >>> market_pk = update_market_with_versioning(
         ...     ticker="NFL-KC-BUF-YES",
         ...     yes_ask_price=Decimal("0.5500"),
-        ...     no_ask_price=Decimal("0.4500")
+        ...     no_ask_price=Decimal("0.4500"),
+        ...     volume_24h=200,
+        ...     previous_price=Decimal("0.5300"),
         ... )
 
     Reference:
         - Migration 0021: markets dimension + market_snapshots fact
         - Migration 0033: enrichment columns on dimension table
         - Migration 0037: league renamed to subcategory
+        - Migration 0046: depth signals + daily movement columns
     """
     # Runtime type validation (enforces Decimal precision)
     if yes_ask_price is not None:
@@ -1566,6 +1652,15 @@ def update_market_with_versioning(
         liquidity = validate_decimal(liquidity, "liquidity")
     if settlement_value is not None:
         settlement_value = validate_decimal(settlement_value, "settlement_value")
+    # Migration 0046: depth + daily movement enrichment fields
+    if notional_value is not None:
+        notional_value = validate_decimal(notional_value, "notional_value")
+    if previous_yes_bid is not None:
+        previous_yes_bid = validate_decimal(previous_yes_bid, "previous_yes_bid")
+    if previous_yes_ask is not None:
+        previous_yes_ask = validate_decimal(previous_yes_ask, "previous_yes_ask")
+    if previous_price is not None:
+        previous_price = validate_decimal(previous_price, "previous_price")
 
     # Get current market + snapshot
     current = get_current_market(ticker)
@@ -1590,6 +1685,18 @@ def update_market_with_versioning(
     new_last_price = last_price if last_price is not None else current["last_price"]
     new_liquidity = liquidity if liquidity is not None else current["liquidity"]
 
+    # Migration 0046: snapshot enrichment — use fresh values, fall back to current
+    new_volume_24h = volume_24h if volume_24h is not None else current.get("volume_24h")
+    new_prev_yes_bid = (
+        previous_yes_bid if previous_yes_bid is not None else current.get("previous_yes_bid")
+    )
+    new_prev_yes_ask = (
+        previous_yes_ask if previous_yes_ask is not None else current.get("previous_yes_ask")
+    )
+    new_prev_price = previous_price if previous_price is not None else current.get("previous_price")
+    new_yes_bid_size = yes_bid_size if yes_bid_size is not None else current.get("yes_bid_size")
+    new_yes_ask_size = yes_ask_size if yes_ask_size is not None else current.get("yes_ask_size")
+
     # Enrichment columns: only override if explicitly provided (not None)
     new_subtitle = subtitle if subtitle is not None else current["subtitle"]
     new_open_time = open_time if open_time is not None else current["open_time"]
@@ -1604,11 +1711,19 @@ def update_market_with_versioning(
     new_settlement_value = (
         settlement_value if settlement_value is not None else current["settlement_value"]
     )
+    # Migration 0046: dimension enrichment — use fresh values, fall back to current
+    new_expiration_value = (
+        expiration_value if expiration_value is not None else current.get("expiration_value")
+    )
+    new_notional_value = (
+        notional_value if notional_value is not None else current.get("notional_value")
+    )
 
     with get_cursor(commit=True) as cur:
         # Step 1: Update dimension row — always bump updated_at, plus
         # status/metadata/enrichment if they changed.
         # Migration 0033: enrichment columns updated on dimension row.
+        # Migration 0046: expiration_value, notional_value added.
         cur.execute(
             """
             UPDATE markets
@@ -1623,6 +1738,8 @@ def update_market_with_versioning(
                 bracket_count = %s,
                 source_url = %s,
                 settlement_value = %s,
+                expiration_value = %s,
+                notional_value = %s,
                 updated_at = NOW()
             WHERE id = %s
             """,
@@ -1638,6 +1755,8 @@ def update_market_with_versioning(
                 new_bracket_count,
                 new_source_url,
                 new_settlement_value,
+                new_expiration_value,
+                new_notional_value,
                 market_pk,
             ),
         )
@@ -1657,15 +1776,18 @@ def update_market_with_versioning(
 
         # Insert new snapshot
         # Migration 0021: yes_bid_price, no_bid_price, last_price, liquidity
+        # Migration 0046: volume_24h, previous_*, yes_bid_size, yes_ask_size
         cur.execute(
             """
             INSERT INTO market_snapshots (
                 market_id, yes_ask_price, no_ask_price,
                 yes_bid_price, no_bid_price, last_price,
                 spread, volume, open_interest, liquidity,
+                volume_24h, previous_yes_bid, previous_yes_ask,
+                previous_price, yes_bid_size, yes_ask_size,
                 row_current_ind, updated_at
             )
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, TRUE, NOW())
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, TRUE, NOW())
             """,
             (
                 market_pk,
@@ -1678,6 +1800,12 @@ def update_market_with_versioning(
                 new_volume,
                 new_open_interest,
                 new_liquidity,
+                new_volume_24h,
+                new_prev_yes_bid,
+                new_prev_yes_ask,
+                new_prev_price,
+                new_yes_bid_size,
+                new_yes_ask_size,
             ),
         )
 

--- a/src/precog/schedulers/kalshi_poller.py
+++ b/src/precog/schedulers/kalshi_poller.py
@@ -1180,6 +1180,7 @@ class KalshiMarketPoller(BasePoller):
             # Migration 0033: subtitle, open_time, close_time, expiration_time
             # promoted from metadata JSONB to proper dimension columns.
             # can_close_early and series_ticker remain in metadata.
+            # Migration 0046: depth signals + daily movement columns.
             create_market(
                 platform_id=self.PLATFORM_ID,
                 event_internal_id=event_pk,  # Integer FK to events(id)
@@ -1205,6 +1206,16 @@ class KalshiMarketPoller(BasePoller):
                 source_url=source_url,
                 outcome_label=outcome_label,
                 settlement_value=create_settlement_value,
+                # Migration 0046: dimension enrichment
+                expiration_value=market.get("expiration_value"),
+                notional_value=market.get("notional_value_dollars"),
+                # Migration 0046: snapshot enrichment
+                volume_24h=market.get("volume_24h"),
+                previous_yes_bid=market.get("previous_yes_bid_dollars"),
+                previous_yes_ask=market.get("previous_yes_ask_dollars"),
+                previous_price=market.get("previous_price_dollars"),
+                yes_bid_size=market.get("yes_bid_size"),
+                yes_ask_size=market.get("yes_ask_size"),
                 metadata={
                     k: v
                     for k, v in {
@@ -1265,6 +1276,7 @@ class KalshiMarketPoller(BasePoller):
 
             # Migration 0033: pass enrichment columns on update path too,
             # so lifecycle timestamps are refreshed when prices change.
+            # Migration 0046: pass depth + daily movement columns too.
             update_market_with_versioning(
                 ticker=ticker,
                 yes_ask_price=yes_price,
@@ -1284,6 +1296,16 @@ class KalshiMarketPoller(BasePoller):
                 subcategory=subcategory,
                 source_url=source_url,
                 settlement_value=settlement_value,
+                # Migration 0046: dimension enrichment
+                expiration_value=market.get("expiration_value"),
+                notional_value=market.get("notional_value_dollars"),
+                # Migration 0046: snapshot enrichment
+                volume_24h=market.get("volume_24h"),
+                previous_yes_bid=market.get("previous_yes_bid_dollars"),
+                previous_yes_ask=market.get("previous_yes_ask_dollars"),
+                previous_price=market.get("previous_price_dollars"),
+                yes_bid_size=market.get("yes_bid_size"),
+                yes_ask_size=market.get("yes_ask_size"),
             )
             logger.debug(
                 "Updated market: %s (yes: %s -> %s)",

--- a/src/precog/schedulers/kalshi_websocket.py
+++ b/src/precog/schedulers/kalshi_websocket.py
@@ -758,6 +758,10 @@ class KalshiWebSocketHandler:
             )
 
             if price_changed:
+                # Note: enrichment fields (volume_24h, previous_*, depth signals)
+                # are not available in WebSocket messages — only price/volume data.
+                # Existing enrichment values are preserved via fallback logic in
+                # update_market_with_versioning (reads current snapshot for missing keys).
                 update_market_with_versioning(
                     ticker=ticker,
                     yes_ask_price=yes_price,

--- a/tests/unit/database/test_crud_operations_unit.py
+++ b/tests/unit/database/test_crud_operations_unit.py
@@ -31,6 +31,7 @@ from precog.database.crud_operations import (
     build_event_result,
     check_event_fully_settled,
     create_game_state,
+    create_market,
     create_team,
     create_team_ranking,
     create_venue,
@@ -3006,3 +3007,413 @@ class TestBuildEventResult:
         params = call_args[0][1]
         assert "event_internal_id" in sql
         assert params == (42,)
+
+
+# =============================================================================
+# MARKET ENRICHMENT UNIT TESTS (Migration 0046)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestCreateMarketEnrichment:
+    """Unit tests for create_market with enrichment fields (migration 0046).
+
+    Verifies that new dimension fields (expiration_value, notional_value) and
+    snapshot fields (volume_24h, previous_*, yes_bid_size, yes_ask_size) are
+    correctly passed through to SQL INSERT statements.
+
+    Educational Note:
+        Dimension fields (markets table) are per-market constants that don't
+        change between polls. Snapshot fields (market_snapshots table) are
+        per-poll observations captured via SCD Type 2 versioning.
+
+    Reference:
+        - Migration 0046: depth signals + daily movement columns
+        - Issue #513: Kalshi API enrichment (P1)
+    """
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_market_with_all_enrichment_fields(self, mock_get_cursor):
+        """All 8 new enrichment fields are passed to SQL INSERT statements.
+
+        Verifies that dimension fields go to markets table INSERT and
+        snapshot fields go to market_snapshots table INSERT.
+        """
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = {"id": 99}
+        mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = create_market(
+            platform_id="kalshi",
+            event_internal_id=7,
+            external_id="KXNFLKCBUF",
+            ticker="NFL-KC-BUF-YES",
+            title="Chiefs to beat Bills",
+            yes_ask_price=Decimal("0.5200"),
+            no_ask_price=Decimal("0.4900"),
+            # Dimension enrichment (migration 0046)
+            expiration_value="above 42.5",
+            notional_value=Decimal("1.0000"),
+            # Snapshot enrichment (migration 0046)
+            volume_24h=150,
+            previous_yes_bid=Decimal("0.5100"),
+            previous_yes_ask=Decimal("0.5300"),
+            previous_price=Decimal("0.5200"),
+            yes_bid_size=45,
+            yes_ask_size=30,
+        )
+
+        assert result == 99
+
+        # Two execute calls: dimension INSERT + snapshot INSERT
+        assert mock_cursor.execute.call_count == 2
+
+        # Verify dimension INSERT includes expiration_value and notional_value
+        dim_call = mock_cursor.execute.call_args_list[0]
+        dim_sql = dim_call[0][0]
+        dim_params = dim_call[0][1]
+        assert "expiration_value" in dim_sql
+        assert "notional_value" in dim_sql
+        # expiration_value is 2nd-to-last before metadata in the params tuple
+        assert "above 42.5" in dim_params
+        assert Decimal("1.0000") in dim_params
+
+        # Verify snapshot INSERT includes all 6 new fields
+        snap_call = mock_cursor.execute.call_args_list[1]
+        snap_sql = snap_call[0][0]
+        snap_params = snap_call[0][1]
+        assert "volume_24h" in snap_sql
+        assert "previous_yes_bid" in snap_sql
+        assert "previous_yes_ask" in snap_sql
+        assert "previous_price" in snap_sql
+        assert "yes_bid_size" in snap_sql
+        assert "yes_ask_size" in snap_sql
+        # Verify actual values in params
+        assert 150 in snap_params  # volume_24h
+        assert Decimal("0.5100") in snap_params  # previous_yes_bid
+        assert Decimal("0.5300") in snap_params  # previous_yes_ask
+        assert Decimal("0.5200") in snap_params  # previous_price
+        assert 45 in snap_params  # yes_bid_size
+        assert 30 in snap_params  # yes_ask_size
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_market_enrichment_fields_nullable(self, mock_get_cursor):
+        """Enrichment fields default to None when not provided.
+
+        Educational Note:
+            All new columns are nullable because existing markets won't have
+            these values and not all API responses include them. The poller
+            passes None (via .get() on missing keys) which becomes SQL NULL.
+        """
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = {"id": 100}
+        mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = create_market(
+            platform_id="kalshi",
+            event_internal_id=None,
+            external_id="KXTEST",
+            ticker="TEST-MKT",
+            title="Test Market",
+            yes_ask_price=Decimal("0.5000"),
+            no_ask_price=Decimal("0.5000"),
+            # No enrichment fields provided -- all should be None
+        )
+
+        assert result == 100
+
+        # Verify dimension INSERT includes the new column names
+        # (values will be None since not provided, validated via snapshot below)
+        dim_sql = mock_cursor.execute.call_args_list[0][0][0]
+        assert "expiration_value" in dim_sql
+        assert "notional_value" in dim_sql
+
+        # Verify snapshot INSERT: all 6 new fields are None
+        snap_params = mock_cursor.execute.call_args_list[1][0][1]
+        # The last 6 params before row_current_ind/updated_at should be None
+        # Snapshot params: market_pk, yes_ask, no_ask, yes_bid, no_bid, last_price,
+        #                  spread, volume, open_interest, liquidity,
+        #                  volume_24h, prev_yes_bid, prev_yes_ask, prev_price,
+        #                  yes_bid_size, yes_ask_size
+        # Indices 10-15 are the new enrichment fields (all None)
+        assert snap_params[10] is None  # volume_24h
+        assert snap_params[11] is None  # previous_yes_bid
+        assert snap_params[12] is None  # previous_yes_ask
+        assert snap_params[13] is None  # previous_price
+        assert snap_params[14] is None  # yes_bid_size
+        assert snap_params[15] is None  # yes_ask_size
+
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_create_market_decimal_validation_on_enrichment(self, mock_get_cursor):
+        """Decimal enrichment fields are validated by validate_decimal().
+
+        Educational Note:
+            previous_yes_bid, previous_yes_ask, previous_price, and
+            notional_value are DECIMAL(10,4) columns. They must go through
+            validate_decimal() to enforce Decimal type at runtime, catching
+            accidental float usage early (Pattern 1: NEVER USE FLOAT).
+        """
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.return_value = {"id": 101}
+        mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Should succeed with proper Decimal values
+        create_market(
+            platform_id="kalshi",
+            event_internal_id=None,
+            external_id="KXTEST2",
+            ticker="TEST-MKT-2",
+            title="Test Market 2",
+            yes_ask_price=Decimal("0.6000"),
+            no_ask_price=Decimal("0.4000"),
+            notional_value=Decimal("1.0000"),
+            previous_yes_bid=Decimal("0.5900"),
+            previous_yes_ask=Decimal("0.6100"),
+            previous_price=Decimal("0.6000"),
+        )
+
+        # Verify the function completed (2 SQL calls = dim + snap)
+        assert mock_cursor.execute.call_count == 2
+
+
+@pytest.mark.unit
+class TestUpdateMarketEnrichment:
+    """Unit tests for update_market_with_versioning with enrichment fields.
+
+    Verifies that dimension enrichment (expiration_value, notional_value) goes
+    to the UPDATE on markets table, and snapshot enrichment (volume_24h,
+    previous_*, yes_bid_size, yes_ask_size) goes to the new snapshot INSERT.
+
+    Reference:
+        - Migration 0046: depth signals + daily movement columns
+        - Issue #513: Kalshi API enrichment (P1)
+    """
+
+    @patch("precog.database.crud_operations.get_current_market")
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_market_with_enrichment_fields(self, mock_get_cursor, mock_get_current):
+        """All 8 enrichment fields are passed through on update path.
+
+        Dimension fields go to UPDATE markets SET ..., and snapshot fields
+        go to INSERT INTO market_snapshots (...).
+        """
+        # Mock existing market (current state)
+        mock_get_current.return_value = {
+            "id": 42,
+            "yes_ask_price": Decimal("0.5000"),
+            "no_ask_price": Decimal("0.5000"),
+            "status": "open",
+            "volume": 100,
+            "open_interest": 50,
+            "metadata": None,
+            "spread": Decimal("0.0200"),
+            "yes_bid_price": Decimal("0.4900"),
+            "no_bid_price": Decimal("0.4900"),
+            "last_price": Decimal("0.5000"),
+            "liquidity": Decimal("10.0000"),
+            "subtitle": "Week 14",
+            "open_time": "2026-01-01T00:00:00Z",
+            "close_time": "2026-01-15T18:00:00Z",
+            "expiration_time": "2026-01-15T23:59:00Z",
+            "outcome_label": "YES",
+            "subcategory": "nfl",
+            "bracket_count": 2,
+            "source_url": "https://kalshi.com/markets/kxnflgame/NFL-KC-BUF-YES",
+            "settlement_value": None,
+            # Migration 0046 fields (existing values)
+            "expiration_value": None,
+            "notional_value": None,
+            "volume_24h": None,
+            "previous_yes_bid": None,
+            "previous_yes_ask": None,
+            "previous_price": None,
+            "yes_bid_size": None,
+            "yes_ask_size": None,
+        }
+
+        mock_cursor = MagicMock()
+        mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        update_market_with_versioning(
+            ticker="NFL-KC-BUF-YES",
+            yes_ask_price=Decimal("0.5500"),
+            no_ask_price=Decimal("0.4500"),
+            # Migration 0046: dimension enrichment
+            expiration_value="Chiefs win",
+            notional_value=Decimal("1.0000"),
+            # Migration 0046: snapshot enrichment
+            volume_24h=200,
+            previous_yes_bid=Decimal("0.5000"),
+            previous_yes_ask=Decimal("0.5200"),
+            previous_price=Decimal("0.5100"),
+            yes_bid_size=60,
+            yes_ask_size=40,
+        )
+
+        # 3 execute calls: dimension UPDATE, snapshot close UPDATE, snapshot INSERT
+        assert mock_cursor.execute.call_count == 3
+
+        # Verify dimension UPDATE includes expiration_value and notional_value
+        dim_call = mock_cursor.execute.call_args_list[0]
+        dim_sql = dim_call[0][0]
+        dim_params = dim_call[0][1]
+        assert "expiration_value" in dim_sql
+        assert "notional_value" in dim_sql
+        assert "Chiefs win" in dim_params
+        assert Decimal("1.0000") in dim_params
+
+        # Verify snapshot INSERT includes all 6 new fields
+        snap_call = mock_cursor.execute.call_args_list[2]  # 3rd call = new snapshot
+        snap_sql = snap_call[0][0]
+        snap_params = snap_call[0][1]
+        assert "volume_24h" in snap_sql
+        assert "previous_yes_bid" in snap_sql
+        assert "previous_yes_ask" in snap_sql
+        assert "previous_price" in snap_sql
+        assert "yes_bid_size" in snap_sql
+        assert "yes_ask_size" in snap_sql
+        assert 200 in snap_params  # volume_24h
+        assert Decimal("0.5000") in snap_params  # previous_yes_bid
+        assert Decimal("0.5200") in snap_params  # previous_yes_ask
+        assert Decimal("0.5100") in snap_params  # previous_price
+        assert 60 in snap_params  # yes_bid_size
+        assert 40 in snap_params  # yes_ask_size
+
+    @patch("precog.database.crud_operations.get_current_market")
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_market_enrichment_falls_back_to_current(
+        self, mock_get_cursor, mock_get_current
+    ):
+        """When enrichment fields are not provided, falls back to current values.
+
+        Educational Note:
+            The update function merges new values with existing ones. If a new
+            enrichment field is None (not provided), the existing value from the
+            current snapshot is carried forward. This prevents data loss when the
+            poller only updates prices without re-providing all enrichment fields.
+        """
+        # Mock existing market with enrichment values already populated
+        mock_get_current.return_value = {
+            "id": 42,
+            "yes_ask_price": Decimal("0.5000"),
+            "no_ask_price": Decimal("0.5000"),
+            "status": "open",
+            "volume": 100,
+            "open_interest": 50,
+            "metadata": None,
+            "spread": Decimal("0.0200"),
+            "yes_bid_price": Decimal("0.4900"),
+            "no_bid_price": Decimal("0.4900"),
+            "last_price": Decimal("0.5000"),
+            "liquidity": Decimal("10.0000"),
+            "subtitle": None,
+            "open_time": None,
+            "close_time": None,
+            "expiration_time": None,
+            "outcome_label": None,
+            "subcategory": "nfl",
+            "bracket_count": None,
+            "source_url": None,
+            "settlement_value": None,
+            # Existing enrichment values that should be preserved
+            "expiration_value": "Chiefs win",
+            "notional_value": Decimal("1.0000"),
+            "volume_24h": 150,
+            "previous_yes_bid": Decimal("0.4800"),
+            "previous_yes_ask": Decimal("0.5100"),
+            "previous_price": Decimal("0.4900"),
+            "yes_bid_size": 30,
+            "yes_ask_size": 25,
+        }
+
+        mock_cursor = MagicMock()
+        mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Only update prices -- no enrichment fields provided
+        update_market_with_versioning(
+            ticker="NFL-KC-BUF-YES",
+            yes_ask_price=Decimal("0.5500"),
+            no_ask_price=Decimal("0.4500"),
+        )
+
+        # Verify dimension UPDATE preserves existing enrichment values
+        dim_params = mock_cursor.execute.call_args_list[0][0][1]
+        assert "Chiefs win" in dim_params  # expiration_value preserved
+        assert Decimal("1.0000") in dim_params  # notional_value preserved
+
+        # Verify snapshot INSERT carries forward existing enrichment values
+        snap_params = mock_cursor.execute.call_args_list[2][0][1]
+        assert 150 in snap_params  # volume_24h preserved
+        assert Decimal("0.4800") in snap_params  # previous_yes_bid preserved
+        assert Decimal("0.5100") in snap_params  # previous_yes_ask preserved
+        assert Decimal("0.4900") in snap_params  # previous_price preserved
+        assert 30 in snap_params  # yes_bid_size preserved
+        assert 25 in snap_params  # yes_ask_size preserved
+
+    @patch("precog.database.crud_operations.get_current_market")
+    @patch("precog.database.crud_operations.get_cursor")
+    def test_update_market_integer_fields_pass_through(self, mock_get_cursor, mock_get_current):
+        """Integer enrichment fields (volume_24h, yes_bid_size, yes_ask_size)
+        are passed through without Decimal validation.
+
+        Educational Note:
+            These fields are contract counts, not dollar prices. They are
+            stored as INTEGER in the database, not DECIMAL(10,4). They should
+            NOT go through validate_decimal() -- that would be a type error.
+        """
+        mock_get_current.return_value = {
+            "id": 42,
+            "yes_ask_price": Decimal("0.5000"),
+            "no_ask_price": Decimal("0.5000"),
+            "status": "open",
+            "volume": 100,
+            "open_interest": 50,
+            "metadata": None,
+            "spread": None,
+            "yes_bid_price": None,
+            "no_bid_price": None,
+            "last_price": None,
+            "liquidity": None,
+            "subtitle": None,
+            "open_time": None,
+            "close_time": None,
+            "expiration_time": None,
+            "outcome_label": None,
+            "subcategory": None,
+            "bracket_count": None,
+            "source_url": None,
+            "settlement_value": None,
+            "expiration_value": None,
+            "notional_value": None,
+            "volume_24h": None,
+            "previous_yes_bid": None,
+            "previous_yes_ask": None,
+            "previous_price": None,
+            "yes_bid_size": None,
+            "yes_ask_size": None,
+        }
+
+        mock_cursor = MagicMock()
+        mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Pass integer values directly -- no Decimal wrapping needed
+        update_market_with_versioning(
+            ticker="NFL-KC-BUF-YES",
+            yes_ask_price=Decimal("0.5500"),
+            no_ask_price=Decimal("0.4500"),
+            volume_24h=500,
+            yes_bid_size=100,
+            yes_ask_size=75,
+        )
+
+        # Verify snapshot INSERT contains the integer values
+        snap_params = mock_cursor.execute.call_args_list[2][0][1]
+        assert 500 in snap_params  # volume_24h as int
+        assert 100 in snap_params  # yes_bid_size as int
+        assert 75 in snap_params  # yes_ask_size as int


### PR DESCRIPTION
## Summary
- Add 8 new Kalshi API fields across markets dimension and market_snapshots fact tables
- Migration 0046: `expiration_value`, `notional_value` (dimension); `volume_24h`, `previous_yes_bid`, `previous_yes_ask`, `previous_price`, `yes_bid_size`, `yes_ask_size` (fact)
- Full pipeline wired: TypedDict → API client conversion → poller extraction → CRUD create/update → DB → current_markets view

## Agent Review Trail
| Agent | Role | Findings | Fixed |
|-------|------|----------|-------|
| **Samwise** | Builder | Built migration + CRUD + poller + tests (808 lines, 6 tests) | N/A |
| **Glokta** | Reviewer | 1 BLOCKER: `get_current_market()` missing new columns (silent data loss on update fallback). 2 warnings: WS handler doc, bid/ask size API uncertainty. | Blocker fixed (added 8 columns to SELECT). WS comment added. |
| **Ripley** | Sentinel | PASS: Blocker fix verified, SCD integrity clean, Decimal/int types correct, view consistency confirmed. | N/A |

## Key Design Decisions
- **Dimension vs Fact**: `expiration_value` and `notional_value` are per-market constants → dimension table. All others are per-poll observations → fact table (SCD Type 2).
- **`yes_bid_size`/`yes_ask_size`**: Not confirmed in current Kalshi API responses. Columns added as nullable — will populate when available, harmless if not.
- **WebSocket path**: Intentionally omits enrichment fields (not in WS messages). Fallback logic preserves existing values.

## Test plan
- [x] 6 new unit tests (create/update enrichment, nullable, Decimal validation, fallback, integer pass-through)
- [x] 2,431 unit tests pass
- [x] 982 integration + e2e tests pass
- [x] 1,057 stress + chaos + race tests pass
- [x] Ruff lint + format clean
- [x] Mypy type check pass
- [x] Migration 0046 applied on dev + test DBs
- [ ] S64: Post-merge data verify (Hari — after poller runs with new code)

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)