### PR TITLE
fix: Kalshi API _fp suffix field name mismatch — restore volume/depth data

### DIFF
--- a/src/precog/api_connectors/types.py
+++ b/src/precog/api_connectors/types.py
@@ -54,20 +54,22 @@ class MarketData(TypedDict):
     no_bid: str  # Highest resting NO buy order (in cents as string)
     no_ask: str  # Lowest resting NO sell order (cost to buy NO contract)
     last_price: str
-    volume: int
-    open_interest: int
+    # Volume/OI fields: Kalshi API returns these with an _fp suffix as strings
+    # (e.g., volume_fp: "8981763.00"). Convert with int(float(x)) before DB insert.
+    volume_fp: str  # Total lifetime contracts traded (string like "8981763.00")
+    open_interest_fp: str  # Total contracts currently held (string like "4997871.00")
     liquidity: int
 
     # -- Enrichment fields (Issue #513 P1) --
-    # 24-hour rolling trading volume in contracts. Integer count, not dollar value.
-    # May be absent from some API responses (e.g., newly listed markets).
-    volume_24h: int
+    # 24-hour rolling trading volume in contracts. String like "150.00" from API.
+    # Convert with int(float(x)). May be absent for newly listed markets.
+    volume_24h_fp: str
     # Number of contracts resting at the best YES bid price. Depth signal for
-    # liquidity assessment. Integer count. May be 0 for illiquid markets.
-    yes_bid_size: int
+    # liquidity assessment. String like "500.00" from API. May be "0.00" for illiquid markets.
+    yes_bid_size_fp: str
     # Number of contracts resting at the best YES ask price. Depth signal for
-    # liquidity assessment. Integer count. May be 0 for illiquid markets.
-    yes_ask_size: int
+    # liquidity assessment. String like "500.00" from API. May be "0.00" for illiquid markets.
+    yes_ask_size_fp: str
     # Free-text settlement outcome description from Kalshi (e.g., "above 42.5",
     # "yes", "Chiefs"). Describes what outcome this market represents.
     # Distinct from settlement_value_dollars (which is the payout amount).
@@ -234,8 +236,11 @@ class ProcessedMarketData(TypedDict, total=False):
     no_bid: int  # Highest NO buy order in cents (0-99)
     no_ask: int  # Lowest NO sell order in cents (cost to buy NO)
     last_price: int
-    volume: int
-    open_interest: int
+    # Volume/OI fields: Kalshi API returns these with an _fp suffix as strings
+    # (e.g., volume_fp: "8981763.00"). Not converted by _convert_prices_to_decimal;
+    # the poller converts them to int via _parse_fp_int() before DB insert.
+    volume_fp: str  # Total lifetime contracts traded (string like "8981763.00")
+    open_interest_fp: str  # Total contracts currently held (string like "4997871.00")
     liquidity: int
 
     # Sub-penny Decimal fields (*_dollars suffix - converted to Decimal)
@@ -263,13 +268,13 @@ class ProcessedMarketData(TypedDict, total=False):
     # Dollar notional value of the contract, converted to Decimal by _convert_prices_to_decimal.
     # Represents the total dollar exposure per contract. None for markets where API omits it.
     notional_value_dollars: Decimal
-    # 24-hour rolling trading volume in contracts. Integer count, not dollar value.
-    # May be absent from some API responses (e.g., newly listed markets).
-    volume_24h: int
+    # 24-hour rolling trading volume in contracts. String like "150.00" from API.
+    # Not converted by _convert_prices_to_decimal; poller converts via _parse_fp_int().
+    volume_24h_fp: str
     # Number of contracts resting at the best YES bid/ask price. Depth signals
-    # for liquidity assessment. Integer counts. May be 0 for illiquid markets.
-    yes_bid_size: int
-    yes_ask_size: int
+    # for liquidity assessment. Strings like "500.00" from API. May be "0.00".
+    yes_bid_size_fp: str
+    yes_ask_size_fp: str
     # Free-text settlement outcome description (e.g., "above 42.5", "yes").
     # Describes what outcome this market represents. Not a price.
     expiration_value: str

