### PR TITLE
Session 41: Era 2 roadmap, Phase 2 requirements, schema migrations

### DIFF
--- a/docs/foundation/DEVELOPMENT_PHASES_ERA2_V1.0.md
+++ b/docs/foundation/DEVELOPMENT_PHASES_ERA2_V1.0.md
@@ -1,0 +1,247 @@
+# Era 2: Development Phases (V1.0)
+
+**Created:** 2026-04-05 (Session 41)
+**Replaces:** DEVELOPMENT_PHASES_V1.15.md (archived, Era 1 phases 0-1.5)
+**Freshness:** Update at each phase gate and after scope changes.
+
+---
+
+## Overview
+
+**Era 1** (Phases 0-1.5) established the data collection foundation: fetch, validate, and store market + game data from Kalshi and ESPN across 4 sports (NFL, NCAAF, NBA, NHL).
+
+**Era 2** (Phases 2-5) builds the trading platform — from full manual trading through ML-driven autonomous execution.
+
+### Phase Summary
+
+| Phase | Theme | Issue Count | GitHub Label |
+|-------|-------|-------------|-------------|
+| **2** | Full Manual Trading Platform | 38 | `phase-2` |
+| **3** | Operations & Platform Expansion | 17 | `phase-3` |
+| **4** | ML & Models | 9 | `phase-4` |
+| **5** | Strategy & Autonomous Trading | 16 | `phase-5` |
+
+### Phase Dependencies
+
+```
+Phase 1 (COMPLETE) ──> Phase 2 ──> Phase 3 ──> Phase 4 ──> Phase 5
+  Data Collection        Trading     Operations    ML/Models    Strategy
+                         + Web UI    + Expansion   + Analytics  + Autonomous
+```
+
+Each phase builds on the previous. Phase gates enforce entry/exit criteria.
+
+---
+
+## Phase 2: Full Manual Trading Platform
+
+**Goal:** A user can browse markets, place all order types (market, limit, stop loss, take profit, trailing stop), view and manage positions, and analyze trade history — all through a web UI on Kalshi's demo API.
+
+### Entry Criteria
+- Phase 1 software validation PASSED (C4 gate: GO — Session 40)
+- Phase 1 environment validation PASSED (desktop deployment + 1-week soak)
+- Phase 2 requirements formalized (#339)
+- Trade flow architecture designed (#508)
+- Kalshi demo API behavior verified (#335)
+
+### Exit Criteria
+- [ ] All 5 order types functional through web UI (market, limit, stop loss, take profit, trailing stop)
+- [ ] Market browsing with search, filter, live prices
+- [ ] Position management with real-time P&L
+- [ ] Trade history with performance analytics (ROI, win rate, P&L curve)
+- [ ] All 10 Tier 1 safety guards active and tested
+- [ ] Kill switch tested on demo API
+- [ ] Fills pipeline processing and reconciling with Kalshi
+- [ ] Order condition monitoring service running (evaluates stop/TP/trailing)
+- [ ] 1-week soak on demo with zero safety guard failures
+
+### Scope
+
+#### Web UI Foundation
+- #568 — FastAPI backend, frontend framework, authentication, design system
+- #569 — Market browsing page (search, filter, live prices)
+- #570 — Trading page (all order types, confirmation flow)
+- #571 — Position management page (open positions, P&L, modify/close)
+- #572 — Trade history and performance reporting
+- Epic: #583 (Web UI Platform)
+
+#### Order Execution Pipeline
+- #508 — Trade flow architecture (design)
+- #509 — FastAPI trade placement endpoint
+- #510 — Web form for trade submission
+- #325 — Mandatory client_order_id for idempotency
+- #326 — OrderValidator safety guards (10 Tier 1 guards)
+- #328 — Three-state order result classification
+- #329 — Trading kill switch
+- #330 — Behavioral circuit breakers
+- #332 — Pre-trade live market validation chain
+- Epic: #504 (Trade Execution Pipeline)
+
+#### Advanced Order Types
+- #573 — Stop loss order type
+- #574 — Take profit order type
+- #575 — Trailing stop order type
+- #576 — Order condition monitoring service
+
+#### Fills & Reconciliation
+- #401 — Public market trades: API client + types
+- #402 — Public market trades: schema + CRUD + validation
+- #403 — Public market trades: poller + config + CLI
+- #404 — Portfolio fills: schema + CRUD
+- #405 — Portfolio fills: poller + config + CLI + pipeline tests
+- #417 — Order-fills-positions reconciliation state machine
+- #327 — Order reconciliation loop (DB <-> Kalshi sync)
+
+#### Safety & Data Quality
+- #303 — Stale ESPN data phantom edge prevention
+- #561 — Pre-trade data freshness guard
+- #335 — Test Kalshi demo API order behavior
+- #338 — Clarify price column semantics
+- #339 — Formalize Phase 2 requirements
+- #365 — Database schema health audit
+
+#### Infrastructure
+- #343 — Kalshi WebSocket streaming
+- #394 — Validation model for WebSocket streaming
+- #526 — Games coverage reporting CLI
+- #527 — Matching alert escalation to circuit breaker
+- #528 — Backfill resumption and progress tracking
+
+---
+
+## Phase 3: Operations & Platform Expansion
+
+**Goal:** Operational maturity — web-based system management, automated backups, multi-platform support (Polymarket), and additional sport coverage (MLB).
+
+### Entry Criteria
+- Phase 2 complete (all exit criteria met)
+- Polymarket requirements formalized
+- MLB requirements formalized
+
+### Exit Criteria
+- [ ] Operations web pages functional (config, alerts, logs, scheduler)
+- [ ] Automated backup system running with cloud sync
+- [ ] Polymarket integration operational with shared PredictionMarketClient Protocol
+- [ ] MLB data collection running
+- [ ] Cross-platform event matching working
+- [ ] Operations guide complete
+
+### Scope
+
+#### Web UI — Operations
+- #577 — Configuration management page
+- #578 — Alerts dashboard
+- #579 — Log viewer
+- #580 — Scheduler management page
+
+#### Platform Expansion — Polymarket
+- #495 — Polymarket integration (Tier A3 prediction market source)
+- #496 — Cross-platform event matching
+
+#### Data Expansion
+- #487 — CFBD integration (historical game data for Elo)
+- #489 — CBBD integration (NCAAB team classification)
+- #505 — Data Source Expansion epic
+- #511 — Widen snapshot versioning
+- #514 — Kalshi enrichment audit
+- #548 — Extended soak test
+
+#### Operational Infrastructure
+- #493 — MaintenanceRunner for Tier B source heartbeats
+- #494 — Shared test mock harness
+- #565 — Automated backup system (Filen priority)
+- #566 — Operations guide
+- #567 — Doc restructure
+
+#### Schema & Data Quality
+- #368 — team_id FK backfill
+- #370 — execution_environment filtering for views
+- #453 — Monitor for NULL game_id
+
+---
+
+## Phase 4: ML & Models
+
+**Goal:** Prediction capability — Elo ratings computed for all sports, at least one ML model trained and validated, model analytics dashboard operational.
+
+### Entry Criteria
+- Phase 3 complete
+- Sufficient historical data (200+ settled markets per sport)
+- Elo ratings computed and validated
+
+### Exit Criteria
+- [ ] Elo engine running in production for all supported sports
+- [ ] At least one ML model trained, validated, and serving predictions
+- [ ] Model performance dashboard showing calibration metrics
+- [ ] Model promotion pipeline tested (C30 gate)
+- [ ] Feature engineering pipeline producing cross-source features
+
+### Scope
+
+#### Elo Engine
+- #480 — Elo Rating System epic
+- #481 — Load historical game data from all sources
+- #482 — Run and validate Elo computation against historical data
+- #483 — Elo scheduling, monitoring, maintenance
+- #484 — Audit Elo engine post-migration
+
+#### ML Prerequisites
+- #529 — Play-by-play data feasibility study
+- #553 — Phase 4 data model prerequisites (win probability columns, multi-book)
+
+#### Web UI — Model Analytics
+- #581 — Model training interface
+- #582 — Model analytics dashboard (calibration, performance, feature importance)
+
+---
+
+## Phase 5: Strategy & Autonomous Trading
+
+**Goal:** Automated execution — strategies designed, backtested, paper-traded, and deployed with full safety infrastructure.
+
+### Entry Criteria
+- Phase 4 complete
+- At least one validated model producing edge signals
+- Risk management framework reviewed (Scorpius + Armitage council)
+
+### Exit Criteria
+- [ ] At least one strategy backtested, paper-traded, and live-traded
+- [ ] Autonomous execution pipeline running with safety guards
+- [ ] Strategy performance dashboard operational
+- [ ] Kill switch + circuit breakers tested under autonomous operation
+- [ ] Strategy retirement criteria defined and automated
+
+### Scope
+
+#### Strategy Development
+- #540 — Strategy & Model Feature Ideas epic
+- #541 — DraftKings odds as features for edge detection
+- #544 — NHL slight-underdog mispricing strategy
+- #545 — Sport-specific model architecture
+- #546 — Pre-game entry / in-game management strategy
+- #547 — NBA strong-favorite underpricing signal
+
+#### Infrastructure
+- #497 — KalshiAuth PEM content for cloud deployment
+
+---
+
+## Architecture Prerequisites (Cross-Phase)
+
+These items are prerequisites for specific phases but are tracked separately:
+
+| Item | Needed By | Description |
+|------|-----------|-------------|
+| PredictionMarketClient Protocol | Phase 3 | Platform-agnostic client interface |
+| Common TypedDict types | Phase 3 | Platform-agnostic data structures |
+| FastAPI ADR | Phase 2 | Frontend technology decisions |
+| EnvironmentConfig polymarket_mode | Phase 3 | Multi-platform env configuration |
+| Strategy Development Lifecycle (SDL) | Phase 5 | Formal strategy pipeline |
+
+---
+
+## Version History
+
+| Version | Date | Session | Changes |
+|---------|------|---------|---------|
+| 1.0 | 2026-04-05 | 41 | Initial Era 2 roadmap. 4 phases, 80 issues across phases. |

--- a/docs/foundation/MASTER_REQUIREMENTS_V2.25.md
+++ b/docs/foundation/MASTER_REQUIREMENTS_V2.25.md
@@ -1462,7 +1462,219 @@ Complements live data polling (REQ-DATA-001-005) with batch import capabilities.
 
 ---
 
+### 4.14 Trade Execution Requirements (Era 2, Phase 2)
+
+> **Added:** V2.26 (Session 41, 2026-04-05). Formalizes C4 Phase Gate finding B1.
+> **Reference:** DEVELOPMENT_PHASES_ERA2_V1.0.md, Epic #504
+
+#### REQ-TRADE-001: Order Placement Pipeline
+- Submit orders to Kalshi API through validated pipeline
+- Pipeline: Web UI form → FastAPI endpoint → OrderValidator → Kalshi API → Result classification
+- All orders must pass through OrderValidator before submission (no bypass path)
+- Related: #509 (endpoint), #510 (form), #326 (validator)
+
+#### REQ-TRADE-002: Order Result Classification
+- Every order attempt classified as CONFIRMED, REJECTED, or UNKNOWN
+- CONFIRMED: Kalshi accepted the order (has order_id)
+- REJECTED: Kalshi returned an error (reason captured)
+- UNKNOWN: Network timeout, ambiguous response (triggers reconciliation)
+- Related: #328
+
+#### REQ-TRADE-003: Order Idempotency
+- Every order submission includes a unique client_order_id (UUID)
+- Duplicate client_order_id submissions must not create duplicate orders
+- client_order_id stored in orders table, used for reconciliation
+- Related: #325
+
+#### REQ-TRADE-004: Order Reconciliation
+- Periodic sync between local orders table and Kalshi API state
+- Detect: orders that Kalshi has but we don't (missed fills), orders we have but Kalshi doesn't (phantom)
+- Reconciliation runs on configurable interval (default: every 60 seconds during market hours)
+- Related: #327, #417
+
+#### REQ-TRADE-005: Fills Pipeline
+- Ingest public market trades and portfolio fills from Kalshi API
+- Store in trades table with full audit trail
+- Auto-paginate large result sets
+- Link fills to orders via order_id
+- Related: #401-#405
+
+#### REQ-TRADE-006: Kill Switch
+- Instant kill switch: cancel all open orders + disable new order submission
+- Activatable from: web UI button, CLI command, API endpoint
+- Kill switch state persisted (survives service restart)
+- Re-enable requires explicit user action (not automatic)
+- Related: #329
+
+---
+
+### 4.15 Order Types Requirements (Era 2, Phase 2)
+
+> **Added:** V2.26 (Session 41, 2026-04-05).
+> **Note:** Kalshi natively supports limit orders. Stop loss, take profit, and trailing stops are application-level features built on top of Kalshi's order API.
+
+#### REQ-ORDER-001: Market Orders
+- Place orders at best available price (aggressive limit on Kalshi)
+- For YES side: limit price at or above current ask
+- For NO side: limit price at or below current bid
+- User selects quantity only; price determined by market
+- Related: #509, #570
+
+#### REQ-ORDER-002: Limit Orders
+- Place orders at user-specified price
+- Time-in-force options: GTC (good-til-cancelled), IOC (immediate-or-cancel)
+- Order remains open until filled, cancelled, or market closes
+- Related: #509, #570
+
+#### REQ-ORDER-003: Stop Loss Orders
+- Application-level conditional order
+- Trigger: current market price drops to or below user-specified stop price
+- On trigger: automatically place a sell order (market or limit, user-configurable)
+- Stop price configurable as absolute price or distance from entry
+- Persisted to database; survives service restarts
+- Related: #573, #576
+
+#### REQ-ORDER-004: Take Profit Orders
+- Application-level conditional order
+- Trigger: current market price rises to or above user-specified target price
+- On trigger: automatically place a sell order
+- Partial take profit supported: sell percentage of position at target
+- Can be combined with stop loss on same position (bracket order)
+- Related: #574, #576
+
+#### REQ-ORDER-005: Trailing Stop Orders
+- Application-level conditional order with dynamic threshold
+- Track peak price since activation
+- Stop price = peak_price - trail_distance (absolute or percentage)
+- Stop price only moves up, never down (ratchet behavior)
+- Activation modes: immediate (from entry) or conditional (after minimum profit reached)
+- Related: #575, #576
+- Leverages existing positions.trailing_stop_state JSONB infrastructure
+
+#### REQ-ORDER-006: Order Condition Monitoring Service
+- Background service evaluating all active order conditions
+- Runs as EventLoopService under ServiceSupervisor
+- Configurable polling interval (default: 10-30 seconds during market hours)
+- Respects kill switch state, API rate limits
+- Idempotent: conditions that already triggered are not re-triggered
+- Related: #576
+
+---
+
+### 4.16 Trading Safety Requirements (Era 2, Phase 2)
+
+> **Added:** V2.26 (Session 41, 2026-04-05).
+> **Reference:** C4 gate finding G3 — "No real trade without safety infrastructure."
+
+#### REQ-SAFE-001: OrderValidator — 10 Tier 1 Safety Guards
+All orders must pass these guards before submission:
+1. **Max order size:** Reject orders exceeding configured max contracts (default: 25)
+2. **Max order value:** Reject orders exceeding configured max dollar value (default: $50)
+3. **Max position size:** Reject if resulting position would exceed limit
+4. **Max daily loss:** Reject if daily realized loss exceeds threshold
+5. **Max open orders:** Reject if too many orders already pending
+6. **Market status check:** Reject if market is closed/settled
+7. **Balance check:** Reject if insufficient account balance
+8. **Spread check:** Reject if bid/ask spread exceeds threshold (illiquid)
+9. **Price sanity:** Reject if price is outside reasonable bounds (e.g., <$0.02 or >$0.98)
+10. **Data freshness:** Reject if market data is older than configured max age
+- Guard thresholds configurable in trading.yaml `safety_guards:` section
+- All guard evaluations logged regardless of pass/fail
+- Related: #326, #561, #303
+
+#### REQ-SAFE-002: Pre-Trade Data Freshness
+- Before placing any order, verify market data freshness
+- Re-poll market if data age exceeds threshold (configurable, default: 30 seconds)
+- Abort trade if re-poll fails or data remains stale
+- Prevents phantom edges from stale ESPN/Kalshi data
+- Related: #561, #303
+
+#### REQ-SAFE-003: Behavioral Circuit Breakers
+- Automatic safety triggers based on trading patterns:
+  - Rapid loss circuit breaker: pause trading after N consecutive losses
+  - Velocity circuit breaker: pause after N orders in M minutes
+  - Drawdown circuit breaker: pause after portfolio drops X% in a session
+- Circuit breaker state visible in web UI
+- Manual reset required to resume trading
+- Related: #330
+
+#### REQ-SAFE-004: Pre-Live Checklist
+Before any real-money trading is enabled:
+- [ ] All 10 Tier 1 guards tested on demo API
+- [ ] Kill switch tested (activate + verify orders cancelled + verify lockout)
+- [ ] Order reconciliation verified (DB matches Kalshi state)
+- [ ] Fills pipeline verified (fills appear in DB within 60 seconds)
+- [ ] Data freshness guard tested (stale data correctly blocked)
+- [ ] Circuit breakers tested (trigger conditions produce expected behavior)
+- [ ] 1-week demo soak with zero safety failures
+
+---
+
+### 4.17 Web UI Requirements (Era 2, Phases 2-4)
+
+> **Added:** V2.26 (Session 41, 2026-04-05).
+> **Reference:** Epic #583 (Web UI Platform)
+
+#### REQ-WEB-001: Web Application Foundation
+- FastAPI backend with frontend framework (technology choice per FastAPI ADR)
+- Authentication: session-based, single-user local auth for MVP
+- Design system with consistent components, typography, color palette
+- Navigation shell with sidebar/header accommodating all Phase 2-5 pages
+- Desktop-first responsive layout
+- Related: #568
+
+#### REQ-WEB-002: Market Browsing
+- Market list with filters: sport, status (open/closed/settled), category, date
+- Text search across market tickers and titles
+- Market detail view: current yes/no prices, bid/ask spread, volume
+- Live price updates without full page reload
+- Quick navigation to trading page with market context
+- Related: #569
+
+#### REQ-WEB-003: Trading Interface
+- Order entry form supporting all 5 order types (REQ-ORDER-001 through 005)
+- Market context panel showing current bid/ask, spread, volume
+- Order confirmation dialog before submission (safety UX)
+- Active orders panel with cancel capability
+- Recent fills display
+- Inline OrderValidator feedback (which guards passed/failed)
+- Related: #570
+
+#### REQ-WEB-004: Position Management
+- Open positions list with real-time P&L
+- Position detail: entry price, current value, exposure, attached conditions
+- Modify actions: adjust stop loss, take profit, trailing stop settings
+- Close actions: market sell or limit sell
+- Exposure summary: total by sport, market type
+- SCD Type 2 filtering (row_current_ind = TRUE)
+- Related: #571
+
+#### REQ-WEB-005: Trade History & Reporting
+- Completed trades with filters: date range, sport, market, side, outcome
+- Performance metrics: ROI, win rate, P&L curve, Sharpe ratio, max drawdown
+- Breakdowns by sport, market type, time period
+- Export: CSV/JSON
+- Related: #572
+
+#### REQ-WEB-006: Operations Pages (Phase 3)
+- Configuration management: view/edit YAML settings, environment display
+- Alerts dashboard: system health, trading alerts, custom rules
+- Log viewer: searchable logs with live tail
+- Scheduler management: service status, start/stop controls, rate limit visualization
+- Related: #577, #578, #579, #580
+
+#### REQ-WEB-007: Model Analytics Pages (Phase 4)
+- Model training interface: configure, train, compare, promote
+- Model analytics: calibration curves, Brier score, ECE, feature importance
+- Model decay detection and alerting
+- Related: #581, #582
+
+---
+
 ## 5. Development Phases
+
+> **Note:** Phases 0-1.5 below are Era 1 definitions (historical). For Era 2 phases (2-5),
+> see `docs/foundation/DEVELOPMENT_PHASES_ERA2_V1.0.md`.
 
 ### Phase 0: Foundation & Documentation (COMPLETED)
 
@@ -4443,6 +4655,7 @@ For questions or issues:
 | 2.4 | 2025-10-19 | **MAJOR UPDATE**: Added Phase 0.5 (Foundation Enhancement); added versioning requirements (strategies, probability_models with immutable pattern); added trailing stop loss requirements; updated database overview to V1.4; added Phase 1.5 (Foundation Validation); updated all phase descriptions to reflect versioning enhancements |
 | 2.5 | 2025-10-21 | **CRITICAL UPDATE**: Added Phase 5 monitoring and exit management requirements; Added REQ-MON-*, REQ-EXIT-*, REQ-EXEC-* requirements; Updated database to V1.5 (position_exits, exit_attempts tables); Added 10 exit conditions with priority hierarchy |
 | 2.6 | 2025-10-22 | **STANDARDIZATION**: Added systematic REQ IDs to all requirements; Added REQUIREMENT_INDEX.md and ADR_INDEX.md references; Improved requirement traceability |
+| 2.26 | 2026-04-05 | **ERA 2 REQUIREMENTS**: Added sections 4.14-4.17 (REQ-TRADE, REQ-ORDER, REQ-SAFE, REQ-WEB). Formalizes C4 Phase Gate finding B1. 22 new requirements covering trade execution, 5 order types, safety guards, and web UI across Phases 2-4. |
 
 ---
 

--- a/docs/foundation/REQUIREMENT_INDEX_V1.17.md
+++ b/docs/foundation/REQUIREMENT_INDEX_V1.17.md
@@ -831,14 +831,49 @@ This document provides a systematic index of all Precog requirements using categ
 - Deployment: Vercel for frontend, PostgreSQL backend unchanged
 - Related: ADR-081 (dashboard stack), ADR-083 (data source), DASHBOARD_DEVELOPMENT_GUIDE_V1.0.md
 
+### Trade Execution (TRADE) — NEW in V1.18
+
+**REQ-TRADE-001: Order Placement Pipeline** — Web UI -> FastAPI -> OrderValidator -> Kalshi API -> Result
+**REQ-TRADE-002: Order Result Classification** — CONFIRMED / REJECTED / UNKNOWN three-state
+**REQ-TRADE-003: Order Idempotency** — Mandatory client_order_id (UUID) on every submission
+**REQ-TRADE-004: Order Reconciliation** — Periodic DB <-> Kalshi state sync
+**REQ-TRADE-005: Fills Pipeline** — Ingest public trades + portfolio fills with auto-pagination
+**REQ-TRADE-006: Kill Switch** — Instant cancel-all + disable, persisted, explicit re-enable
+
+### Order Types (ORDER) — NEW in V1.18
+
+**REQ-ORDER-001: Market Orders** — Aggressive limit at best available price
+**REQ-ORDER-002: Limit Orders** — User-specified price, GTC/IOC time-in-force
+**REQ-ORDER-003: Stop Loss** — App-level conditional sell on price drop below threshold
+**REQ-ORDER-004: Take Profit** — App-level conditional sell on price rise above target, partial support
+**REQ-ORDER-005: Trailing Stop** — Dynamic ratcheting stop, peak tracking, conditional activation
+**REQ-ORDER-006: Order Condition Monitoring Service** — Background evaluator for all conditional orders
+
+### Trading Safety (SAFE) — NEW in V1.18
+
+**REQ-SAFE-001: OrderValidator — 10 Tier 1 Safety Guards** — Max size/value/position/loss, market/balance/spread/price/freshness checks
+**REQ-SAFE-002: Pre-Trade Data Freshness** — Re-poll + abort on stale market data
+**REQ-SAFE-003: Behavioral Circuit Breakers** — Rapid loss, velocity, drawdown auto-pause
+**REQ-SAFE-004: Pre-Live Checklist** — 7-item gate before real-money trading enabled
+
+### Web UI (WEB) — NEW in V1.18
+
+**REQ-WEB-001: Web Application Foundation** — FastAPI backend, auth, design system, navigation
+**REQ-WEB-002: Market Browsing** — Search, filter, live prices, market detail
+**REQ-WEB-003: Trading Interface** — All 5 order types, confirmation, active orders, validator feedback
+**REQ-WEB-004: Position Management** — Real-time P&L, modify/close, exposure summary
+**REQ-WEB-005: Trade History & Reporting** — Performance metrics, breakdowns, export
+**REQ-WEB-006: Operations Pages (Phase 3)** — Config, alerts, logs, scheduler management
+**REQ-WEB-007: Model Analytics Pages (Phase 4)** — Training interface, calibration, feature importance
+
 ---
 
 ## Requirement Statistics
 
-**Total Requirements:** 127
-**Completed (✅):** 31 (Phase 0-2.5, including REQ-SCHED-001, REQ-SCHED-002)
-**In Progress (🟡):** 1 (REQ-DATA-003 - ESPN client complete, database pending)
-**Planned (🔵):** 95 (Phase 0.7, 1-10 including REQ-ML-001, REQ-ANALYTICS-001-004, REQ-REPORTING-001, REQ-DATA-001-005, REQ-OBSERV-003)
+**Total Requirements:** 159
+**Completed:** 31 (Phase 0-2.5, including REQ-SCHED-001, REQ-SCHED-002)
+**In Progress:** 1 (REQ-DATA-003 - ESPN client complete, database pending)
+**Planned:** 127 (Phase 0.7-5 including all Era 2 requirements)
 
 **By Category:**
 - System (SYS): 6 requirements
@@ -863,6 +898,10 @@ This document provides a systematic index of all Precog requirements using categ
 - **Security (SEC): 1 requirement** (NEW in V1.3)
 - **Analytics (ANALYTICS): 4 requirements** (NEW in V1.5 - materialized views, performance tracking)
 - **Reporting (REPORTING): 1 requirement** (NEW in V1.5 - dashboard architecture)
+- **Trade Execution (TRADE): 6 requirements** (NEW in V1.18 - order pipeline, reconciliation, kill switch)
+- **Order Types (ORDER): 6 requirements** (NEW in V1.18 - market, limit, stop loss, take profit, trailing stop)
+- **Trading Safety (SAFE): 4 requirements** (NEW in V1.18 - OrderValidator, freshness, circuit breakers)
+- **Web UI (WEB): 7 requirements** (NEW in V1.18 - foundation through Phase 4 analytics)
 
 **By Phase:**
 - Phase 0: 6 requirements (100% complete)
@@ -871,7 +910,10 @@ This document provides a systematic index of all Precog requirements using categ
 - **Phase 0.7: 7 requirements (0% complete)** - CI/CD and advanced testing
 - **Phase 1: 29 requirements (0% complete)** - API best practices, alerts, CLI
 - **Phase 1.5-2: 1 requirement (0% complete)** - performance tracking architecture (REQ-ANALYTICS-003)
-- **Phase 2: 8 requirements (0% complete)** - ESPN data, venues, rankings (REQ-DATA-001-005)
+- **Era 1 Phase 2: 8 requirements (0% complete)** - ESPN data, venues, rankings (REQ-DATA-001-005)
+- **Era 2 Phase 2: 22 requirements (0% complete)** - trade execution, orders, safety, web UI (REQ-TRADE/ORDER/SAFE/WEB)
+- **Era 2 Phase 3: 1 requirement (0% complete)** - operations web pages (REQ-WEB-006)
+- **Era 2 Phase 4: 1 requirement (0% complete)** - model analytics pages (REQ-WEB-007)
 - Phase 4: 5 requirements (0% complete)
 - Phase 4-5: 15 requirements (0% complete) - methods system
 - Phase 5: 14 requirements (100% complete - documented)

--- a/src/precog/database/alembic/versions/0049_account_balance_scd_temporal_columns.py
+++ b/src/precog/database/alembic/versions/0049_account_balance_scd_temporal_columns.py
@@ -1,0 +1,83 @@
+"""
+Add SCD Type 2 temporal columns and unique index to account_balance.
+
+Revision ID: 0049
+Revises: 0048
+Create Date: 2026-04-05
+
+account_balance is the only SCD Type 2 table missing row_start_ts and row_end_ts
+columns. This migration adds them for point-in-time balance reconstruction, which
+Phase 2 trade execution requires for pre-trade balance checks and P&L reporting.
+
+Also adds a partial unique index on (platform_id) WHERE row_current_ind = TRUE
+to prevent concurrent SCD writes from creating duplicate current rows.
+
+Changes:
+    1. ADD COLUMN row_start_ts TIMESTAMPTZ DEFAULT NOW()
+    2. ADD COLUMN row_end_ts TIMESTAMPTZ (nullable)
+    3. Backfill row_start_ts from created_at for existing rows
+    4. CREATE UNIQUE INDEX idx_balance_unique_current ON account_balance(platform_id)
+       WHERE row_current_ind = TRUE
+
+Related:
+    - C4 Phase Gate findings H1 (blocker) and H2 (warning)
+    - Issue #339: Phase 2 requirements formalization
+    - Pattern 2 in CLAUDE.md: SCD Type 2 Versioning
+    - REQ-DB-004: SCD Type 2 for Frequently-Changing Data
+"""
+
+from alembic import op
+
+# revision identifiers
+revision = "0049"
+down_revision = "0048"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Step 1: Add temporal columns
+    op.execute("""
+        ALTER TABLE account_balance
+        ADD COLUMN row_start_ts TIMESTAMPTZ DEFAULT NOW(),
+        ADD COLUMN row_end_ts TIMESTAMPTZ
+    """)
+
+    # Step 2: Backfill row_start_ts from created_at for existing rows
+    # This preserves the original creation time as the version start time
+    op.execute("""
+        UPDATE account_balance
+        SET row_start_ts = created_at
+        WHERE row_start_ts IS NULL OR row_start_ts != created_at
+    """)
+
+    # Step 3: Set row_end_ts for historical rows (non-current)
+    # Historical rows ended when the next row for the same platform started
+    op.execute("""
+        UPDATE account_balance ab
+        SET row_end_ts = (
+            SELECT MIN(ab2.created_at)
+            FROM account_balance ab2
+            WHERE ab2.platform_id = ab.platform_id
+              AND ab2.created_at > ab.created_at
+        )
+        WHERE ab.row_current_ind = FALSE
+          AND ab.row_end_ts IS NULL
+    """)
+
+    # Step 4: Add partial unique index to prevent duplicate current rows
+    # Only one row per platform can be current at any time
+    op.execute("""
+        CREATE UNIQUE INDEX idx_balance_unique_current
+        ON account_balance(platform_id)
+        WHERE row_current_ind = TRUE
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_balance_unique_current")
+    op.execute("""
+        ALTER TABLE account_balance
+        DROP COLUMN IF EXISTS row_end_ts,
+        DROP COLUMN IF EXISTS row_start_ts
+    """)

--- a/src/precog/database/alembic/versions/0050_phase2_trade_indexes.py
+++ b/src/precog/database/alembic/versions/0050_phase2_trade_indexes.py
@@ -1,0 +1,47 @@
+"""
+Add Phase 2 indexes for trade execution queries.
+
+Revision ID: 0050
+Revises: 0049
+Create Date: 2026-04-05
+
+Adds partial indexes to support Phase 2 manual trading query patterns:
+- orders(trade_source) for filtering manual trades
+- positions(market_internal_id) for market+current lookups
+
+Related:
+    - C4 Phase Gate findings H3 and H4
+    - REQ-TRADE-001: Order placement pipeline queries
+    - REQ-WEB-004: Position management page queries
+"""
+
+from alembic import op
+
+# revision identifiers
+revision = "0050"
+down_revision = "0049"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # H3: Partial index on orders(trade_source) for manual trade filtering
+    # Phase 2 queries: "show me all manually placed orders"
+    op.execute("""
+        CREATE INDEX idx_orders_manual_trade_source
+        ON orders(trade_source)
+        WHERE trade_source = 'manual'
+    """)
+
+    # H4: Composite partial index on positions for market+current lookups
+    # Phase 2 queries: "what's my current position on this market?"
+    op.execute("""
+        CREATE INDEX idx_positions_market_current
+        ON positions(market_internal_id)
+        WHERE row_current_ind = TRUE AND status = 'open'
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_positions_market_current")
+    op.execute("DROP INDEX IF EXISTS idx_orders_manual_trade_source")

--- a/src/precog/database/crud_account.py
+++ b/src/precog/database/crud_account.py
@@ -83,9 +83,10 @@ def create_account_balance(
 
     query = """
         INSERT INTO account_balance (
-            platform_id, balance, currency, row_current_ind, created_at
+            platform_id, balance, currency,
+            row_current_ind, row_start_ts, created_at
         )
-        VALUES (%s, %s, %s, TRUE, NOW())
+        VALUES (%s, %s, %s, TRUE, NOW(), NOW())
         RETURNING id
     """
 
@@ -166,27 +167,29 @@ def update_account_balance_with_versioning(
     if not isinstance(new_balance, Decimal):
         raise ValueError(f"Balance must be Decimal, got {type(new_balance).__name__}")
 
-    # Step 1: Mark current balance as historical (row_current_ind = FALSE)
-    update_query = """
+    # Step 1: Close current row (set row_current_ind = FALSE, row_end_ts = NOW)
+    close_query = """
         UPDATE account_balance
-        SET row_current_ind = FALSE
+        SET row_current_ind = FALSE,
+            row_end_ts = NOW()
         WHERE platform_id = %s AND row_current_ind = TRUE
     """
 
-    # Step 2: Insert new balance record
+    # Step 2: Insert new balance record with row_start_ts
     insert_query = """
         INSERT INTO account_balance (
-            platform_id, balance, currency, row_current_ind, created_at
+            platform_id, balance, currency,
+            row_current_ind, row_start_ts, created_at
         )
-        VALUES (%s, %s, %s, TRUE, NOW())
+        VALUES (%s, %s, %s, TRUE, NOW(), NOW())
         RETURNING id
     """
 
     with get_cursor(commit=True) as cur:
-        # Mark old balance as historical
-        cur.execute(update_query, (platform_id,))
+        # Close old balance version
+        cur.execute(close_query, (platform_id,))
 
-        # Insert new balance
+        # Insert new balance version
         cur.execute(insert_query, (platform_id, new_balance, currency))
         result = cur.fetchone()
         return result["id"] if result else None


### PR DESCRIPTION
## Summary
- **Scope triage:** 31 phase-2 issues triaged across 4 phases (38/17/9/16 issues)
- **Era 2 roadmap:** `DEVELOPMENT_PHASES_ERA2_V1.0.md` with Phase 2-5 definitions + entry/exit criteria
- **22 new requirements:** REQ-TRADE (6), REQ-ORDER (6), REQ-SAFE (4), REQ-WEB (7)
- **15 new issues filed** (#568-#582): advanced orders (stop loss, take profit, trailing stop), web UI pages, analytics
- **Web UI epic #583** created; epic #504 updated with advanced order types
- **Polymarket deferred** to Phase 3 (#495, #496)
- **Migration 0049:** account_balance SCD temporal columns + unique index (H1+H2)
- **Migration 0050:** Phase 2 trade indexes on orders + positions (H3+H4)
- **CRUD updated:** crud_account.py now uses row_end_ts/row_start_ts

Closes C4 gate findings: B1, B3, G1, G4, G5, H1, H2, H3, H4 (9 of 27 action items).

## Test plan
- [x] 2493 unit tests pass
- [x] Ruff lint + format clean
- [x] Mypy type check clean
- [x] Pre-commit hooks pass
- [ ] Migration 0049/0050 applied on desktop deployment (Session 42b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)