### PR TITLE
refactor: Remove redundant event_id column from events table (#530)

### DIFF
--- a/scripts/backfill_enrichment.py
+++ b/scripts/backfill_enrichment.py
@@ -281,7 +281,7 @@ def backfill_market_settlement_values(
     # Find settled markets with NULL settlement_value
     find_query = """
         SELECT m.id, m.ticker, m.status, m.metadata,
-               e.event_id AS event_ticker
+               e.external_id AS event_ticker
         FROM markets m
         LEFT JOIN events e ON e.id = m.event_internal_id
         WHERE m.status = 'settled'

--- a/src/precog/database/alembic/versions/0047_drop_redundant_event_id_column.py
+++ b/src/precog/database/alembic/versions/0047_drop_redundant_event_id_column.py
@@ -1,0 +1,83 @@
+"""Drop redundant event_id column from events table.
+
+The events table has two columns storing identical values:
+  - event_id (VARCHAR, UNIQUE) -- the original PK, demoted in migration 0020
+  - external_id (VARCHAR, UNIQUE compound with platform_id) -- semantically correct
+
+All 3,894 existing events have event_id == external_id.  The external_id column
+is the correct one: it is scoped by platform_id for multi-platform support.
+event_id is redundant and confusingly named (looks like the PK but isn't --
+id SERIAL is the PK since migration 0020).
+
+Steps:
+    1. DROP the uq_events_event_id UNIQUE constraint
+    2. DROP the event_id column
+
+Downgrade:
+    1. ADD event_id column back (nullable first)
+    2. Backfill from external_id
+    3. Set NOT NULL
+    4. Re-add UNIQUE constraint
+
+Revision ID: 0047
+Revises: 0046
+Create Date: 2026-03-31
+
+Related:
+- Issue #530: Remove redundant event_id column
+- Migration 0020: event_id demoted from PK to UNIQUE business key
+- Migration 0001: Original events table with event_id as PK
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0047"
+down_revision: str = "0046"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Drop the redundant event_id column from events."""
+    # -- Step 1: Drop UNIQUE constraint on event_id --
+    # Added in migration 0020 when event_id was demoted from PK to business key.
+    op.execute("""
+        ALTER TABLE events
+        DROP CONSTRAINT IF EXISTS uq_events_event_id
+    """)
+
+    # -- Step 2: Drop the event_id column --
+    # All code now uses external_id (scoped by platform_id) instead.
+    op.execute("""
+        ALTER TABLE events
+        DROP COLUMN IF EXISTS event_id
+    """)
+
+
+def downgrade() -> None:
+    """Restore the event_id column and populate from external_id."""
+    # -- Step 1: Add event_id column back (nullable to allow backfill) --
+    op.execute("""
+        ALTER TABLE events
+        ADD COLUMN IF NOT EXISTS event_id VARCHAR(100)
+    """)
+
+    # -- Step 2: Backfill from external_id --
+    op.execute("""
+        UPDATE events SET event_id = external_id WHERE event_id IS NULL
+    """)
+
+    # -- Step 3: Set NOT NULL --
+    op.execute("""
+        ALTER TABLE events
+        ALTER COLUMN event_id SET NOT NULL
+    """)
+
+    # -- Step 4: Re-add UNIQUE constraint --
+    op.execute("""
+        ALTER TABLE events
+        ADD CONSTRAINT uq_events_event_id UNIQUE (event_id)
+    """)

--- a/src/precog/database/crud_operations.py
+++ b/src/precog/database/crud_operations.py
@@ -891,12 +891,14 @@ def get_or_create_series(
 
 def get_event(event_id: str) -> dict[str, Any] | None:
     """
-    Get an event by its business key (event_id VARCHAR).
+    Get an event by its external_id (platform-scoped business key).
 
     Args:
-        event_id: The event business key (UNIQUE, from Kalshi API).
-            Note: this is NOT the integer surrogate PK. The surrogate PK
-            is available in the returned dict as result["id"].
+        event_id: The event business key (from Kalshi API).
+            Note: Parameter name is a legacy holdover; the DB column
+            queried is ``external_id``.  This is NOT the integer
+            surrogate PK.  The surrogate PK is available in the
+            returned dict as result["id"].
 
     Returns:
         Dictionary with event data (including 'id' surrogate PK), or None if not found
@@ -908,12 +910,13 @@ def get_event(event_id: str) -> dict[str, Any] | None:
         ...     print(event['title'])  # Event title
 
     Reference:
-        - Migration 0020: event_id demoted to UNIQUE business key, id is SERIAL PK
+        - Migration 0020: id is SERIAL PK, external_id is the business key
+        - Migration 0047: Dropped redundant event_id column; external_id is canonical
     """
     query = """
         SELECT *
         FROM events
-        WHERE event_id = %s
+        WHERE external_id = %s
     """
     return fetch_one(query, (event_id,))
 
@@ -940,9 +943,13 @@ def create_event(
     enforced via foreign key constraint (markets.event_internal_id -> events.id).
 
     Args:
-        event_id: Unique event business key (VARCHAR, from Kalshi API)
+        event_id: Legacy parameter name kept for caller compatibility.
+            The value is stored in the ``external_id`` column.
+            Callers typically pass the same value for both ``event_id``
+            and ``external_id``; only ``external_id`` is written to the DB.
         platform_id: Foreign key to platforms table (e.g., 'kalshi')
-        external_id: External ID from the platform API
+        external_id: External ID from the platform API (stored as the
+            business key in ``events.external_id``)
         category: Event category ('sports', 'politics', 'entertainment',
                   'economics', 'weather', 'other')
         title: Event title/description
@@ -964,7 +971,8 @@ def create_event(
         to set markets.event_internal_id FK.
 
     Raises:
-        psycopg2.IntegrityError: If event_id already exists or platform_id invalid
+        psycopg2.IntegrityError: If external_id+platform_id already exists
+            or platform_id invalid
 
     Example:
         >>> event_pk = create_event(
@@ -993,21 +1001,21 @@ def create_event(
         - Migration 0019: events.series_internal_id replaces events.series_id
         - Migration 0020: events.id SERIAL PK, markets.event_internal_id INTEGER FK
         - Migration 0038: events.game_id FK to games(id)
+        - Migration 0047: Dropped redundant event_id column
     """
     query = """
         INSERT INTO events (
-            event_id, platform_id, series_internal_id, external_id,
+            platform_id, series_internal_id, external_id,
             category, subcategory, title, description,
             start_time, end_time, status, metadata,
             game_id,
             created_at, updated_at
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW(), NOW())
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW(), NOW())
         RETURNING id
     """
 
     params = (
-        event_id,
         platform_id,
         series_internal_id,
         external_id,
@@ -1111,7 +1119,8 @@ def get_or_create_event(
     to handle the common pattern of "upsert" behavior for events.
 
     Args:
-        event_id: Unique event business key (VARCHAR, from Kalshi API)
+        event_id: Legacy parameter name kept for caller compatibility.
+            The value is looked up via ``external_id`` in the DB.
         platform_id: Foreign key to platforms table
         external_id: External ID from the platform API
         category: Event category
@@ -1149,13 +1158,14 @@ def get_or_create_event(
         This pattern is essential for polling services like KalshiMarketPoller.
         When polling API data, the same events appear repeatedly. This function
         ensures we don't attempt duplicate inserts (which would fail due to
-        UNIQUE constraint on event_id) while still creating new events when
-        they appear.
+        UNIQUE constraint on external_id+platform_id) while still creating
+        new events when they appear.
 
     Reference:
         - src/precog/schedulers/kalshi_poller.py
         - Migration 0019: events.series_internal_id replaces events.series_id
         - Migration 0020: events.id SERIAL PK, returns integer instead of VARCHAR
+        - Migration 0047: Dropped redundant event_id column
         - Migration 0038: events.game_id FK to games(id)
     """
     # Check if event already exists — fill NULL enrichment fields if caller
@@ -1241,7 +1251,7 @@ def create_market(
     Args:
         platform_id: Foreign key to platforms table (VARCHAR)
         event_internal_id: Integer FK to events(id) surrogate PK. This is the
-            integer returned by get_or_create_event(), NOT the VARCHAR event_id.
+            integer returned by get_or_create_event().
             None if the market has no associated event.
         external_id: External market ID from platform
         ticker: Market ticker (e.g., "NFL-KC-BUF-YES")
@@ -9309,7 +9319,7 @@ def find_unlinked_sports_events(league: str | None = None) -> list[dict[str, Any
         league: Optional subcategory/league filter (e.g., "nfl", "nba").
 
     Returns:
-        List of event dicts with keys: id, event_id, title, subcategory.
+        List of event dicts with keys: id, external_id, title, subcategory.
 
     Example:
         >>> unlinked = find_unlinked_sports_events("nfl")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -257,7 +257,7 @@ def clean_test_data(db_cursor):
     # Delete markets by ticker pattern — CASCADE handles downstream tables
     # (edges, positions, trades, settlements via market_internal_id FK)
     db_cursor.execute("DELETE FROM markets WHERE ticker LIKE 'TEST-%'")
-    db_cursor.execute("DELETE FROM events WHERE event_id LIKE 'TEST-%'")
+    db_cursor.execute("DELETE FROM events WHERE external_id LIKE 'TEST-%'")
     db_cursor.execute("DELETE FROM series WHERE series_id LIKE 'TEST-%'")
     # Clean up ALL test models and strategies (fixture data + SERIAL-generated)
     # This ensures clean state for property tests that create many strategies
@@ -291,11 +291,12 @@ def clean_test_data(db_cursor):
     _test_series_pk = _series_row["id"] if _series_row else None
 
     # Create test event (uses series_internal_id integer FK)
+    # external_id is the canonical business key (migration 0047 dropped the old event_id column)
     db_cursor.execute(
         """
-        INSERT INTO events (event_id, platform_id, series_internal_id, external_id, category, title, status)
-        VALUES ('TEST-EVT-NFL-KC-BUF', 'test_platform', %s, 'TEST-EXT-EVT', 'sports', 'Test Event: KC vs BUF', 'scheduled')
-        ON CONFLICT (event_id) DO NOTHING
+        INSERT INTO events (platform_id, series_internal_id, external_id, category, title, status)
+        VALUES ('test_platform', %s, 'TEST-EVT-NFL-KC-BUF', 'sports', 'Test Event: KC vs BUF', 'scheduled')
+        ON CONFLICT (platform_id, external_id) DO NOTHING
     """,
         (_test_series_pk,),
     )
@@ -303,9 +304,9 @@ def clean_test_data(db_cursor):
     # Create additional test event for test_execute_query
     db_cursor.execute(
         """
-        INSERT INTO events (event_id, platform_id, series_internal_id, external_id, category, title, status)
-        VALUES ('TEST-EVT', 'test_platform', %s, 'TEST-EVT-2', 'sports', 'Test Event 2', 'scheduled')
-        ON CONFLICT (event_id) DO NOTHING
+        INSERT INTO events (platform_id, series_internal_id, external_id, category, title, status)
+        VALUES ('test_platform', %s, 'TEST-EVT-2', 'sports', 'Test Event 2', 'scheduled')
+        ON CONFLICT (platform_id, external_id) DO NOTHING
     """,
         (_test_series_pk,),
     )
@@ -349,7 +350,7 @@ def clean_test_data(db_cursor):
         db_cursor.connection.rollback()  # CRITICAL: Clear aborted transaction state
     # Delete markets by ticker pattern — CASCADE handles downstream tables
     db_cursor.execute("DELETE FROM markets WHERE ticker LIKE 'TEST-%'")
-    db_cursor.execute("DELETE FROM events WHERE event_id LIKE 'TEST-%'")
+    db_cursor.execute("DELETE FROM events WHERE external_id LIKE 'TEST-%'")
     db_cursor.execute("DELETE FROM series WHERE series_id LIKE 'TEST-%'")
     # Clean up ALL test models and strategies (fixture data + SERIAL-generated)
     # This ensures clean state for next test
@@ -720,10 +721,10 @@ def sample_event(db_pool, clean_test_data, sample_platform, sample_series) -> st
     series_pk = series_row["id"] if series_row else None
 
     query = """
-        INSERT INTO events (event_id, platform_id, series_internal_id, external_id, category, subcategory, title, status)
-        VALUES ('HIGHTEST', 'kalshi', %s, 'HIGHTEST-ext', 'sports', 'nfl', 'Super Bowl LIX', 'scheduled')
-        ON CONFLICT (event_id) DO NOTHING
-        RETURNING event_id
+        INSERT INTO events (platform_id, series_internal_id, external_id, category, subcategory, title, status)
+        VALUES ('kalshi', %s, 'HIGHTEST', 'sports', 'nfl', 'Super Bowl LIX', 'scheduled')
+        ON CONFLICT (platform_id, external_id) DO NOTHING
+        RETURNING external_id
     """
     execute_query(query, (series_pk,))
     return "HIGHTEST"
@@ -740,7 +741,7 @@ def sample_market(db_pool, clean_test_data, sample_platform, sample_event) -> in
     from precog.database.crud_operations import create_market
 
     # Look up event surrogate PK (migration 0020: events use integer FK)
-    event_row = fetch_one("SELECT id FROM events WHERE event_id = 'HIGHTEST'")
+    event_row = fetch_one("SELECT id FROM events WHERE external_id = 'HIGHTEST'")
     event_pk = event_row["id"] if event_row else None
 
     # Check if market already exists (by ticker, since market_id VARCHAR is dropped)

--- a/tests/e2e/schedulers/test_kalshi_poller_e2e.py
+++ b/tests/e2e/schedulers/test_kalshi_poller_e2e.py
@@ -142,9 +142,9 @@ class TestKalshiPollerDatabaseIntegration:
         The bug: create_market() was called without first creating the event.
 
         Educational Note:
-            The markets table has: event_id REFERENCES events(event_id)
+            The markets table has: event_internal_id REFERENCES events(id)
             Without the event existing first, INSERT fails with:
-            "violates foreign key constraint markets_event_id_fkey"
+            "violates foreign key constraint on event_internal_id"
         """
         from precog.schedulers.kalshi_poller import KalshiMarketPoller
 

--- a/tests/fixtures/testcontainers_fixtures.py
+++ b/tests/fixtures/testcontainers_fixtures.py
@@ -135,7 +135,6 @@ def _apply_migration_sql(connection: psycopg2.extensions.connection) -> None:
 
     CREATE TABLE IF NOT EXISTS events (
         id SERIAL PRIMARY KEY,
-        event_id VARCHAR(100) NOT NULL UNIQUE,
         platform_id VARCHAR(50) REFERENCES platforms(platform_id) ON DELETE CASCADE,
         series_internal_id INTEGER REFERENCES series(id) ON DELETE SET NULL,
         external_id VARCHAR(100) NOT NULL,

--- a/tests/fixtures/transaction_fixtures.py
+++ b/tests/fixtures/transaction_fixtures.py
@@ -187,11 +187,12 @@ def db_transaction_with_setup(
     _series_pk = _sr["id"] if _sr else None
 
     # Create test event (uses series_internal_id integer FK)
+    # external_id is the canonical business key (migration 0047 dropped event_id column)
     cursor.execute(
         """
-        INSERT INTO events (event_id, platform_id, series_internal_id, external_id, category, title, status)
-        VALUES ('TEST-EVT-NFL-KC-BUF', 'test_platform', %s, 'TEST-EXT-EVT', 'sports', 'Test Event: KC vs BUF', 'scheduled')
-        ON CONFLICT (event_id) DO NOTHING
+        INSERT INTO events (platform_id, series_internal_id, external_id, category, title, status)
+        VALUES ('test_platform', %s, 'TEST-EVT-NFL-KC-BUF', 'sports', 'Test Event: KC vs BUF', 'scheduled')
+        ON CONFLICT (platform_id, external_id) DO NOTHING
     """,
         (_series_pk,),
     )
@@ -199,9 +200,9 @@ def db_transaction_with_setup(
     # Create additional test event for compatibility
     cursor.execute(
         """
-        INSERT INTO events (event_id, platform_id, series_internal_id, external_id, category, title, status)
-        VALUES ('TEST-EVT', 'test_platform', %s, 'TEST-EVT-2', 'sports', 'Test Event 2', 'scheduled')
-        ON CONFLICT (event_id) DO NOTHING
+        INSERT INTO events (platform_id, series_internal_id, external_id, category, title, status)
+        VALUES ('test_platform', %s, 'TEST-EVT-2', 'sports', 'Test Event 2', 'scheduled')
+        ON CONFLICT (platform_id, external_id) DO NOTHING
     """,
         (_series_pk,),
     )

--- a/tests/integration/cli/_deprecated_test_cli_database_integration.py
+++ b/tests/integration/cli/_deprecated_test_cli_database_integration.py
@@ -99,13 +99,13 @@ def setup_kalshi_platform(db_pool, clean_test_data):
         # Note: VCR cassette events (KXNFLGAME-25NOV27*) + mock test event (KXNFLGAME-25DEC15CLEKC)
         cur.execute(
             """
-            INSERT INTO events (event_id, platform_id, series_id, external_id, category, title, status)
+            INSERT INTO events (platform_id, series_internal_id, external_id, category, title, status)
             VALUES
-                ('KXNFLGAME-25NOV27GBDET', 'kalshi', 'KXNFLGAME', 'KXNFLGAME-25NOV27GBDET-EXT', 'sports', 'Green Bay at Detroit', 'scheduled'),
-                ('KXNFLGAME-25NOV27KCDAL', 'kalshi', 'KXNFLGAME', 'KXNFLGAME-25NOV27KCDAL-EXT', 'sports', 'Kansas City at Dallas', 'scheduled'),
-                ('KXNFLGAME-25NOV27CINBAL', 'kalshi', 'KXNFLGAME', 'KXNFLGAME-25NOV27CINBAL-EXT', 'sports', 'Cincinnati at Baltimore', 'scheduled'),
-                ('KXNFLGAME-25DEC15CLEKC', 'kalshi', 'KXNFLGAME', 'KXNFLGAME-25DEC15CLEKC-EXT', 'sports', 'Mock Test Event', 'scheduled')
-            ON CONFLICT (event_id) DO NOTHING
+                ('kalshi', (SELECT id FROM series WHERE series_id = 'KXNFLGAME'), 'KXNFLGAME-25NOV27GBDET', 'sports', 'Green Bay at Detroit', 'scheduled'),
+                ('kalshi', (SELECT id FROM series WHERE series_id = 'KXNFLGAME'), 'KXNFLGAME-25NOV27KCDAL', 'sports', 'Kansas City at Dallas', 'scheduled'),
+                ('kalshi', (SELECT id FROM series WHERE series_id = 'KXNFLGAME'), 'KXNFLGAME-25NOV27CINBAL', 'sports', 'Cincinnati at Baltimore', 'scheduled'),
+                ('kalshi', (SELECT id FROM series WHERE series_id = 'KXNFLGAME'), 'KXNFLGAME-25DEC15CLEKC', 'sports', 'Mock Test Event', 'scheduled')
+            ON CONFLICT (platform_id, external_id) DO NOTHING
         """
         )
 
@@ -325,7 +325,7 @@ def test_fetch_markets_creates_new_markets(
             """
             SELECT COUNT(*) as market_count
             FROM markets m
-            JOIN events e ON m.event_id = e.event_id
+            JOIN events e ON m.event_internal_id = e.id
             WHERE e.series_id = 'KXNFLGAME' AND m.row_current_ind = TRUE
         """
         )
@@ -340,7 +340,7 @@ def test_fetch_markets_creates_new_markets(
             """
             SELECT m.ticker, m.yes_price, m.no_price, m.volume, m.open_interest
             FROM markets m
-            JOIN events e ON m.event_id = e.event_id
+            JOIN events e ON m.event_internal_id = e.id
             WHERE e.series_id = 'KXNFLGAME' AND m.row_current_ind = TRUE
             LIMIT 1
         """
@@ -383,7 +383,7 @@ def test_fetch_markets_upsert_pattern(
             """
             DELETE FROM markets m
             USING events e
-            WHERE m.event_id = e.event_id
+            WHERE m.event_internal_id = e.id
               AND e.series_id = 'KXNFLGAME'
         """
         )
@@ -407,7 +407,7 @@ def test_fetch_markets_upsert_pattern(
             """
             SELECT COUNT(*) as market_count
             FROM markets m
-            JOIN events e ON m.event_id = e.event_id
+            JOIN events e ON m.event_internal_id = e.id
             WHERE e.series_id = 'KXNFLGAME'
         """
         )
@@ -435,7 +435,7 @@ def test_fetch_markets_upsert_pattern(
             """
             SELECT COUNT(*) as market_count
             FROM markets m
-            JOIN events e ON m.event_id = e.event_id
+            JOIN events e ON m.event_internal_id = e.id
             WHERE e.series_id = 'KXNFLGAME'
         """
         )
@@ -451,7 +451,7 @@ def test_fetch_markets_upsert_pattern(
             """
             SELECT COUNT(*) as current_count
             FROM markets m
-            JOIN events e ON m.event_id = e.event_id
+            JOIN events e ON m.event_internal_id = e.id
             WHERE e.series_id = 'KXNFLGAME' AND m.row_current_ind = TRUE
         """
         )
@@ -465,7 +465,7 @@ def test_fetch_markets_upsert_pattern(
             """
             SELECT COUNT(*) as historical_count
             FROM markets m
-            JOIN events e ON m.event_id = e.event_id
+            JOIN events e ON m.event_internal_id = e.id
             WHERE e.series_id = 'KXNFLGAME' AND m.row_current_ind = FALSE
         """
         )
@@ -479,7 +479,7 @@ def test_fetch_markets_upsert_pattern(
             """
             SELECT m.ticker, m.yes_price, m.row_current_ind
             FROM markets m
-            JOIN events e ON m.event_id = e.event_id
+            JOIN events e ON m.event_internal_id = e.id
             WHERE e.series_id = 'KXNFLGAME' AND m.row_current_ind = FALSE
             ORDER BY m.ticker
         """
@@ -543,7 +543,7 @@ def test_fetch_settlements_creates_records_and_updates_market_status(
             """
             SELECT m.ticker, m.status
             FROM markets m
-            JOIN events e ON m.event_id = e.event_id
+            JOIN events e ON m.event_internal_id = e.id
             WHERE m.ticker = 'KXNFLGAME-25DEC15CLEKC-KC-YES' AND m.row_current_ind = TRUE
         """
         )
@@ -581,7 +581,7 @@ def test_fetch_settlements_creates_records_and_updates_market_status(
             """
             SELECT m.ticker, m.status
             FROM markets m
-            JOIN events e ON m.event_id = e.event_id
+            JOIN events e ON m.event_internal_id = e.id
             WHERE m.ticker = 'KXNFLGAME-25DEC15CLEKC-KC-YES' AND m.row_current_ind = TRUE
         """
         )

--- a/tests/integration/fixtures/test_transaction_fixtures.py
+++ b/tests/integration/fixtures/test_transaction_fixtures.py
@@ -62,7 +62,9 @@ class TestTransactionWithSetup:
         assert result["cnt"] == 1, "Test series should exist"
 
         # Test event should exist
-        cursor.execute("SELECT COUNT(*) as cnt FROM events WHERE event_id = 'TEST-EVT-NFL-KC-BUF'")
+        cursor.execute(
+            "SELECT COUNT(*) as cnt FROM events WHERE external_id = 'TEST-EVT-NFL-KC-BUF'"
+        )
         result = cursor.fetchone()
         assert result["cnt"] == 1, "Test event should exist"
 

--- a/tests/integration/schedulers/test_kalshi_poller_integration.py
+++ b/tests/integration/schedulers/test_kalshi_poller_integration.py
@@ -168,9 +168,11 @@ class TestPollerDatabaseIntegration:
         """New markets should create both event and market records.
 
         Educational Note:
-            We verify the expected event_id was called rather than asserting
-            exactly one call. This avoids flakiness from test pollution if
-            other pollers are running in background threads during the test run.
+            We verify the expected event_id parameter was passed rather than
+            asserting exactly one call. This avoids flakiness from test
+            pollution if other pollers are running in background threads.
+            Note: ``event_id`` is the function parameter name (legacy);
+            the DB column is ``external_id`` (migration 0047).
         """
         # Reset mock to ensure clean state
         mock_kalshi_client.reset_mock()

--- a/tests/integration/trading/test_position_manager.py
+++ b/tests/integration/trading/test_position_manager.py
@@ -39,7 +39,7 @@ def test_market_pks(db_cursor, clean_test_data):
         with conn.cursor() as cur:
             # Look up event surrogate PK (migration 0020: markets use integer FK)
             # Note: get_connection() returns raw psycopg2 (tuple rows), not dict cursor
-            cur.execute("SELECT id FROM events WHERE event_id = 'TEST-EVT-NFL-KC-BUF'")
+            cur.execute("SELECT id FROM events WHERE external_id = 'TEST-EVT-NFL-KC-BUF'")
             _evt = cur.fetchone()
             event_pk = _evt[0] if _evt else None
 

--- a/tests/property/test_database_crud_properties.py
+++ b/tests/property/test_database_crud_properties.py
@@ -123,13 +123,14 @@ def setup_kalshi_platform(db_pool, clean_test_data):
 
         # Create events for test markets (idempotent)
         # Uses series_internal_id (integer FK) instead of old series_id VARCHAR
+        # Migration 0047: event_id column dropped, external_id is canonical business key
         cur.execute(
             """
-            INSERT INTO events (event_id, platform_id, series_internal_id, external_id, category, title, status)
+            INSERT INTO events (platform_id, series_internal_id, external_id, category, title, status)
             VALUES
-                ('KXNFLGAME-25DEC15CLEKC', 'kalshi', %s, 'KXNFLGAME-25DEC15CLEKC-EXT', 'sports', 'NFL Games Dec 15', 'scheduled'),
-                ('KXNFLGAME-25DEC08LACKC', 'kalshi', %s, 'KXNFLGAME-25DEC08LACKC-EXT', 'sports', 'NFL Games Dec 08', 'scheduled')
-            ON CONFLICT (event_id) DO NOTHING
+                ('kalshi', %s, 'KXNFLGAME-25DEC15CLEKC', 'sports', 'NFL Games Dec 15', 'scheduled'),
+                ('kalshi', %s, 'KXNFLGAME-25DEC08LACKC', 'sports', 'NFL Games Dec 08', 'scheduled')
+            ON CONFLICT (platform_id, external_id) DO NOTHING
         """,
             (series_pk, series_pk),
         )
@@ -592,7 +593,7 @@ def test_foreign_key_prevents_orphan_markets(
 
     Validates:
     - Cannot create market with non-existent platform_id
-    - Cannot create market with non-existent event_id
+    - Cannot create market with non-existent event_internal_id
     - IntegrityError raised on foreign key violation
 
     Why This Matters:
@@ -1075,17 +1076,17 @@ def test_cascade_delete_integrity(db_pool, clean_test_data, ticker):
         series_pk = cur.fetchone()["id"]
 
         # Create test event (uses series_internal_id integer FK)
+        # Migration 0047: event_id column dropped, external_id is canonical
         cur.execute(
             """
-            INSERT INTO events (event_id, platform_id, series_internal_id, external_id, category, title, status)
-            VALUES (%s, %s, %s, %s, 'sports', 'Test Event', 'scheduled')
+            INSERT INTO events (platform_id, series_internal_id, external_id, category, title, status)
+            VALUES (%s, %s, %s, 'sports', 'Test Event', 'scheduled')
             RETURNING id
         """,
             (
-                test_event_id,
                 test_platform_id,
                 series_pk,
-                f"EXTEVT-{unique_id}",
+                test_event_id,
             ),
         )
         event_pk = cur.fetchone()["id"]

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -137,10 +137,10 @@ def sample_event(db_pool, clean_test_data, sample_platform, sample_series) -> st
     series_pk = series_row["id"] if series_row else None
 
     query = """
-        INSERT INTO events (event_id, platform_id, series_internal_id, external_id, category, subcategory, title, status)
-        VALUES ('HIGHTEST', 'kalshi', %s, 'HIGHTEST-ext', 'sports', 'nfl', 'Super Bowl LIX', 'scheduled')
-        ON CONFLICT (event_id) DO NOTHING
-        RETURNING event_id
+        INSERT INTO events (platform_id, series_internal_id, external_id, category, subcategory, title, status)
+        VALUES ('kalshi', %s, 'HIGHTEST', 'sports', 'nfl', 'Super Bowl LIX', 'scheduled')
+        ON CONFLICT (platform_id, external_id) DO NOTHING
+        RETURNING external_id
     """
     execute_query(query, (series_pk,))
     return "HIGHTEST"
@@ -157,7 +157,7 @@ def sample_market(db_pool, clean_test_data, sample_platform, sample_event) -> in
     from precog.database.crud_operations import create_market
 
     # Look up event surrogate PK (migration 0020: events use integer FK)
-    event_row = fetch_one("SELECT id FROM events WHERE event_id = 'HIGHTEST'")
+    event_row = fetch_one("SELECT id FROM events WHERE external_id = 'HIGHTEST'")
     event_pk = event_row["id"] if event_row else None
 
     # Check if market already exists (by ticker, since market_id VARCHAR is dropped)

--- a/tests/test_attribution_comprehensive.py
+++ b/tests/test_attribution_comprehensive.py
@@ -202,7 +202,7 @@ def test_e2e_full_attribution_workflow(
     # Look up event surrogate PK (migration 0020: events use integer FK)
     from precog.database.connection import fetch_one as _fetch_one
 
-    event_row = _fetch_one("SELECT id FROM events WHERE event_id = %s", (sample_event,))
+    event_row = _fetch_one("SELECT id FROM events WHERE external_id = %s", (sample_event,))
     event_pk = event_row["id"] if event_row else None
 
     market_id = create_market(


### PR DESCRIPTION
## Summary
- Drop redundant `event_id` column from `events` table (migration 0047)
- All 3,894 events had `event_id == external_id` — `external_id` is semantically correct (scoped by `platform_id` for multi-platform)
- Updated CRUD operations (`get_event`, `create_event`), 10 test files, backfill script
- Function parameter names kept as `event_id` for caller compatibility with docstring annotations

## Agent Review Trail
| Agent | Role | Findings | Fixed |
|-------|------|----------|-------|
| **Samwise** | Builder | Scoped 67 files (15 in-scope, 50+ correctly excluded), built migration + CRUD + tests | N/A |
| **Glokta+Ripley** | Reviewer+QA | APPROVE — all SQL refs updated, migration safe and reversible, no remaining events.event_id column refs | N/A |

## Test plan
- [x] 2,431 unit tests pass (0 regressions)
- [x] Ruff lint + format clean
- [x] Mypy type check pass
- [x] Migration 0047 applied on dev + test DBs
- [x] Migration reversible (downgrade adds column back, backfills from external_id)
- [ ] CI integration tests (running)

Note: local pre-push stress tests had 18 pre-existing DB connection pool flakiness errors (`test_connection_stress.py`, `test_crud_operations_stress.py`) — unrelated to this change. CI will validate independently.

Closes #530

🤖 Generated with [Claude Code](https://claude.com/claude-code)