--- a/src/precog/cli/kalshi.py
+++ b/src/precog/cli/kalshi.py
@@ -229,7 +229,8 @@ def markets(
             status = market.get("status", "N/A")
             yes_bid = market.get("yes_bid", Decimal("0"))
             yes_ask = market.get("yes_ask", Decimal("0"))
-            volume = market.get("volume", 0)
+            raw_vol = market.get("volume_fp")
+            volume = int(float(raw_vol)) if raw_vol else 0
 
             # Truncate title if needed
             if len(title) > 40:
@@ -347,7 +348,8 @@ def all_markets(
             status = market.get("status", "N/A")
             yes_bid = market.get("yes_bid", Decimal("0"))
             yes_ask = market.get("yes_ask", Decimal("0"))
-            volume = market.get("volume", 0)
+            raw_vol = market.get("volume_fp")
+            volume = int(float(raw_vol)) if raw_vol else 0
 
             if len(title) > 40:
                 title = title[:37] + "..."

--- a/src/precog/schedulers/kalshi_poller.py
+++ b/src/precog/schedulers/kalshi_poller.py
@@ -69,6 +69,30 @@ from precog.validation.kalshi_validation import KalshiDataValidator
 logger = logging.getLogger(__name__)
 
 
+def _parse_fp_int(market: Any, fp_field: str) -> int | None:
+    """Parse an _fp string field from the Kalshi API into an integer.
+
+    Kalshi API returns several integer-valued fields with an _fp suffix as
+    strings (e.g., volume_fp: "8981763.00").  This helper converts them to
+    int, gracefully handling None and missing keys.
+
+    Args:
+        market: Market data dictionary from the API.
+        fp_field: Key name including the _fp suffix (e.g., "volume_fp").
+
+    Returns:
+        Integer value, or None if the field is absent / None.
+    """
+    raw = market.get(fp_field)
+    if raw is None:
+        return None
+    try:
+        return int(float(raw))
+    except (ValueError, TypeError, OverflowError):
+        logger.warning("Failed to parse %s as int: %r", fp_field, raw)
+        return None
+
+
 class KalshiMarketPoller(BasePoller):
     """
     Kalshi market price polling service.
@@ -1191,8 +1215,8 @@ class KalshiMarketPoller(BasePoller):
                 no_ask_price=no_price,
                 market_type="binary",
                 status=db_status,
-                volume=market.get("volume"),
-                open_interest=market.get("open_interest"),
+                volume=_parse_fp_int(market, "volume_fp"),
+                open_interest=_parse_fp_int(market, "open_interest_fp"),
                 spread=spread,
                 yes_bid_price=yes_bid_price,
                 no_bid_price=no_bid_price,
@@ -1210,12 +1234,12 @@ class KalshiMarketPoller(BasePoller):
                 expiration_value=market.get("expiration_value"),
                 notional_value=market.get("notional_value_dollars"),
                 # Migration 0046: snapshot enrichment
-                volume_24h=market.get("volume_24h"),
+                volume_24h=_parse_fp_int(market, "volume_24h_fp"),
                 previous_yes_bid=market.get("previous_yes_bid_dollars"),
                 previous_yes_ask=market.get("previous_yes_ask_dollars"),
                 previous_price=market.get("previous_price_dollars"),
-                yes_bid_size=market.get("yes_bid_size"),
-                yes_ask_size=market.get("yes_ask_size"),
+                yes_bid_size=_parse_fp_int(market, "yes_bid_size_fp"),
+                yes_ask_size=_parse_fp_int(market, "yes_ask_size_fp"),
                 metadata={
                     k: v
                     for k, v in {
@@ -1282,8 +1306,8 @@ class KalshiMarketPoller(BasePoller):
                 yes_ask_price=yes_price,
                 no_ask_price=no_price,
                 status=db_status,
-                volume=market.get("volume"),
-                open_interest=market.get("open_interest"),
+                volume=_parse_fp_int(market, "volume_fp"),
+                open_interest=_parse_fp_int(market, "open_interest_fp"),
                 spread=spread,
                 yes_bid_price=yes_bid_price,
                 no_bid_price=no_bid_price,
@@ -1300,12 +1324,12 @@ class KalshiMarketPoller(BasePoller):
                 expiration_value=market.get("expiration_value"),
                 notional_value=market.get("notional_value_dollars"),
                 # Migration 0046: snapshot enrichment
-                volume_24h=market.get("volume_24h"),
+                volume_24h=_parse_fp_int(market, "volume_24h_fp"),
                 previous_yes_bid=market.get("previous_yes_bid_dollars"),
                 previous_yes_ask=market.get("previous_yes_ask_dollars"),
                 previous_price=market.get("previous_price_dollars"),
-                yes_bid_size=market.get("yes_bid_size"),
-                yes_ask_size=market.get("yes_ask_size"),
+                yes_bid_size=_parse_fp_int(market, "yes_bid_size_fp"),
+                yes_ask_size=_parse_fp_int(market, "yes_ask_size_fp"),
             )
             logger.debug(
                 "Updated market: %s (yes: %s -> %s)",

--- a/src/precog/schedulers/kalshi_websocket.py
+++ b/src/precog/schedulers/kalshi_websocket.py
@@ -766,6 +766,7 @@ class KalshiWebSocketHandler:
                     ticker=ticker,
                     yes_ask_price=yes_price,
                     no_ask_price=no_price,
+                    # WebSocket ticker messages use integer volume/OI (not _fp strings from REST API)
                     volume=msg.get("volume"),
                     open_interest=msg.get("open_interest"),
                 )

--- a/src/precog/tui/screens/market_browser.py
+++ b/src/precog/tui/screens/market_browser.py
@@ -459,8 +459,9 @@ class MarketBrowserScreen(BaseScreen):
                     title = self._clean_text(market.get("title", ""), max_len=45)
                     ticker = self._clean_text(market.get("ticker", ""), max_len=30)
 
-                    # Format volume safely
-                    volume = market.get("volume", 0)
+                    # Format volume safely (REST API uses _fp suffix for integer fields)
+                    raw_vol = market.get("volume_fp")
+                    volume = int(float(raw_vol)) if raw_vol else 0
                     volume_str = f"{int(volume):,}" if volume else "0"
 
                     table.add_row(

--- a/src/precog/validation/kalshi_validation.py
+++ b/src/precog/validation/kalshi_validation.py
@@ -38,6 +38,19 @@ from precog.utils.logger import get_logger
 logger = get_logger(__name__)
 
 
+def _parse_fp_int(raw: str | None) -> int | None:
+    """Parse a Kalshi _fp string field (e.g., "8981763.00") into an integer.
+
+    Returns None if the value is absent or unparseable.
+    """
+    if raw is None:
+        return None
+    try:
+        return int(float(raw))
+    except (ValueError, TypeError, OverflowError):
+        return None
+
+
 # =============================================================================
 # Validation Level Enum
 # =============================================================================
@@ -582,9 +595,9 @@ class KalshiDataValidator:
             - Active market with volume=0 AND OI=0 for extended period (ghost market)
         """
         status = market.get("status")
-        volume = market.get("volume")
-        open_interest = market.get("open_interest")
-        volume_24h = market.get("volume_24h")
+        volume = _parse_fp_int(market.get("volume_fp"))
+        open_interest = _parse_fp_int(market.get("open_interest_fp"))
+        volume_24h = _parse_fp_int(market.get("volume_24h_fp"))
 
         # OI on never-active market
         if status in self.NEVER_ACTIVE_STATUSES and open_interest and open_interest > 0:
@@ -676,8 +689,8 @@ class KalshiDataValidator:
             ...     "yes_ask_dollars": Decimal("0.47"),
             ...     "no_bid_dollars": Decimal("0.53"),
             ...     "no_ask_dollars": Decimal("0.55"),
-            ...     "volume": 1000,
-            ...     "open_interest": 500,
+            ...     "volume_fp": "1000.00",
+            ...     "open_interest_fp": "500.00",
             ... }
             >>> result = validator.validate_market_data(market)
             >>> print(result.is_valid)
@@ -784,7 +797,7 @@ class KalshiDataValidator:
                     )
 
         # Validate volume (cumulative lifetime — not per-update delta)
-        volume = market.get("volume")
+        volume = _parse_fp_int(market.get("volume_fp"))
         if volume is not None:
             if volume < 0:
                 result.add_error("volume", "Negative volume", value=volume, expected=">= 0")
@@ -797,7 +810,7 @@ class KalshiDataValidator:
                 )
 
         # Validate open interest
-        open_interest = market.get("open_interest")
+        open_interest = _parse_fp_int(market.get("open_interest_fp"))
         if open_interest is not None:
             if open_interest < 0:
                 result.add_error(

--- a/tests/unit/schedulers/test_kalshi_poller.py
+++ b/tests/unit/schedulers/test_kalshi_poller.py
@@ -21,9 +21,73 @@ import pytest
 
 from precog.schedulers.kalshi_poller import (
     KalshiMarketPoller,
+    _parse_fp_int,
     create_kalshi_poller,
     run_single_kalshi_poll,
 )
+
+# =============================================================================
+# _parse_fp_int Helper Tests
+# =============================================================================
+
+
+class TestParseFpInt:
+    """Test the _parse_fp_int helper that converts _fp string fields to int."""
+
+    @pytest.mark.unit
+    def test_normal_value(self):
+        """Typical _fp string like '8981763.00' converts to int."""
+        market = {"volume_fp": "8981763.00"}
+        assert _parse_fp_int(market, "volume_fp") == 8981763
+
+    @pytest.mark.unit
+    def test_zero_value(self):
+        """'0.00' converts to 0, NOT None."""
+        market = {"volume_fp": "0.00"}
+        assert _parse_fp_int(market, "volume_fp") == 0
+
+    @pytest.mark.unit
+    def test_missing_field_returns_none(self):
+        """Missing field returns None (graceful fallback)."""
+        market = {}
+        assert _parse_fp_int(market, "volume_fp") is None
+
+    @pytest.mark.unit
+    def test_none_value_returns_none(self):
+        """Explicit None value returns None."""
+        market = {"volume_fp": None}
+        assert _parse_fp_int(market, "volume_fp") is None
+
+    @pytest.mark.unit
+    def test_small_value(self):
+        """Small _fp string like '50.00' converts correctly."""
+        market = {"yes_bid_size_fp": "50.00"}
+        assert _parse_fp_int(market, "yes_bid_size_fp") == 50
+
+    @pytest.mark.unit
+    def test_large_value(self):
+        """Large _fp string converts without overflow."""
+        market = {"open_interest_fp": "4997871.00"}
+        assert _parse_fp_int(market, "open_interest_fp") == 4997871
+
+    @pytest.mark.unit
+    def test_non_numeric_string_returns_none(self):
+        """Non-numeric string returns None and logs warning."""
+        market = {"volume_fp": "not_a_number"}
+        assert _parse_fp_int(market, "volume_fp") is None
+
+    @pytest.mark.unit
+    def test_fractional_part_truncated(self):
+        """Fractional parts (if any) are truncated by int(float())."""
+        market = {"volume_fp": "100.75"}
+        assert _parse_fp_int(market, "volume_fp") == 100
+
+    @pytest.mark.unit
+    def test_integer_string_without_decimal(self):
+        """Integer string without decimal point converts correctly."""
+        market = {"volume_fp": "500"}
+        assert _parse_fp_int(market, "volume_fp") == 500
+
 
 # =============================================================================
 # Test Fixtures
@@ -41,7 +105,12 @@ def mock_kalshi_client():
 
 @pytest.fixture
 def mock_market_data():
-    """Sample market data from Kalshi API (already Decimal-converted)."""
+    """Sample market data from Kalshi API (already Decimal-converted).
+
+    Includes both legacy integer fields (volume, open_interest) and the
+    authoritative _fp string fields (volume_fp, open_interest_fp) that
+    the Kalshi API returns.  The poller reads the _fp variants.
+    """
     return {
         "ticker": "KXNFLGAME-25NOV29-NEBUF-B250",
         "event_ticker": "KXNFLGAME-25NOV29-NEBUF",
@@ -63,8 +132,15 @@ def mock_market_data():
         "no_bid_dollars": Decimal("0.5200"),
         "no_ask_dollars": Decimal("0.5500"),
         "last_price_dollars": Decimal("0.4700"),
+        # Legacy integer fields (kept for validation module compatibility)
         "volume": 1500,
         "open_interest": 800,
+        # Authoritative _fp string fields (read by poller via _parse_fp_int)
+        "volume_fp": "1500.00",
+        "open_interest_fp": "800.00",
+        "volume_24h_fp": "200.00",
+        "yes_bid_size_fp": "50.00",
+        "yes_ask_size_fp": "75.00",
         "liquidity": 5000,
     }
 
@@ -351,6 +427,12 @@ class TestKalshiMarketPollerSync:
             assert call_kwargs["liquidity"] == Decimal("5000")
             # spread = yes_ask - yes_bid = 0.4800 - 0.4500 = 0.0300
             assert call_kwargs["spread"] == Decimal("0.0300")
+            # Verify _fp string fields are converted to int
+            assert call_kwargs["volume"] == 1500
+            assert call_kwargs["open_interest"] == 800
+            assert call_kwargs["volume_24h"] == 200
+            assert call_kwargs["yes_bid_size"] == 50
+            assert call_kwargs["yes_ask_size"] == 75
 
     @pytest.mark.unit
     def test_sync_updates_existing_market(self, poller_with_mock_client, mock_market_data):
@@ -381,6 +463,12 @@ class TestKalshiMarketPollerSync:
             assert call_kwargs["last_price"] == Decimal("0.4700")
             assert call_kwargs["liquidity"] == Decimal("5000")
             assert call_kwargs["spread"] == Decimal("0.0300")
+            # Verify _fp string fields are converted to int on update path
+            assert call_kwargs["volume"] == 1500
+            assert call_kwargs["open_interest"] == 800
+            assert call_kwargs["volume_24h"] == 200
+            assert call_kwargs["yes_bid_size"] == 50
+            assert call_kwargs["yes_ask_size"] == 75
 
     @pytest.mark.unit
     def test_sync_skips_market_without_ticker(self, poller_with_mock_client):
@@ -428,7 +516,7 @@ class TestKalshiMarketPollerSync:
 
     @pytest.mark.unit
     def test_sync_handles_missing_bid_data_gracefully(self, poller_with_mock_client):
-        """Test that None bid/last/liquidity are passed when API has no data."""
+        """Test that None bid/last/liquidity/_fp fields are passed when API has no data."""
         market_minimal = {
             "ticker": "KXNFLGAME-MINIMAL",
             "event_ticker": "KXNFLGAME-EVENT",
@@ -436,7 +524,7 @@ class TestKalshiMarketPollerSync:
             "yes_ask_dollars": Decimal("0.5000"),
             "no_ask_dollars": Decimal("0.5000"),
             "status": "open",
-            # No bid, last_price, or liquidity fields at all
+            # No bid, last_price, liquidity, or _fp fields at all
         }
 
         with (
@@ -453,6 +541,12 @@ class TestKalshiMarketPollerSync:
             assert call_kwargs["liquidity"] is None
             # spread is None when yes_bid is None
             assert call_kwargs["spread"] is None
+            # _fp fields are None when absent from API response
+            assert call_kwargs["volume"] is None
+            assert call_kwargs["open_interest"] is None
+            assert call_kwargs["volume_24h"] is None
+            assert call_kwargs["yes_bid_size"] is None
+            assert call_kwargs["yes_ask_size"] is None
 
     @pytest.mark.unit
     def test_sync_spread_none_when_bid_is_zero(self, poller_with_mock_client):
@@ -478,6 +572,38 @@ class TestKalshiMarketPollerSync:
             call_kwargs = mock_create.call_args.kwargs
             # spread should be None when bid is 0 (can't compute meaningful spread)
             assert call_kwargs["spread"] is None
+
+    @pytest.mark.unit
+    def test_sync_fp_zero_values_become_zero_not_none(self, poller_with_mock_client):
+        """Test that _fp '0.00' values become 0 (not None) in DB insert."""
+        market_zero_fp = {
+            "ticker": "KXNFLGAME-ZEROFP",
+            "event_ticker": "KXNFLGAME-EVENT",
+            "title": "Zero FP Market",
+            "yes_ask_dollars": Decimal("0.5000"),
+            "no_ask_dollars": Decimal("0.5000"),
+            "status": "open",
+            "volume_fp": "0.00",
+            "open_interest_fp": "0.00",
+            "volume_24h_fp": "0.00",
+            "yes_bid_size_fp": "0.00",
+            "yes_ask_size_fp": "0.00",
+        }
+
+        with (
+            patch("precog.schedulers.kalshi_poller.get_current_market", return_value=None),
+            patch("precog.schedulers.kalshi_poller.get_or_create_event", return_value=(1, True)),
+            patch("precog.schedulers.kalshi_poller.create_market", return_value=1) as mock_create,
+        ):
+            poller_with_mock_client._sync_market_to_db(market_zero_fp)
+
+            call_kwargs = mock_create.call_args.kwargs
+            # "0.00" must become 0 (integer), NOT None
+            assert call_kwargs["volume"] == 0
+            assert call_kwargs["open_interest"] == 0
+            assert call_kwargs["volume_24h"] == 0
+            assert call_kwargs["yes_bid_size"] == 0
+            assert call_kwargs["yes_ask_size"] == 0
 
 
 # =============================================================================
@@ -639,8 +765,8 @@ class TestKalshiPollerValidation:
             "status": "active",
             "yes_ask_dollars": Decimal("0.50"),
             "no_ask_dollars": Decimal("0.50"),
-            "volume": -100,  # Invalid: negative volume triggers ERROR
-            "open_interest": 0,
+            "volume_fp": "-100.00",  # Invalid: negative volume triggers ERROR
+            "open_interest_fp": "0.00",
         }
 
         poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = [bad_market]
@@ -689,8 +815,8 @@ class TestKalshiPollerValidation:
             "status": "active",
             "yes_ask_dollars": Decimal("0.50"),
             "no_ask_dollars": Decimal("0.50"),
-            "volume": -100,  # Triggers validation ERROR
-            "open_interest": 0,
+            "volume_fp": "-100.00",  # Triggers validation ERROR
+            "open_interest_fp": "0.00",
         }
         poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = [bad_market]
 
@@ -717,8 +843,8 @@ class TestKalshiPollerValidation:
             "status": "active",
             "yes_ask_dollars": Decimal("0.50"),
             "no_ask_dollars": Decimal("0.50"),
-            "volume": -100,  # Triggers validation ERROR
-            "open_interest": 0,
+            "volume_fp": "-100.00",  # Triggers validation ERROR
+            "open_interest_fp": "0.00",
         }
         poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = [bad_market]
 
@@ -743,8 +869,8 @@ class TestKalshiPollerValidation:
             "status": "active",
             "yes_ask_dollars": Decimal("0.50"),
             "no_ask_dollars": Decimal("0.50"),
-            "volume": 100,
-            "open_interest": 50,
+            "volume_fp": "100.00",
+            "open_interest_fp": "50.00",
         }
         poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = [market]
 
@@ -787,7 +913,7 @@ class TestKalshiPollerValidation:
             "event_ticker": "KXNFLGAME-EVENT",
             "title": "Bad Market",
             "status": "active",
-            "volume": -100,  # Triggers validation ERROR
+            "volume_fp": "-100.00",  # Triggers validation ERROR
         }
         poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = [bad_market]
 
@@ -814,8 +940,8 @@ class TestKalshiPollerValidation:
             "yes_ask_dollars": Decimal("0.48"),
             "no_bid_dollars": Decimal("0.52"),
             "no_ask_dollars": Decimal("0.55"),
-            "volume": 100,
-            "open_interest": 50,
+            "volume_fp": "100.00",
+            "open_interest_fp": "50.00",
         }
         good_market2 = good_market.copy()
         good_market2["ticker"] = "KXNFLGAME-OK2"
@@ -863,7 +989,7 @@ class TestKalshiPollerValidation:
             "event_ticker": "KXNFLGAME-EVENT",
             "title": "Bad Market",
             "status": "active",
-            "volume": -100,  # ERROR
+            "volume_fp": "-100.00",  # ERROR
         }
         poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = [bad_market]
 
@@ -894,7 +1020,7 @@ class TestKalshiPollerValidation:
             "event_ticker": "KXNFLGAME-EVENT",
             "title": "Bad",
             "status": "active",
-            "volume": -100,  # ERROR
+            "volume_fp": "-100.00",  # ERROR
         }
         good_market = {
             "ticker": "KXNFLGAME-GOOD",
@@ -905,8 +1031,8 @@ class TestKalshiPollerValidation:
             "yes_ask_dollars": Decimal("0.48"),
             "no_bid_dollars": Decimal("0.52"),
             "no_ask_dollars": Decimal("0.55"),
-            "volume": 100,
-            "open_interest": 50,
+            "volume_fp": "100.00",
+            "open_interest_fp": "50.00",
         }
         # 2 bad + 11 good = 2/13 = 15.4% error rate (> 10% threshold)
         markets = [bad_market, bad_market.copy()] + [good_market.copy() for _ in range(11)]
@@ -941,7 +1067,7 @@ class TestKalshiPollerValidation:
             "event_ticker": "KXNFLGAME-EVENT",
             "title": "Bad",
             "status": "active",
-            "volume": -100,  # ERROR
+            "volume_fp": "-100.00",  # ERROR
         }
         good_market = {
             "ticker": "KXNFLGAME-GOOD",
@@ -952,8 +1078,8 @@ class TestKalshiPollerValidation:
             "yes_ask_dollars": Decimal("0.48"),
             "no_bid_dollars": Decimal("0.52"),
             "no_ask_dollars": Decimal("0.55"),
-            "volume": 100,
-            "open_interest": 50,
+            "volume_fp": "100.00",
+            "open_interest_fp": "50.00",
         }
         # 1 bad + 10 good = 1/11 = 9.1% error rate (< 10% threshold)
         markets = [bad_market] + [good_market.copy() for _ in range(10)]
@@ -988,7 +1114,7 @@ class TestKalshiPollerValidation:
             "event_ticker": "KXNFLGAME-EVENT",
             "title": "Bad Market",
             "status": "active",
-            "volume": -100,  # ERROR - triggers >25% rate with 1 market
+            "volume_fp": "-100.00",  # ERROR - triggers >25% rate with 1 market
         }
         poller_with_mock_client.kalshi_client.fetch_all_markets.return_value = [bad_market]
 

--- a/tests/unit/validation/test_kalshi_validation.py
+++ b/tests/unit/validation/test_kalshi_validation.py
@@ -51,8 +51,8 @@ def valid_market_data() -> dict:
         "yes_ask_dollars": Decimal("0.47"),
         "no_bid_dollars": Decimal("0.53"),
         "no_ask_dollars": Decimal("0.55"),
-        "volume": 1000,
-        "open_interest": 500,
+        "volume_fp": "1000.00",
+        "open_interest_fp": "500.00",
         "open_time": (now - timedelta(hours=2)).isoformat(),
         "close_time": (now + timedelta(hours=24)).isoformat(),
         "expiration_time": (now + timedelta(hours=48)).isoformat(),
@@ -350,27 +350,27 @@ class TestMarketDataValidation:
 
     def test_negative_volume_error(self, validator: KalshiDataValidator) -> None:
         """Negative volume generates error."""
-        market = {"ticker": "TEST", "volume": -100}
+        market = {"ticker": "TEST", "volume_fp": "-100.00"}
         result = validator.validate_market_data(market)
         assert result.has_errors
         assert any("volume" in e.field for e in result.errors)
 
     def test_high_volume_warning(self, validator: KalshiDataValidator) -> None:
         """Unusually high lifetime volume generates warning."""
-        market = {"ticker": "TEST", "volume": 2_000_000}  # Above 1M threshold
+        market = {"ticker": "TEST", "volume_fp": "2000000.00"}  # Above 1M threshold
         result = validator.validate_market_data(market)
         assert result.has_warnings
         assert any("volume" in w.field for w in result.warnings)
 
     def test_moderate_volume_no_warning(self, validator: KalshiDataValidator) -> None:
         """Moderate lifetime volume (below 1M) does not generate warning."""
-        market = {"ticker": "TEST", "volume": 200_000}
+        market = {"ticker": "TEST", "volume_fp": "200000.00"}
         result = validator.validate_market_data(market)
         assert not any("volume" in w.field for w in result.warnings)
 
     def test_negative_open_interest_error(self, validator: KalshiDataValidator) -> None:
         """Negative open interest generates error."""
-        market = {"ticker": "TEST", "open_interest": -50}
+        market = {"ticker": "TEST", "open_interest_fp": "-50.00"}
         result = validator.validate_market_data(market)
         assert result.has_errors
 
@@ -795,14 +795,14 @@ class TestAnomalyTracking:
 
     def test_anomaly_count_increments(self, validator: KalshiDataValidator) -> None:
         """Anomaly count increments on validation issues."""
-        market = {"ticker": "TEST", "volume": -100}  # Error
+        market = {"ticker": "TEST", "volume_fp": "-100.00"}  # Error
         validator.validate_market_data(market)
         assert validator.get_anomaly_count("TEST") > 0
 
     def test_get_all_anomaly_counts(self, validator: KalshiDataValidator) -> None:
         """Get all anomaly counts returns dict."""
-        market1 = {"ticker": "TEST1", "volume": -100}
-        market2 = {"ticker": "TEST2", "volume": -200}
+        market1 = {"ticker": "TEST1", "volume_fp": "-100.00"}
+        market2 = {"ticker": "TEST2", "volume_fp": "-200.00"}
         validator.validate_market_data(market1)
         validator.validate_market_data(market2)
         counts = validator.get_all_anomaly_counts()
@@ -811,7 +811,7 @@ class TestAnomalyTracking:
 
     def test_clear_anomaly_counts(self, validator: KalshiDataValidator) -> None:
         """Clear anomaly counts resets all counts."""
-        market = {"ticker": "TEST", "volume": -100}
+        market = {"ticker": "TEST", "volume_fp": "-100.00"}
         validator.validate_market_data(market)
         assert validator.get_anomaly_count("TEST") > 0
         validator.clear_anomaly_counts()
@@ -877,7 +877,7 @@ class TestValidationSummary:
         """Summary counts errors correctly."""
         markets: list[dict[str, object]] = [
             {"ticker": "GOOD", "status": "open"},
-            {"ticker": "BAD", "volume": -100},  # Error
+            {"ticker": "BAD", "volume_fp": "-100.00"},  # Error
         ]
         results = validator.validate_markets(markets)
         summary = validator.get_validation_summary(results)
@@ -1074,8 +1074,8 @@ class TestTimestampValidation:
         market = {
             "ticker": "TEST-TICKER",
             "status": "open",
-            "volume": 100,
-            "open_interest": 50,
+            "volume_fp": "100.00",
+            "open_interest_fp": "50.00",
         }
         result = validator.validate_market_data(market)
         # Should complete without raising — no timestamp issues expected
@@ -1095,8 +1095,8 @@ class TestCrossFieldConsistency:
         market = {
             "ticker": "TEST-TICKER",
             "status": "unopened",
-            "open_interest": 100,
-            "volume": 0,
+            "open_interest_fp": "100.00",
+            "volume_fp": "0.00",
         }
         result = validator.validate_market_data(market)
         warnings = [i for i in result.warnings if i.field == "open_interest"]
@@ -1107,8 +1107,8 @@ class TestCrossFieldConsistency:
         market = {
             "ticker": "TEST-TICKER",
             "status": "initialized",
-            "open_interest": 50,
-            "volume": 0,
+            "open_interest_fp": "50.00",
+            "volume_fp": "0.00",
         }
         result = validator.validate_market_data(market)
         warnings = [i for i in result.warnings if i.field == "open_interest"]
@@ -1120,9 +1120,9 @@ class TestCrossFieldConsistency:
         market = {
             "ticker": "TEST-TICKER",
             "status": "active",
-            "volume": 100,
-            "volume_24h": 500,
-            "open_interest": 50,
+            "volume_fp": "100.00",
+            "volume_24h_fp": "500.00",
+            "open_interest_fp": "50.00",
             "open_time": (now - timedelta(hours=48)).isoformat(),
             "close_time": (now + timedelta(hours=24)).isoformat(),
             "expiration_time": (now + timedelta(hours=48)).isoformat(),
@@ -1138,9 +1138,9 @@ class TestCrossFieldConsistency:
         market = {
             "ticker": "TEST-TICKER",
             "status": "active",
-            "volume": 100,
-            "volume_24h": 100,
-            "open_interest": 50,
+            "volume_fp": "100.00",
+            "volume_24h_fp": "100.00",
+            "open_interest_fp": "50.00",
             "open_time": (now - timedelta(hours=12)).isoformat(),
             "close_time": (now + timedelta(hours=24)).isoformat(),
             "expiration_time": (now + timedelta(hours=48)).isoformat(),
@@ -1155,8 +1155,8 @@ class TestCrossFieldConsistency:
         market = {
             "ticker": "TEST-GHOST",
             "status": "active",
-            "volume": 0,
-            "open_interest": 0,
+            "volume_fp": "0.00",
+            "open_interest_fp": "0.00",
             "open_time": (now - timedelta(hours=48)).isoformat(),
             "close_time": (now + timedelta(hours=24)).isoformat(),
             "expiration_time": (now + timedelta(hours=48)).isoformat(),
@@ -1171,8 +1171,8 @@ class TestCrossFieldConsistency:
         market = {
             "ticker": "TEST-TICKER",
             "status": "active",
-            "volume": 100,
-            "open_interest": 0,
+            "volume_fp": "100.00",
+            "open_interest_fp": "0.00",
             "open_time": (now - timedelta(hours=48)).isoformat(),
             "close_time": (now + timedelta(hours=24)).isoformat(),
             "expiration_time": (now + timedelta(hours=48)).isoformat(),


### PR DESCRIPTION
## Summary
- Fix silent data loss: 5 integer fields (volume, open_interest, volume_24h, yes_bid_size, yes_ask_size) always NULL — Kalshi API returns `volume_fp` (string) but code read `market.get("volume")`
- Fix cascading impact: validator (5 checks silently inactive), CLI (volume=0), TUI (volume=0), TypedDict (wrong names)
- Add `_parse_fp_int()` helper with OverflowError protection, 11 new tests

## Agent Review Trail
| Agent | Role | Finding | Action |
|-------|------|---------|--------|
| Hari (S64) | Investigator | 0% population on all 5 fields | Root cause: `_fp` suffix mismatch |
| Amos | Builder | Core fix: 10 poller sites + types + tests | Implemented |
| Glokta | Reviewer | OverflowError blocker, CLI/TUI bug, validator gap, stale docstring | All fixed |

## Test plan
- [x] 2452 unit tests pass
- [x] 982 integration/e2e tests pass
- [x] 1057 stress/chaos/race tests pass
- [x] All pre-commit hooks pass (ruff, mypy, security)
- [ ] Integration/e2e/property test fixtures deferred to #536

Related: #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)