### PR TITLE
Session 42: C4 hardening — ESPN validation, gap detection, Decimal, E2E tests

### DIFF
--- a/src/precog/api_connectors/espn_client.py
+++ b/src/precog/api_connectors/espn_client.py
@@ -307,7 +307,7 @@ class ESPNGameState(TypedDict, total=False):
     home_score: int
     away_score: int
     period: int
-    clock_seconds: float
+    clock_seconds: Decimal
     clock_display: str
     game_status: str
     situation: ESPNSituationData
@@ -379,7 +379,7 @@ class GameState(TypedDict, total=False):
     home_score: int
     away_score: int
     period: int
-    clock_seconds: float
+    clock_seconds: Decimal
     clock_display: str
     game_status: str
 
@@ -1194,7 +1194,7 @@ class ESPNClient:
                 "home_score": home_score,
                 "away_score": away_score,
                 "period": period,
-                "clock_seconds": float(clock_seconds) if clock_seconds else 0.0,
+                "clock_seconds": Decimal(str(clock_seconds)) if clock_seconds else Decimal("0"),
                 "clock_display": clock_display,
                 "game_status": game_status,
                 "situation": situation,

--- a/src/precog/schedulers/espn_game_poller.py
+++ b/src/precog/schedulers/espn_game_poller.py
@@ -53,7 +53,6 @@ Related ADR: ADR-100 (Service Supervisor Pattern)
 import logging
 import time
 from datetime import UTC, datetime, timedelta
-from decimal import Decimal
 from enum import Enum
 from typing import Any, ClassVar
 
@@ -82,6 +81,7 @@ from precog.database.crud_teams import (
     get_team_by_espn_id,
 )
 from precog.schedulers.base_poller import BasePoller
+from precog.validation.espn_validation import ESPNDataValidator
 
 # Set up logging
 logger = logging.getLogger(__name__)
@@ -188,6 +188,19 @@ class ESPNGamePoller(BasePoller):
 
     # ESPN rate limit budget (configurable via constructor or YAML)
     DEFAULT_RATE_BUDGET: ClassVar[int] = 250  # requests per hour
+
+    # Validation frequency: run game state validation every N polls.
+    # ESPN polls per-league at 30s, so 20 polls = ~10 minutes.
+    # Validates raw API data before DB sync (soft validation, never blocks).
+    VALIDATION_INTERVAL: ClassVar[int] = 20
+
+    # Validation error rate thresholds for log-level escalation.
+    # Below WARN: summary at INFO. Above WARN: summary at WARNING.
+    # Above ERROR: summary at ERROR.
+    # NOTE: float is intentional here -- these are ratios of integer counts,
+    # not prices, probabilities, or money values. Decimal not required.
+    VALIDATION_WARN_RATE: ClassVar[float] = 0.05  # 5% error rate
+    VALIDATION_ERROR_RATE: ClassVar[float] = 0.25  # 25% error rate
 
     # Game status mappings
     LIVE_STATUSES: ClassVar[set[str]] = {"in", "in_progress", "halftime"}
@@ -307,6 +320,32 @@ class ESPNGamePoller(BasePoller):
         # Initialize ESPN client (or use provided mock)
         self.espn_client = espn_client or ESPNClient()
 
+        # Initialize data validator (instance-level, NOT module-level singleton,
+        # because _anomaly_counts is stateful per-poller)
+        self._validator = ESPNDataValidator()
+
+        # Rate-limited validation: run every VALIDATION_INTERVAL league polls.
+        # Counter starts at VALIDATION_INTERVAL to trigger on first poll.
+        # Thread safety: protected by self._lock in _poll_league_wrapper.
+        self._polls_since_validation: int = self.VALIDATION_INTERVAL  # Run on first poll
+
+        # Validation stats tracked separately from PollerStats TypedDict
+        # to avoid type contract violations. Merged in get_stats().
+        self._validation_stats: dict[str, int | float] = {
+            "validation_errors": 0,
+            "validation_warnings": 0,
+            "validation_runs": 0,
+            "games_checked_last_cycle": 0,
+            "error_rate_pct_last_cycle": 0.0,
+        }
+
+        # Per-league last successful poll timestamps for data gap detection.
+        # Exposed in get_stats() so the supervisor's _determine_health() can
+        # detect staleness (degraded at 2x interval, down at 5x interval).
+        # The key "last_successful_poll" is what _determine_health expects.
+        self._last_successful_poll: str | None = None
+        self._league_last_successful_poll: dict[str, str] = {}
+
         logger.info(
             "ESPNGamePoller initialized: leagues=%s, poll_interval=%ds, "
             "idle_interval=%ds, persist_jobs=%s, adaptive_polling=%s",
@@ -322,10 +361,19 @@ class ESPNGamePoller(BasePoller):
         return "ESPN Game State Poll"
 
     def get_stats(self) -> dict[str, Any]:
-        """Return polling stats merged with sync categorization (#476)."""
+        """Return polling stats merged with sync categorization, validation, and gap detection.
+
+        The ``last_successful_poll`` key is consumed by the supervisor's
+        ``_determine_health()`` for staleness detection (degraded at 2x
+        poll interval, down at 5x). Per-league timestamps are included
+        as ``league_last_successful_poll`` for operational visibility.
+        """
         with self._lock:
             stats = dict(self._stats)
             stats.update(self._sync_stats)
+            stats.update(self._validation_stats)
+            stats["last_successful_poll"] = self._last_successful_poll
+            stats["league_last_successful_poll"] = dict(self._league_last_successful_poll)
             return stats
 
     def _record_sync(self, reason: GameSyncReason) -> None:
@@ -339,6 +387,11 @@ class ESPNGamePoller(BasePoller):
 
         Returns:
             Dictionary with counts: items_fetched, items_updated, items_created
+
+        Note:
+            This method is NOT used by the per-league scheduler. Per-league
+            APScheduler jobs call _poll_league_wrapper() directly. This exists
+            for the BasePoller interface and manual/test invocations.
         """
         total_fetched = 0
         total_updated = 0
@@ -605,9 +658,94 @@ class ESPNGamePoller(BasePoller):
         """
         start_time = datetime.now(UTC)
 
+        # Determine whether validation should run this league poll.
+        # Counter incremented per-league-poll (not per-cycle) since APScheduler
+        # calls _poll_league_wrapper directly for each league. Thread-safe:
+        # APScheduler max_instances=1 per job, but multiple league jobs can
+        # overlap, so protect the counter under self._lock.
+        with self._lock:
+            self._polls_since_validation += 1
+            should_validate = self._polls_since_validation >= self.VALIDATION_INTERVAL
+            if should_validate:
+                self._polls_since_validation = 0
+
         try:
             # Poll the league and get games for state evaluation
             games = self.espn_client.get_scoreboard(league)
+
+            # Validate fetched game data (soft validation -- log issues, never block).
+            # Runs on raw API data before any DB sync.
+            # Rate-limited via should_validate (computed above every
+            # VALIDATION_INTERVAL polls). validate_game_state() calls log_issues()
+            # internally, so we only do aggregate summary logging here.
+            # Wrapped in try/except: a validator bug must NEVER prevent game syncing.
+            if should_validate and games:
+                try:
+                    validation_results = [
+                        self._validator.validate_game_state(game) for game in games
+                    ]
+                    error_count = sum(1 for r in validation_results if r.has_errors)
+                    warning_count = sum(
+                        1 for r in validation_results if r.has_warnings and not r.has_errors
+                    )
+                    total_checked = len(games)
+
+                    # Error rate escalation logging (mirrors Kalshi pattern)
+                    error_rate = error_count / total_checked if total_checked > 0 else 0.0
+
+                    if error_rate >= self.VALIDATION_ERROR_RATE:
+                        logger.error(
+                            "ESPN validation [%s]: ERROR RATE %.1f%% - %d/%d games failed "
+                            "(%d errors, %d warnings) [ACTION: investigate data source]",
+                            league.upper(),
+                            error_rate * 100,
+                            error_count,
+                            total_checked,
+                            error_count,
+                            warning_count,
+                        )
+                    elif error_rate >= self.VALIDATION_WARN_RATE:
+                        logger.warning(
+                            "ESPN validation [%s]: error rate %.1f%% - %d/%d games failed "
+                            "(%d errors, %d warnings)",
+                            league.upper(),
+                            error_rate * 100,
+                            error_count,
+                            total_checked,
+                            error_count,
+                            warning_count,
+                        )
+                    elif error_count or warning_count:
+                        logger.info(
+                            "ESPN validation [%s]: %d games checked, %d errors, %d warnings",
+                            league.upper(),
+                            total_checked,
+                            error_count,
+                            warning_count,
+                        )
+                    else:
+                        logger.debug(
+                            "ESPN validation [%s]: %d games checked, all valid",
+                            league.upper(),
+                            total_checked,
+                        )
+
+                    # Track cumulative validation stats
+                    with self._lock:
+                        self._validation_stats["validation_errors"] += error_count
+                        self._validation_stats["validation_warnings"] += warning_count
+                        self._validation_stats["validation_runs"] += 1
+                        self._validation_stats["games_checked_last_cycle"] = total_checked
+                        self._validation_stats["error_rate_pct_last_cycle"] = round(
+                            error_rate * 100, 1
+                        )
+                except Exception as e:
+                    logger.error(
+                        "ESPN validation failed for %s (ingestion continues): %s",
+                        league.upper(),
+                        e,
+                    )
+
             games_updated = 0
             sync_errors = 0
             for game in games:
@@ -623,12 +761,19 @@ class ESPNGamePoller(BasePoller):
                     event_id = game.get("metadata", {}).get("espn_event_id", "unknown")
                     logger.error("Error syncing game %s: %s", event_id, e)
 
+            poll_timestamp = datetime.now(UTC).isoformat()
             with self._lock:
                 self._stats["polls_completed"] += 1
                 self._stats["items_fetched"] += len(games)
                 self._stats["items_updated"] += games_updated
                 self._stats["errors"] += sync_errors
                 self._stats["last_poll"] = start_time.isoformat()
+
+                # Track last_successful_poll for supervisor staleness detection.
+                # Only update when the poll completed without sync errors.
+                if sync_errors == 0:
+                    self._last_successful_poll = poll_timestamp
+                    self._league_last_successful_poll[league] = poll_timestamp
 
             elapsed = (datetime.now(UTC) - start_time).total_seconds()
             if games_updated:
@@ -1216,11 +1361,8 @@ class ESPNGamePoller(BasePoller):
         situation_data = state.get("situation", {})
         situation = dict(situation_data) if situation_data else {}
 
-        # Convert clock_seconds to Decimal for database
-        clock_seconds = None
-        clock_val = state.get("clock_seconds")
-        if clock_val is not None:
-            clock_seconds = Decimal(str(clock_val))
+        # clock_seconds is already Decimal from ESPN client (Pattern 1: Decimal at source)
+        clock_seconds = state.get("clock_seconds")
 
         # Derive season from game_date (calendar year)
         game_season = game_date.year if game_date else None

--- a/tests/e2e/api_connectors/test_espn_edge_cases.py
+++ b/tests/e2e/api_connectors/test_espn_edge_cases.py
@@ -38,6 +38,7 @@ Reference:
 Phase: 2 (Live Data Collection)
 """
 
+from decimal import Decimal
 from typing import Any, cast
 
 import pytest
@@ -174,7 +175,7 @@ class TestVenueEdgeCases:
                 "home_score": 0,
                 "away_score": 0,
                 "period": 0,
-                "clock_seconds": 0.0,  # Pre-game has 0 seconds
+                "clock_seconds": Decimal("0"),  # Pre-game has 0 seconds
                 "clock_display": "",
                 "game_status": "pre",
                 "situation": {},
@@ -238,7 +239,7 @@ class TestVenueEdgeCases:
                 "home_score": 14,
                 "away_score": 10,
                 "period": 2,
-                "clock_seconds": 300,
+                "clock_seconds": Decimal("300"),
                 "clock_display": "5:00",
                 "game_status": "in_progress",
                 "situation": {
@@ -330,7 +331,7 @@ class TestGameStateEdgeCases:
                 "home_score": 42,
                 "away_score": 36,
                 "period": 5,  # Overtime!
-                "clock_seconds": 420,
+                "clock_seconds": Decimal("420"),
                 "clock_display": "7:00",
                 "game_status": "in_progress",
                 "situation": {
@@ -400,7 +401,7 @@ class TestGameStateEdgeCases:
                 "home_score": 63,
                 "away_score": 63,
                 "period": 8,  # 4th overtime!
-                "clock_seconds": 0,
+                "clock_seconds": Decimal("0"),
                 "clock_display": "0:00",
                 "game_status": "in_progress",
                 "situation": {
@@ -851,7 +852,7 @@ class TestRegressionPrevention:
                 "home_score": 7,
                 "away_score": 3,
                 "period": 1,
-                "clock_seconds": 600,
+                "clock_seconds": Decimal("600"),
                 "clock_display": "10:00",
                 "game_status": "in_progress",
                 "situation": {},

--- a/tests/e2e/schedulers/test_espn_game_poller_e2e.py
+++ b/tests/e2e/schedulers/test_espn_game_poller_e2e.py
@@ -76,7 +76,7 @@ def sample_game_data() -> dict[str, Any]:
             "home_score": 21,
             "away_score": 17,
             "period": 3,
-            "clock_seconds": 845.5,
+            "clock_seconds": Decimal("845.5"),
             "clock_display": "14:05",
             "game_status": "in_progress",
             "situation": {

--- a/tests/e2e/schedulers/test_service_supervisor_lifecycle_e2e.py
+++ b/tests/e2e/schedulers/test_service_supervisor_lifecycle_e2e.py
@@ -1,0 +1,849 @@
+"""
+End-to-End Tests for ServiceSupervisor Lifecycle (Credential-Independent).
+
+These tests validate the supervisor's operational lifecycle WITHOUT requiring
+any API credentials (Kalshi or ESPN). They run in CI and on any dev machine.
+
+What makes these E2E and not integration?
+    Integration tests (test_service_supervisor_integration.py) verify
+    in-memory state: service.is_running(), supervisor.services["x"].healthy,
+    supervisor.get_aggregate_metrics(). They do NOT verify:
+    - Database writes (scheduler_status, system_health, circuit_breaker_events)
+    - Cross-process IPC (the CLI `scheduler status` path)
+    - Circuit breaker auto-trip from health check thread
+    - Thread lifecycle across the full start->health->crash->restart->stop cycle
+
+    These E2E tests verify all of the above with real DB, real threads,
+    and real timing.
+
+Test Classes:
+    1. TestSupervisorLifecycleE2E - Full lifecycle with thread cleanup
+    2. TestHealthCheckE2E - Health check loop writes to system_health table
+    3. TestServiceCrashAndRestartE2E - Crash detection, DB state transitions
+    4. TestCircuitBreakerAutoTripE2E - Auto-trip on service down
+    5. TestAlertCallbackE2E - Alert callback fired from health thread
+    6. TestDatabaseIPCE2E - scheduler_status populated for CLI IPC
+
+Prerequisites:
+    - PostgreSQL test database accessible (PRECOG_ENV=test)
+    - No API credentials required
+
+Run with:
+    pytest tests/e2e/schedulers/test_service_supervisor_lifecycle_e2e.py -v -m e2e
+
+Reference: ADR-100 (Service Supervisor Pattern)
+Requirements: REQ-DATA-001, REQ-OBSERV-001, REQ-TEST-002
+"""
+
+import os
+import socket
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from precog.database.connection import get_cursor
+from precog.database.crud_schedulers import get_scheduler_status
+from precog.database.crud_system import get_active_breakers, get_system_health
+from precog.schedulers.service_supervisor import (
+    Environment,
+    RunnerConfig,
+    ServiceConfig,
+    ServiceSupervisor,
+)
+
+# Mark all tests in this module as E2E -- no skipif for credentials
+pytestmark = [pytest.mark.e2e]
+
+
+# =============================================================================
+# Realistic Mock Service (copied from integration tests, extended for E2E)
+# =============================================================================
+
+
+class RealisticMockService:
+    """
+    A realistic mock service for E2E testing of supervisor lifecycle.
+
+    Simulates a polling service with configurable failure modes. Unlike the
+    integration test version, this one is tuned for faster E2E timing.
+
+    Educational Note:
+        E2E mocks serve a different purpose than integration mocks. They
+        need to produce enough activity (polls, errors) to trigger the
+        supervisor's DB-writing health check logic within short timeouts.
+    """
+
+    def __init__(
+        self,
+        name: str = "mock",
+        poll_interval: float = 0.1,
+        fail_after_polls: int | None = None,
+        error_rate: float = 0.0,
+    ) -> None:
+        """
+        Initialize realistic mock service.
+
+        Args:
+            name: Service identifier
+            poll_interval: Simulated poll interval in seconds
+            fail_after_polls: Stop running after this many polls (simulate crash)
+            error_rate: Probability of incrementing error count per poll
+        """
+        self.name = name
+        self.poll_interval = poll_interval
+        self.fail_after_polls = fail_after_polls
+        self.error_rate = error_rate
+
+        self._running = False
+        self._poll_count = 0
+        self._error_count = 0
+        self._poll_thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+
+    def start(self) -> None:
+        """Start the mock polling loop.
+
+        Resets poll and error counts so that restarts behave like fresh starts.
+        Without this, fail_after_polls would immediately re-trigger on restart
+        because _poll_count persists from the previous run.
+        """
+        self._running = True
+        self._poll_count = 0
+        self._error_count = 0
+        self._stop_event.clear()
+        self._poll_thread = threading.Thread(target=self._poll_loop, daemon=True)
+        self._poll_thread.start()
+
+    def stop(self) -> None:
+        """Stop the mock polling loop."""
+        self._stop_event.set()
+        self._running = False
+        if self._poll_thread:
+            self._poll_thread.join(timeout=2)
+
+    def is_running(self) -> bool:
+        """Check if service is running."""
+        return self._running
+
+    def get_stats(self) -> dict[str, Any]:
+        """Get service statistics."""
+        return {
+            "polls_completed": self._poll_count,
+            "errors": self._error_count,
+            "running": self._running,
+        }
+
+    def _poll_loop(self) -> None:
+        """Simulated polling loop."""
+        import random
+
+        while not self._stop_event.is_set():
+            self._stop_event.wait(self.poll_interval)
+            if self._stop_event.is_set():
+                break
+
+            self._poll_count += 1
+
+            # Simulate errors based on error_rate
+            if random.random() < self.error_rate:
+                self._error_count += 1
+
+            # Simulate crash after certain polls
+            if self.fail_after_polls and self._poll_count >= self.fail_after_polls:
+                self._running = False
+                break
+
+
+# =============================================================================
+# Shared Fixtures
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _clean_db_tables():
+    """Delete scheduler_status, system_health, and circuit_breaker_events before/after each test.
+
+    E2E lifecycle tests create real supervisors that write to these tables.
+    The startup guard detects stale scheduler_status entries and blocks
+    subsequent tests. Health check threads may also write circuit breaker
+    events that persist across tests.
+
+    Educational Note:
+        This is more aggressive than the integration test cleanup which only
+        cleans scheduler_status. E2E tests exercise the full DB write path
+        including system_health and circuit_breaker_events, so all three
+        tables need cleanup.
+    """
+
+    def _purge():
+        try:
+            with get_cursor(commit=True) as cur:
+                cur.execute("DELETE FROM scheduler_status")
+                cur.execute("DELETE FROM system_health")
+                # Only delete auto-tripped breakers (preserve manual ones)
+                cur.execute("DELETE FROM circuit_breaker_events WHERE notes LIKE 'Auto-tripped:%'")
+        except Exception:
+            pass  # Tables may not exist in some test environments
+
+    _purge()
+    yield
+    _purge()
+
+
+@pytest.fixture
+def e2e_config() -> RunnerConfig:
+    """Create configuration optimized for E2E testing.
+
+    Uses very short intervals so health checks and metrics fire quickly,
+    keeping total test time manageable (< 30s per class).
+
+    Educational Note:
+        health_check_interval=1 means the health thread fires every 1s.
+        For tests that need to observe a health check writing to DB, we
+        sleep ~2s to guarantee at least one health check has completed.
+    """
+    return RunnerConfig(
+        environment=Environment.DEVELOPMENT,
+        log_level="DEBUG",
+        log_dir=Path("/tmp/e2e_lifecycle_test_logs"),
+        health_check_interval=1,
+        metrics_interval=2,
+    )
+
+
+@pytest.fixture
+def supervisor(e2e_config: RunnerConfig) -> ServiceSupervisor:
+    """Create a supervisor instance for E2E testing.
+
+    Yields the supervisor and ensures stop_all() is called on teardown,
+    even if the test fails mid-execution (prevents thread leaks).
+    """
+    sup = ServiceSupervisor(e2e_config)
+    yield sup
+    # Defensive cleanup: stop if still running
+    if sup.is_running:
+        sup.stop_all()
+
+
+# =============================================================================
+# 1. Full Lifecycle E2E Tests
+# =============================================================================
+
+
+class TestSupervisorLifecycleE2E:
+    """E2E tests for the full supervisor lifecycle: create -> start -> run -> stop.
+
+    Why E2E?
+        Integration tests verify in-memory state (service.is_running(), etc).
+        These tests verify that the supervisor's DB writes (scheduler_status)
+        and background threads (health, metrics) all start and stop cleanly
+        as a coordinated whole. Thread leaks are a real production failure
+        mode that only manifests under the full lifecycle.
+    """
+
+    def test_full_lifecycle_with_thread_cleanup(self, supervisor: ServiceSupervisor) -> None:
+        """Verify create -> add -> start -> verify -> stop -> verify with thread cleanup."""
+        # 1. Not running yet
+        assert not supervisor.is_running
+
+        # 2. Add service
+        service = RealisticMockService(name="lifecycle", poll_interval=0.1)
+        supervisor.add_service("lifecycle", service, ServiceConfig(name="Lifecycle Test"))
+        assert "lifecycle" in supervisor.services
+
+        # 3. Start
+        supervisor.start_all()
+        assert supervisor.is_running
+        assert service.is_running()
+
+        # 4. Let it run (accumulate some polls)
+        time.sleep(0.5)
+        assert service._poll_count > 0
+
+        # 5. Record thread names before stop
+        thread_names_before = {t.name for t in threading.enumerate()}
+        assert "health-checker" in thread_names_before
+        assert "metrics-reporter" in thread_names_before
+
+        # 6. Stop
+        supervisor.stop_all()
+        assert not supervisor.is_running
+        assert not service.is_running()
+
+        # 7. Verify daemon threads stopped (give them a moment to join)
+        time.sleep(0.5)
+        thread_names_after = {t.name for t in threading.enumerate()}
+        assert "health-checker" not in thread_names_after, (
+            "health-checker thread should be cleaned up after stop_all()"
+        )
+        assert "metrics-reporter" not in thread_names_after, (
+            "metrics-reporter thread should be cleaned up after stop_all()"
+        )
+
+    def test_multi_service_lifecycle(self, supervisor: ServiceSupervisor) -> None:
+        """Verify lifecycle with multiple services, all start and stop cleanly."""
+        services = []
+        for i in range(3):
+            svc = RealisticMockService(name=f"multi{i}", poll_interval=0.1)
+            supervisor.add_service(f"multi{i}", svc, ServiceConfig(name=f"Multi {i}"))
+            services.append(svc)
+
+        supervisor.start_all()
+        time.sleep(0.5)
+
+        # All running and polling
+        for svc in services:
+            assert svc.is_running(), f"{svc.name} should be running"
+            assert svc._poll_count > 0, f"{svc.name} should have polled"
+
+        supervisor.stop_all()
+
+        # All stopped
+        for svc in services:
+            assert not svc.is_running(), f"{svc.name} should be stopped"
+
+    def test_graceful_shutdown_timing(self, supervisor: ServiceSupervisor) -> None:
+        """Verify shutdown completes within a reasonable timeframe under load."""
+        # 5 busy services
+        for i in range(5):
+            svc = RealisticMockService(name=f"busy{i}", poll_interval=0.05)
+            supervisor.add_service(f"busy{i}", svc, ServiceConfig(name=f"Busy{i}"))
+
+        supervisor.start_all()
+        time.sleep(0.5)
+
+        start = time.time()
+        supervisor.stop_all()
+        elapsed = time.time() - start
+
+        assert elapsed < 10, f"Shutdown took {elapsed:.1f}s, expected < 10s"
+
+
+# =============================================================================
+# 2. Health Check E2E Tests
+# =============================================================================
+
+
+class TestHealthCheckE2E:
+    """E2E tests for health check loop writing to system_health table.
+
+    Why E2E?
+        Integration tests verify that supervisor.services["x"].healthy is True.
+        These tests verify that the health check thread actually writes
+        'espn_api' -> 'healthy' into the system_health database table,
+        which is the persistent state that the CLI reads for `scheduler status`.
+        This DB write path cannot be verified without real DB + real threading.
+
+    Key constraint:
+        Only services named 'espn', 'kalshi_rest', or 'kalshi_ws' trigger
+        system_health writes (via SERVICE_TO_COMPONENT mapping). Mock services
+        with arbitrary names are silently skipped. Tests that need system_health
+        writes use name='espn' for the mock service.
+    """
+
+    def test_health_check_writes_healthy_to_system_health(
+        self, supervisor: ServiceSupervisor
+    ) -> None:
+        """Verify health check writes 'healthy' to system_health for espn_api."""
+        # Name the mock 'espn' so SERVICE_TO_COMPONENT maps it to 'espn_api'
+        service = RealisticMockService(name="espn", poll_interval=0.1)
+        supervisor.add_service("espn", service, ServiceConfig(name="ESPN Mock"))
+
+        supervisor.start_all()
+
+        # Wait for at least one health check cycle (interval=1s, wait 2.5s)
+        time.sleep(2.5)
+
+        # Query system_health for espn_api component
+        records = get_system_health(component="espn_api")
+
+        assert len(records) > 0, (
+            "system_health should have an entry for espn_api after health check"
+        )
+        assert records[0]["status"] == "healthy", (
+            f"Expected 'healthy', got '{records[0]['status']}'"
+        )
+        assert records[0]["component"] == "espn_api"
+
+        supervisor.stop_all()
+
+    def test_health_check_skips_unmapped_services(self, supervisor: ServiceSupervisor) -> None:
+        """Verify mock services not in SERVICE_TO_COMPONENT don't write system_health.
+
+        Educational Note:
+            This verifies the safe default: unknown service names are skipped
+            in _update_system_health(). This is intentional -- future services
+            should not crash the health check loop just because they lack a
+            component mapping.
+        """
+        service = RealisticMockService(name="unknown", poll_interval=0.1)
+        supervisor.add_service("unknown", service, ServiceConfig(name="Unknown Service"))
+
+        supervisor.start_all()
+        time.sleep(2.5)
+
+        # Should NOT have written any system_health entries for this service
+        # (unless other tests leaked; cleanup fixture handles that)
+        records = get_system_health(component="unknown")
+        assert len(records) == 0, "Unmapped service should not create system_health entries"
+
+        supervisor.stop_all()
+
+    def test_health_check_updates_on_repeated_cycles(self, supervisor: ServiceSupervisor) -> None:
+        """Verify health check updates (not just inserts) on repeated cycles.
+
+        Educational Note:
+            system_health uses DELETE + INSERT per component per health check.
+            This test verifies that multiple health checks don't create
+            duplicate rows -- there should always be exactly one row per
+            component.
+        """
+        service = RealisticMockService(name="espn", poll_interval=0.1)
+        supervisor.add_service("espn", service, ServiceConfig(name="ESPN Mock"))
+
+        supervisor.start_all()
+        # Wait for at least 3 health check cycles
+        time.sleep(4)
+
+        records = get_system_health(component="espn_api")
+        assert len(records) == 1, (
+            f"Expected exactly 1 system_health row for espn_api, got {len(records)}"
+        )
+
+        supervisor.stop_all()
+
+
+# =============================================================================
+# 3. Service Crash and Restart E2E Tests
+# =============================================================================
+
+
+class TestServiceCrashAndRestartE2E:
+    """E2E tests for crash detection, restart attempts, and DB state transitions.
+
+    Why E2E?
+        Integration tests check in-memory state.consecutive_failures. These
+        tests verify the DB-visible state transitions: scheduler_status goes
+        from 'running' -> 'failed' -> 'starting' -> 'running' (on successful
+        restart) as the health check thread detects crashes and attempts
+        restarts. The system_health table also transitions to 'down'.
+
+    Key timing:
+        fail_after_polls=2 with poll_interval=0.1 means crash at ~0.2s.
+        health_check_interval=1 means detection at ~1s after crash.
+        retry_delay=1 means restart attempt at ~1s after detection.
+        Total: ~3-4s from start to restart attempt.
+    """
+
+    def test_crash_detected_and_system_health_goes_down(
+        self, supervisor: ServiceSupervisor
+    ) -> None:
+        """Verify crash sets system_health to 'down' for the component."""
+        service = RealisticMockService(name="espn", poll_interval=0.1, fail_after_polls=2)
+        config = ServiceConfig(name="ESPN Crasher", max_retries=0, retry_delay=1)
+        supervisor.add_service("espn", service, config)
+
+        supervisor.start_all()
+
+        # Wait for crash (0.2s) + health check detection (1s) + margin
+        time.sleep(3)
+
+        # system_health should show 'down' for espn_api
+        records = get_system_health(component="espn_api")
+        assert len(records) > 0, "system_health should have an espn_api entry"
+        assert records[0]["status"] == "down", (
+            f"Expected 'down' after crash, got '{records[0]['status']}'"
+        )
+
+        supervisor.stop_all()
+
+    def test_restart_increments_restart_count(self, supervisor: ServiceSupervisor) -> None:
+        """Verify restart_count increments after successful restart.
+
+        Educational Note:
+            The RealisticMockService with fail_after_polls will crash, but
+            when restarted (start() called again), it resets its internal
+            state and runs again. This simulates a transient failure where
+            restart succeeds.
+        """
+        service = RealisticMockService(name="espn", poll_interval=0.1, fail_after_polls=3)
+        config = ServiceConfig(name="ESPN Restarter", max_retries=3, retry_delay=1)
+        supervisor.add_service("espn", service, config)
+
+        supervisor.start_all()
+
+        # Wait for crash + health check + restart delay + restart
+        time.sleep(5)
+
+        state = supervisor.services["espn"]
+        assert state.restart_count > 0, f"Expected restart_count > 0, got {state.restart_count}"
+
+        supervisor.stop_all()
+
+    def test_scheduler_status_shows_failed_on_crash(self, supervisor: ServiceSupervisor) -> None:
+        """Verify scheduler_status table reflects 'failed' after crash detection."""
+        service = RealisticMockService(name="espn", poll_interval=0.1, fail_after_polls=2)
+        config = ServiceConfig(name="ESPN Crasher", max_retries=0, retry_delay=1)
+        supervisor.add_service("espn", service, config)
+
+        supervisor.start_all()
+
+        # Wait for crash + health check
+        time.sleep(3)
+
+        # Query scheduler_status for the espn service
+        status_row = get_scheduler_status(supervisor.host_id, "espn")
+        assert status_row is not None, "scheduler_status should have an espn entry"
+        assert status_row["status"] == "failed", f"Expected 'failed', got '{status_row['status']}'"
+        assert status_row["error_message"] is not None, (
+            "error_message should be populated on failure"
+        )
+
+        supervisor.stop_all()
+
+
+# =============================================================================
+# 4. Circuit Breaker Auto-Trip E2E Tests
+# =============================================================================
+
+
+class TestCircuitBreakerAutoTripE2E:
+    """E2E tests for automatic circuit breaker tripping on service down.
+
+    Why E2E?
+        The circuit breaker auto-trip happens inside _auto_trip_circuit_breaker(),
+        called from _update_system_health(), called from _check_service_health(),
+        called from the _health_check_loop() thread. This is a 4-level deep
+        call chain that writes to circuit_breaker_events. Integration tests
+        cannot verify this DB write without running the full health thread.
+
+    Key mapping:
+        Service name 'espn' -> component 'espn_api' -> breaker_type 'data_stale'.
+        The breaker is only tripped when system_health transitions to 'down'
+        and no active breaker of that type already exists.
+    """
+
+    def test_circuit_breaker_trips_on_permanent_failure(
+        self, supervisor: ServiceSupervisor
+    ) -> None:
+        """Verify circuit breaker is created when service goes down permanently."""
+        service = RealisticMockService(name="espn", poll_interval=0.1, fail_after_polls=2)
+        config = ServiceConfig(name="ESPN Permanent Failure", max_retries=0)
+        supervisor.add_service("espn", service, config)
+
+        supervisor.start_all()
+
+        # Wait for crash + health check + circuit breaker write
+        time.sleep(3)
+
+        # Query circuit_breaker_events for data_stale type
+        breakers = get_active_breakers(breaker_type="data_stale")
+        assert len(breakers) > 0, "Expected a 'data_stale' circuit breaker to be auto-tripped"
+
+        breaker = breakers[0]
+        assert breaker["breaker_type"] == "data_stale"
+        assert "Auto-tripped" in (breaker.get("notes") or ""), (
+            "Breaker notes should indicate auto-trip"
+        )
+
+        supervisor.stop_all()
+
+    def test_duplicate_breaker_not_created(self, supervisor: ServiceSupervisor) -> None:
+        """Verify repeated health checks don't create duplicate breakers.
+
+        Educational Note:
+            The _auto_trip_circuit_breaker() method checks get_active_breakers()
+            before creating a new one. On the second health check that reports
+            'down', the active breaker already exists so no duplicate is created.
+        """
+        service = RealisticMockService(name="espn", poll_interval=0.1, fail_after_polls=2)
+        config = ServiceConfig(name="ESPN Dup Test", max_retries=0)
+        supervisor.add_service("espn", service, config)
+
+        supervisor.start_all()
+
+        # Wait for multiple health checks after crash
+        time.sleep(5)
+
+        breakers = get_active_breakers(breaker_type="data_stale")
+        assert len(breakers) == 1, (
+            f"Expected exactly 1 active data_stale breaker, got {len(breakers)}"
+        )
+
+        supervisor.stop_all()
+
+    def test_breaker_contains_component_details(self, supervisor: ServiceSupervisor) -> None:
+        """Verify breaker trigger_value includes component name and reason."""
+        service = RealisticMockService(name="espn", poll_interval=0.1, fail_after_polls=2)
+        config = ServiceConfig(name="ESPN Details Test", max_retries=0)
+        supervisor.add_service("espn", service, config)
+
+        supervisor.start_all()
+        time.sleep(3)
+
+        breakers = get_active_breakers(breaker_type="data_stale")
+        assert len(breakers) > 0
+
+        trigger = breakers[0].get("trigger_value")
+        assert trigger is not None, "trigger_value should be populated"
+        # JSONB may come back as str depending on driver; parse if needed
+        if isinstance(trigger, str):
+            import json
+
+            trigger = json.loads(trigger)
+        assert isinstance(trigger, dict), f"trigger_value should be dict, got {type(trigger)}"
+        assert trigger.get("component") == "espn_api", (
+            f"Expected component='espn_api' in trigger_value, got {trigger}"
+        )
+
+        supervisor.stop_all()
+
+
+# =============================================================================
+# 5. Alert Callback E2E Tests
+# =============================================================================
+
+
+class TestAlertCallbackE2E:
+    """E2E tests for alert callbacks triggered by the health check thread.
+
+    Why E2E?
+        Integration tests manually call _trigger_alert() or set up callbacks
+        that may or may not fire within the test timing window. These E2E
+        tests verify the full path: service crashes -> health check detects
+        -> consecutive_failures exceeds max_retries -> alert triggered with
+        correct service name and context. The alert fires from the health
+        check thread, not the main thread.
+    """
+
+    def test_alert_fires_on_service_exhausting_retries(self, supervisor: ServiceSupervisor) -> None:
+        """Verify alert callback is called when service exhausts max_retries.
+
+        The alert fires when consecutive_failures > max_retries, with
+        message indicating the service has given up.
+        """
+        received_alerts: list[tuple[str, str, dict[str, Any]]] = []
+        alert_event = threading.Event()
+
+        def alert_handler(name: str, message: str, context: dict[str, Any]) -> None:
+            received_alerts.append((name, message, context))
+            alert_event.set()
+
+        supervisor.register_alert_callback(alert_handler)
+
+        service = RealisticMockService(name="espn", poll_interval=0.1, fail_after_polls=2)
+        # max_retries=0 means alert fires on first health check detection of crash
+        config = ServiceConfig(name="ESPN Alerter", max_retries=0, retry_delay=1)
+        supervisor.add_service("espn", service, config)
+
+        supervisor.start_all()
+
+        # Service crashes at ~0.2s. First health check at ~1s detects crash.
+        # consecutive_failures=1 > max_retries=0, so alert fires immediately.
+        got_alert = alert_event.wait(timeout=5)
+
+        assert got_alert, "Alert callback should have been called within 5s"
+        assert len(received_alerts) > 0, "Should have received at least one alert"
+
+        name, message, context = received_alerts[0]
+        assert name == "espn", f"Expected alert for 'espn', got '{name}'"
+        assert "failed" in message.lower() or "giving up" in message.lower(), (
+            f"Alert message should indicate failure: '{message}'"
+        )
+        assert "restart_count" in context, f"Alert context should include restart_count: {context}"
+
+        supervisor.stop_all()
+
+    def test_multiple_callbacks_all_receive_alert(self, supervisor: ServiceSupervisor) -> None:
+        """Verify all registered callbacks receive the same alert."""
+        events = [threading.Event() for _ in range(3)]
+        received: list[list[tuple[str, str, dict[str, Any]]]] = [[] for _ in range(3)]
+
+        for i in range(3):
+
+            def make_handler(idx: int):
+                def handler(name: str, msg: str, ctx: dict[str, Any]) -> None:
+                    received[idx].append((name, msg, ctx))
+                    events[idx].set()
+
+                return handler
+
+            supervisor.register_alert_callback(make_handler(i))
+
+        service = RealisticMockService(name="espn", poll_interval=0.1, fail_after_polls=2)
+        config = ServiceConfig(name="ESPN Multi-Callback", max_retries=0)
+        supervisor.add_service("espn", service, config)
+
+        supervisor.start_all()
+
+        # Wait for all callbacks to fire
+        for i, evt in enumerate(events):
+            assert evt.wait(timeout=5), f"Callback {i} should have been called"
+
+        supervisor.stop_all()
+
+        # All three should have alerts
+        for i in range(3):
+            assert len(received[i]) > 0, f"Callback {i} should have received alerts"
+
+    def test_alert_context_includes_meaningful_data(self, supervisor: ServiceSupervisor) -> None:
+        """Verify alert context dict contains actionable information."""
+        received_alerts: list[tuple[str, str, dict[str, Any]]] = []
+        alert_event = threading.Event()
+
+        def alert_handler(name: str, message: str, context: dict[str, Any]) -> None:
+            received_alerts.append((name, message, context))
+            alert_event.set()
+
+        supervisor.register_alert_callback(alert_handler)
+
+        service = RealisticMockService(name="espn", poll_interval=0.1, fail_after_polls=2)
+        config = ServiceConfig(name="ESPN Context", max_retries=0)
+        supervisor.add_service("espn", service, config)
+
+        supervisor.start_all()
+        alert_event.wait(timeout=5)
+        supervisor.stop_all()
+
+        assert len(received_alerts) > 0
+        _name, _msg, context = received_alerts[0]
+
+        # Context should have restart_count key (from the giving-up path)
+        assert isinstance(context, dict), f"Context should be dict, got {type(context)}"
+        assert "restart_count" in context, (
+            f"Context should include 'restart_count', got keys: {list(context.keys())}"
+        )
+
+
+# =============================================================================
+# 6. Database IPC E2E Tests
+# =============================================================================
+
+
+class TestDatabaseIPCE2E:
+    """E2E tests for scheduler_status table -- enables CLI `scheduler status`.
+
+    Why E2E?
+        The scheduler_status table is the cross-process IPC mechanism. When
+        `precog scheduler start` runs in process A, it writes to this table.
+        When `precog scheduler status` runs in process B, it reads from it.
+        Integration tests never verify the actual DB content -- only in-memory
+        supervisor state. These tests query the DB directly to verify the
+        same rows the CLI would read.
+    """
+
+    def test_scheduler_status_populated_on_start(self, supervisor: ServiceSupervisor) -> None:
+        """Verify scheduler_status has correct entries after start_all()."""
+        service = RealisticMockService(name="espn", poll_interval=0.1)
+        supervisor.add_service("espn", service, ServiceConfig(name="ESPN IPC"))
+
+        supervisor.start_all()
+        # Small delay to let the _start_service DB write complete
+        time.sleep(0.5)
+
+        status = get_scheduler_status(supervisor.host_id, "espn")
+        assert status is not None, "scheduler_status should have an espn entry"
+        assert status["status"] == "running", f"Expected 'running', got '{status['status']}'"
+        assert status["host_id"] == socket.gethostname()
+        assert status["pid"] == os.getpid()
+
+        supervisor.stop_all()
+
+    def test_scheduler_status_shows_stopped_after_stop(self, supervisor: ServiceSupervisor) -> None:
+        """Verify scheduler_status transitions to 'stopped' after stop_all()."""
+        service = RealisticMockService(name="espn", poll_interval=0.1)
+        supervisor.add_service("espn", service, ServiceConfig(name="ESPN Stop"))
+
+        supervisor.start_all()
+        time.sleep(0.5)
+
+        supervisor.stop_all()
+
+        status = get_scheduler_status(supervisor.host_id, "espn")
+        assert status is not None
+        assert status["status"] == "stopped", (
+            f"Expected 'stopped' after stop_all(), got '{status['status']}'"
+        )
+
+    def test_scheduler_status_heartbeat_updates(self, supervisor: ServiceSupervisor) -> None:
+        """Verify health check refreshes last_heartbeat in scheduler_status.
+
+        Educational Note:
+            The heartbeat is the 'lease renewal' that proves the service
+            is still alive. If the heartbeat is older than the stale
+            threshold, other processes consider the service crashed.
+        """
+        service = RealisticMockService(name="espn", poll_interval=0.1)
+        supervisor.add_service("espn", service, ServiceConfig(name="ESPN HB"))
+
+        supervisor.start_all()
+        time.sleep(0.5)
+
+        # Record initial heartbeat
+        status_1 = get_scheduler_status(supervisor.host_id, "espn")
+        assert status_1 is not None
+        heartbeat_1 = status_1["last_heartbeat"]
+
+        # Wait for at least one health check to update the heartbeat
+        time.sleep(2)
+
+        status_2 = get_scheduler_status(supervisor.host_id, "espn")
+        assert status_2 is not None
+        heartbeat_2 = status_2["last_heartbeat"]
+
+        assert heartbeat_2 > heartbeat_1, (
+            f"Heartbeat should advance after health check: {heartbeat_1} -> {heartbeat_2}"
+        )
+
+        supervisor.stop_all()
+
+    def test_scheduler_status_includes_stats(self, supervisor: ServiceSupervisor) -> None:
+        """Verify health check writes service stats to scheduler_status.
+
+        The stats field is a JSONB column containing service-specific
+        metrics (polls_completed, errors, etc).
+        """
+        service = RealisticMockService(name="espn", poll_interval=0.1)
+        supervisor.add_service("espn", service, ServiceConfig(name="ESPN Stats"))
+
+        supervisor.start_all()
+        # Wait for health check to write stats
+        time.sleep(2.5)
+
+        status = get_scheduler_status(supervisor.host_id, "espn")
+        assert status is not None
+
+        stats = status.get("stats")
+        assert stats is not None, "stats should be populated by health check"
+        # Stats is stored as JSONB, may be dict or JSON string
+        if isinstance(stats, str):
+            import json
+
+            stats = json.loads(stats)
+        assert "polls_completed" in stats, f"stats should contain polls_completed, got: {stats}"
+        assert stats["polls_completed"] > 0, "Should have completed polls by now"
+
+        supervisor.stop_all()
+
+    def test_multiple_services_in_scheduler_status(self, supervisor: ServiceSupervisor) -> None:
+        """Verify each service gets its own row in scheduler_status."""
+        svc1 = RealisticMockService(name="svc1", poll_interval=0.1)
+        svc2 = RealisticMockService(name="svc2", poll_interval=0.1)
+        supervisor.add_service("svc1", svc1, ServiceConfig(name="Svc 1"))
+        supervisor.add_service("svc2", svc2, ServiceConfig(name="Svc 2"))
+
+        supervisor.start_all()
+        time.sleep(0.5)
+
+        status_1 = get_scheduler_status(supervisor.host_id, "svc1")
+        status_2 = get_scheduler_status(supervisor.host_id, "svc2")
+
+        assert status_1 is not None, "svc1 should have a scheduler_status entry"
+        assert status_2 is not None, "svc2 should have a scheduler_status entry"
+        assert status_1["status"] == "running"
+        assert status_2["status"] == "running"
+
+        supervisor.stop_all()

--- a/tests/fixtures/espn_responses.py
+++ b/tests/fixtures/espn_responses.py
@@ -22,6 +22,7 @@ Usage in tests:
 Reference: docs/testing/PHASE_2_TEST_PLAN_V1.0.md Section 2.1
 """
 
+from decimal import Decimal
 
 # =============================================================================
 # ESPN NFL Scoreboard - Live Game
@@ -980,7 +981,7 @@ EXPECTED_GAME_STATE_LIVE = {
     "home_score": 24,
     "away_score": 21,
     "period": 4,
-    "clock_seconds": 485,
+    "clock_seconds": Decimal("485"),
     "clock_display": "8:05",
     "game_status": "in_progress",
     "possession": "away",  # KC has the ball
@@ -999,7 +1000,7 @@ EXPECTED_GAME_STATE_PREGAME = {
     "home_score": 0,
     "away_score": 0,
     "period": 0,
-    "clock_seconds": 0,
+    "clock_seconds": Decimal("0"),
     "clock_display": "0:00",
     "game_status": "scheduled",
     "possession": None,
@@ -1018,7 +1019,7 @@ EXPECTED_GAME_STATE_FINAL = {
     "home_score": 20,
     "away_score": 27,
     "period": 4,
-    "clock_seconds": 0,
+    "clock_seconds": Decimal("0"),
     "clock_display": "0:00",
     "game_status": "final",
     "possession": None,
@@ -1038,7 +1039,7 @@ EXPECTED_GAME_STATE_HALFTIME = {
     "home_score": 10,
     "away_score": 14,
     "period": 2,
-    "clock_seconds": 0,
+    "clock_seconds": Decimal("0"),
     "clock_display": "0:00",
     "game_status": "halftime",
     "possession": None,

--- a/tests/property/database/test_validate_decimal_properties.py
+++ b/tests/property/database/test_validate_decimal_properties.py
@@ -1,0 +1,160 @@
+"""
+Property-based tests for validate_decimal runtime type enforcement.
+
+Tests invariants that should hold for any input to validate_decimal():
+1. Decimal inputs always pass (identity property)
+2. Non-Decimal inputs always raise TypeError (rejection property)
+3. The returned value equals the input (no mutation)
+4. Error messages contain the parameter name (debuggability)
+
+Reference: TESTING_STRATEGY V3.9 - Property tests for business logic
+Related: Pattern 1 (Decimal Precision) in CLAUDE.md
+"""
+
+from decimal import Decimal
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from precog.database.crud_shared import validate_decimal
+
+pytestmark = [pytest.mark.property]
+
+
+# =============================================================================
+# Custom Strategies
+# =============================================================================
+
+# Valid Decimal values (realistic trading/price domain)
+decimal_strategy = st.decimals(
+    min_value=Decimal("-1000000"),
+    max_value=Decimal("1000000"),
+    places=4,
+    allow_nan=False,
+    allow_infinity=False,
+)
+
+# Price-range Decimals (0 to 1, sub-penny precision)
+price_decimal_strategy = st.decimals(
+    min_value=Decimal("0.0001"),
+    max_value=Decimal("0.9999"),
+    places=4,
+    allow_nan=False,
+    allow_infinity=False,
+)
+
+# Non-Decimal types that should be rejected
+non_decimal_strategy = (
+    st.floats(allow_nan=False, allow_infinity=False)
+    | st.integers()
+    | st.text(max_size=20)
+    | st.none()
+    | st.booleans()
+    | st.lists(st.integers(), max_size=3)
+)
+
+# Parameter names
+param_name_strategy = st.sampled_from(
+    [
+        "yes_ask_price",
+        "no_bid_price",
+        "edge",
+        "probability",
+        "clock_seconds",
+        "min_edge",
+    ]
+)
+
+
+# =============================================================================
+# Property Tests: Identity (Decimal in = Decimal out)
+# =============================================================================
+
+
+@pytest.mark.property
+class TestValidateDecimalIdentity:
+    """Property: validate_decimal(Decimal_value) always returns the same value."""
+
+    @given(value=decimal_strategy, param_name=param_name_strategy)
+    @settings(max_examples=200)
+    def test_decimal_passes_through_unchanged(self, value: Decimal, param_name: str) -> None:
+        """Any Decimal value passes validation and is returned unchanged."""
+        result = validate_decimal(value, param_name)
+        assert result == value
+        assert result is value  # Same object, not a copy
+
+    @given(value=price_decimal_strategy)
+    @settings(max_examples=100)
+    def test_price_range_decimals_pass(self, value: Decimal) -> None:
+        """Price-range Decimals (0.0001-0.9999) always pass."""
+        result = validate_decimal(value, "price")
+        assert result == value
+
+    def test_zero_decimal_passes(self) -> None:
+        """Decimal("0") passes validation."""
+        assert validate_decimal(Decimal("0"), "value") == Decimal("0")
+
+    def test_negative_decimal_passes(self) -> None:
+        """Negative Decimal passes (validation is type-only, not range)."""
+        assert validate_decimal(Decimal("-1.5"), "value") == Decimal("-1.5")
+
+
+# =============================================================================
+# Property Tests: Rejection (non-Decimal always raises TypeError)
+# =============================================================================
+
+
+@pytest.mark.property
+class TestValidateDecimalRejection:
+    """Property: validate_decimal(non_Decimal) always raises TypeError."""
+
+    @given(value=non_decimal_strategy, param_name=param_name_strategy)
+    @settings(max_examples=200)
+    def test_non_decimal_always_rejected(self, value: object, param_name: str) -> None:
+        """Any non-Decimal value raises TypeError."""
+        with pytest.raises(TypeError):
+            validate_decimal(value, param_name)
+
+    @given(value=st.floats(allow_nan=False, allow_infinity=False))
+    @settings(max_examples=100)
+    def test_float_always_rejected(self, value: float) -> None:
+        """Float values are always rejected, even when numerically equivalent."""
+        with pytest.raises(TypeError, match="must be Decimal"):
+            validate_decimal(value, "price")
+
+    @given(value=st.integers())
+    @settings(max_examples=50)
+    def test_int_always_rejected(self, value: int) -> None:
+        """Integer values are always rejected (must use Decimal explicitly)."""
+        with pytest.raises(TypeError, match="must be Decimal"):
+            validate_decimal(value, "count")
+
+
+# =============================================================================
+# Property Tests: Error Message Quality
+# =============================================================================
+
+
+@pytest.mark.property
+class TestValidateDecimalErrorMessages:
+    """Property: error messages always contain the parameter name and type guidance."""
+
+    @given(param_name=param_name_strategy)
+    @settings(max_examples=50)
+    def test_error_contains_param_name(self, param_name: str) -> None:
+        """TypeError message includes the parameter name for debuggability."""
+        with pytest.raises(TypeError, match=param_name):
+            validate_decimal(0.5, param_name)
+
+    @given(value=st.floats(min_value=0.01, max_value=0.99, allow_nan=False))
+    @settings(max_examples=50)
+    def test_error_contains_type_name(self, value: float) -> None:
+        """TypeError message includes 'float' so the developer knows what went wrong."""
+        with pytest.raises(TypeError, match="float"):
+            validate_decimal(value, "price")
+
+    def test_error_contains_pattern_reference(self) -> None:
+        """TypeError message references Pattern 1 in CLAUDE.md."""
+        with pytest.raises(TypeError, match="Pattern 1"):
+            validate_decimal(0.5, "price")

--- a/tests/unit/schedulers/test_espn_game_poller_unit.py
+++ b/tests/unit/schedulers/test_espn_game_poller_unit.py
@@ -11,6 +11,7 @@ Usage:
 """
 
 from contextlib import nullcontext
+from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -25,6 +26,7 @@ from precog.schedulers.espn_game_poller import (
     refresh_all_scoreboards,
     run_single_espn_poll,
 )
+from precog.validation.espn_validation import ValidationResult
 
 # =============================================================================
 # Fixtures
@@ -71,7 +73,7 @@ def sample_game_data() -> dict[str, Any]:
             "home_score": 21,
             "away_score": 17,
             "period": 3,
-            "clock_seconds": 845.5,
+            "clock_seconds": Decimal("845.5"),
             "clock_display": "14:05",
             "game_status": "in_progress",
             "situation": {
@@ -1508,3 +1510,515 @@ class TestPeriodicTeamValidation:
             assert job is None
         finally:
             poller.stop()
+
+
+# =============================================================================
+# Unit Tests: ESPN Data Validation Wiring
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestESPNDataValidationWiring:
+    """Unit tests for ESPN data validation wiring in the poller.
+
+    Educational Note:
+        The ESPNDataValidator is wired into _poll_league_wrapper to run
+        soft validation on raw API data BEFORE DB sync. Validation is
+        rate-limited (every VALIDATION_INTERVAL polls) and never blocks
+        ingestion. This mirrors the Kalshi poller's validation pattern.
+    """
+
+    def test_validator_initialized(self, mock_espn_client: MagicMock) -> None:
+        """Test ESPNDataValidator is instantiated in __init__."""
+        from precog.validation.espn_validation import ESPNDataValidator
+
+        poller = ESPNGamePoller(espn_client=mock_espn_client)
+
+        assert hasattr(poller, "_validator")
+        assert isinstance(poller._validator, ESPNDataValidator)
+
+    def test_validation_constants_defined(self) -> None:
+        """Test validation class constants exist and have correct values."""
+        assert ESPNGamePoller.VALIDATION_INTERVAL == 20
+        assert ESPNGamePoller.VALIDATION_ERROR_RATE == 0.25
+        assert ESPNGamePoller.VALIDATION_WARN_RATE == 0.05
+
+    def test_validation_stats_initialized(self, mock_espn_client: MagicMock) -> None:
+        """Test validation stats are initialized to zero."""
+        poller = ESPNGamePoller(espn_client=mock_espn_client)
+
+        assert poller._validation_stats["validation_errors"] == 0
+        assert poller._validation_stats["validation_warnings"] == 0
+        assert poller._validation_stats["validation_runs"] == 0
+        assert poller._validation_stats["games_checked_last_cycle"] == 0
+        assert poller._validation_stats["error_rate_pct_last_cycle"] == 0.0
+
+    def test_validation_stats_in_get_stats(self, mock_espn_client: MagicMock) -> None:
+        """Test get_stats includes validation stats."""
+        poller = ESPNGamePoller(espn_client=mock_espn_client)
+        stats = poller.get_stats()
+
+        assert "validation_errors" in stats
+        assert "validation_warnings" in stats
+        assert "validation_runs" in stats
+
+    def test_polls_since_validation_starts_at_interval(self, mock_espn_client: MagicMock) -> None:
+        """Test counter starts at VALIDATION_INTERVAL to trigger on first poll."""
+        poller = ESPNGamePoller(espn_client=mock_espn_client)
+
+        assert poller._polls_since_validation == ESPNGamePoller.VALIDATION_INTERVAL
+
+    def test_counter_triggers_on_first_league_poll(self, mock_espn_client: MagicMock) -> None:
+        """Test validation triggers on first _poll_league_wrapper call.
+
+        Counter starts at VALIDATION_INTERVAL so the first poll increments it
+        past the threshold, triggering validation and resetting to 0.
+        """
+        mock_espn_client.get_scoreboard.return_value = []
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+
+        poller._poll_league_wrapper("nfl")
+
+        # After first poll: counter was at VALIDATION_INTERVAL, incremented to
+        # VALIDATION_INTERVAL+1 which >= VALIDATION_INTERVAL, so it reset to 0
+        assert poller._polls_since_validation == 0
+
+    def test_counter_does_not_trigger_after_recent_validation(
+        self, mock_espn_client: MagicMock
+    ) -> None:
+        """Test validation does not trigger on subsequent polls before interval."""
+        mock_espn_client.get_scoreboard.return_value = []
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+
+        # First poll triggers validation (counter starts at VALIDATION_INTERVAL)
+        poller._poll_league_wrapper("nfl")
+        # Second poll should NOT trigger (counter is at 1 after reset+increment)
+        poller._poll_league_wrapper("nfl")
+
+        assert poller._polls_since_validation == 1
+
+    @patch("precog.schedulers.espn_game_poller.update_game_result")
+    @patch("precog.schedulers.espn_game_poller.get_or_create_game")
+    @patch("precog.schedulers.espn_game_poller.get_team_by_espn_id")
+    @patch("precog.schedulers.espn_game_poller.upsert_game_state")
+    @patch("precog.schedulers.espn_game_poller.create_venue")
+    def test_validation_runs_when_should_validate(
+        self,
+        mock_create_venue: MagicMock,
+        mock_upsert: MagicMock,
+        mock_get_team: MagicMock,
+        mock_get_or_create_game: MagicMock,
+        mock_update_result: MagicMock,
+        mock_espn_client: MagicMock,
+        sample_game_data: dict[str, Any],
+    ) -> None:
+        """Test validation runs on games when _should_validate is True."""
+        mock_espn_client.get_scoreboard.return_value = [sample_game_data]
+        mock_get_team.return_value = {"team_id": 1}
+        mock_create_venue.return_value = 100
+        mock_get_or_create_game.return_value = 42
+
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        # Force validation to run
+        poller._polls_since_validation = ESPNGamePoller.VALIDATION_INTERVAL
+
+        with patch.object(poller._validator, "validate_game_state") as mock_validate:
+            mock_validate.return_value = ValidationResult(game_id="401547417")
+            poller._poll_league_wrapper("nfl")
+
+            # Validator should have been called once per game
+            mock_validate.assert_called_once_with(sample_game_data)
+
+        # Validation stats should be updated
+        assert poller._validation_stats["validation_runs"] == 1
+        assert poller._validation_stats["games_checked_last_cycle"] == 1
+
+    @patch("precog.schedulers.espn_game_poller.update_game_result")
+    @patch("precog.schedulers.espn_game_poller.get_or_create_game")
+    @patch("precog.schedulers.espn_game_poller.get_team_by_espn_id")
+    @patch("precog.schedulers.espn_game_poller.upsert_game_state")
+    @patch("precog.schedulers.espn_game_poller.create_venue")
+    def test_validation_skipped_when_not_due(
+        self,
+        mock_create_venue: MagicMock,
+        mock_upsert: MagicMock,
+        mock_get_team: MagicMock,
+        mock_get_or_create_game: MagicMock,
+        mock_update_result: MagicMock,
+        mock_espn_client: MagicMock,
+        sample_game_data: dict[str, Any],
+    ) -> None:
+        """Test validation is skipped when _should_validate is False."""
+        mock_espn_client.get_scoreboard.return_value = [sample_game_data]
+        mock_get_team.return_value = {"team_id": 1}
+        mock_create_venue.return_value = 100
+        mock_get_or_create_game.return_value = 42
+
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        # Ensure validation does NOT run
+        poller._polls_since_validation = 0
+
+        with patch.object(poller._validator, "validate_game_state") as mock_validate:
+            poller._poll_league_wrapper("nfl")
+
+            mock_validate.assert_not_called()
+
+        # Validation stats should remain at zero
+        assert poller._validation_stats["validation_runs"] == 0
+
+    def test_validation_skipped_on_empty_games(self, mock_espn_client: MagicMock) -> None:
+        """Test validation is skipped when no games returned (even if due)."""
+        mock_espn_client.get_scoreboard.return_value = []
+
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        poller._polls_since_validation = ESPNGamePoller.VALIDATION_INTERVAL
+
+        with patch.object(poller._validator, "validate_game_state") as mock_validate:
+            poller._poll_league_wrapper("nfl")
+
+            mock_validate.assert_not_called()
+
+        assert poller._validation_stats["validation_runs"] == 0
+
+    @patch("precog.schedulers.espn_game_poller.update_game_result")
+    @patch("precog.schedulers.espn_game_poller.get_or_create_game")
+    @patch("precog.schedulers.espn_game_poller.get_team_by_espn_id")
+    @patch("precog.schedulers.espn_game_poller.upsert_game_state")
+    @patch("precog.schedulers.espn_game_poller.create_venue")
+    def test_validation_error_does_not_block_sync(
+        self,
+        mock_create_venue: MagicMock,
+        mock_upsert: MagicMock,
+        mock_get_team: MagicMock,
+        mock_get_or_create_game: MagicMock,
+        mock_update_result: MagicMock,
+        mock_espn_client: MagicMock,
+        sample_game_data: dict[str, Any],
+    ) -> None:
+        """Test validator exception does NOT prevent game sync."""
+        mock_espn_client.get_scoreboard.return_value = [sample_game_data]
+        mock_get_team.return_value = {"team_id": 1}
+        mock_create_venue.return_value = 100
+        mock_get_or_create_game.return_value = 42
+
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        poller._polls_since_validation = ESPNGamePoller.VALIDATION_INTERVAL
+
+        with patch.object(
+            poller._validator,
+            "validate_game_state",
+            side_effect=RuntimeError("Validator exploded"),
+        ):
+            poller._poll_league_wrapper("nfl")
+
+        # Game sync should still have happened
+        mock_upsert.assert_called_once()
+        mock_get_or_create_game.assert_called_once()
+        # Items should be fetched and updated
+        assert poller._stats["items_fetched"] == 1
+        assert poller._stats["items_updated"] == 1
+
+    @patch("precog.schedulers.espn_game_poller.update_game_result")
+    @patch("precog.schedulers.espn_game_poller.get_or_create_game")
+    @patch("precog.schedulers.espn_game_poller.get_team_by_espn_id")
+    @patch("precog.schedulers.espn_game_poller.upsert_game_state")
+    @patch("precog.schedulers.espn_game_poller.create_venue")
+    def test_validation_stats_accumulate(
+        self,
+        mock_create_venue: MagicMock,
+        mock_upsert: MagicMock,
+        mock_get_team: MagicMock,
+        mock_get_or_create_game: MagicMock,
+        mock_update_result: MagicMock,
+        mock_espn_client: MagicMock,
+        sample_game_data: dict[str, Any],
+    ) -> None:
+        """Test validation stats accumulate across multiple poll cycles."""
+        mock_espn_client.get_scoreboard.return_value = [sample_game_data]
+        mock_get_team.return_value = {"team_id": 1}
+        mock_create_venue.return_value = 100
+        mock_get_or_create_game.return_value = 42
+
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+
+        # Create a result with one error
+        error_result = ValidationResult(game_id="401547417")
+        error_result.add_error("home_score", "Negative score", value=-1)
+
+        with patch.object(poller._validator, "validate_game_state", return_value=error_result):
+            # Run two validation cycles
+            poller._polls_since_validation = ESPNGamePoller.VALIDATION_INTERVAL
+            poller._poll_league_wrapper("nfl")
+            poller._polls_since_validation = ESPNGamePoller.VALIDATION_INTERVAL
+            poller._poll_league_wrapper("nfl")
+
+        # Errors should accumulate
+        assert poller._validation_stats["validation_errors"] == 2
+        assert poller._validation_stats["validation_runs"] == 2
+
+    @patch("precog.schedulers.espn_game_poller.update_game_result")
+    @patch("precog.schedulers.espn_game_poller.get_or_create_game")
+    @patch("precog.schedulers.espn_game_poller.get_team_by_espn_id")
+    @patch("precog.schedulers.espn_game_poller.upsert_game_state")
+    @patch("precog.schedulers.espn_game_poller.create_venue")
+    def test_error_rate_escalation_error_level(
+        self,
+        mock_create_venue: MagicMock,
+        mock_upsert: MagicMock,
+        mock_get_team: MagicMock,
+        mock_get_or_create_game: MagicMock,
+        mock_update_result: MagicMock,
+        mock_espn_client: MagicMock,
+        sample_game_data: dict[str, Any],
+    ) -> None:
+        """Test error-level logging when error rate >= VALIDATION_ERROR_RATE."""
+        mock_espn_client.get_scoreboard.return_value = [sample_game_data]
+        mock_get_team.return_value = {"team_id": 1}
+        mock_create_venue.return_value = 100
+        mock_get_or_create_game.return_value = 42
+
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        poller._polls_since_validation = ESPNGamePoller.VALIDATION_INTERVAL
+
+        # 1 game with error = 100% error rate (> 25% threshold)
+        error_result = ValidationResult(game_id="401547417")
+        error_result.add_error("home_score", "Negative score", value=-1)
+
+        with patch.object(poller._validator, "validate_game_state", return_value=error_result):
+            with patch("precog.schedulers.espn_game_poller.logger") as mock_logger:
+                poller._poll_league_wrapper("nfl")
+                # Should have logged at ERROR level for the aggregate
+                mock_logger.error.assert_any_call(
+                    "ESPN validation [%s]: ERROR RATE %.1f%% - %d/%d games failed "
+                    "(%d errors, %d warnings) [ACTION: investigate data source]",
+                    "NFL",
+                    100.0,
+                    1,
+                    1,
+                    1,
+                    0,
+                )
+
+        assert poller._validation_stats["error_rate_pct_last_cycle"] == 100.0
+
+    @patch("precog.schedulers.espn_game_poller.update_game_result")
+    @patch("precog.schedulers.espn_game_poller.get_or_create_game")
+    @patch("precog.schedulers.espn_game_poller.get_team_by_espn_id")
+    @patch("precog.schedulers.espn_game_poller.upsert_game_state")
+    @patch("precog.schedulers.espn_game_poller.create_venue")
+    def test_warning_only_games_counted_correctly(
+        self,
+        mock_create_venue: MagicMock,
+        mock_upsert: MagicMock,
+        mock_get_team: MagicMock,
+        mock_get_or_create_game: MagicMock,
+        mock_update_result: MagicMock,
+        mock_espn_client: MagicMock,
+        sample_game_data: dict[str, Any],
+    ) -> None:
+        """Test warnings-only results count toward warnings not errors."""
+        mock_espn_client.get_scoreboard.return_value = [sample_game_data]
+        mock_get_team.return_value = {"team_id": 1}
+        mock_create_venue.return_value = 100
+        mock_get_or_create_game.return_value = 42
+
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        poller._polls_since_validation = ESPNGamePoller.VALIDATION_INTERVAL
+
+        # Result with warnings only (no errors)
+        warn_result = ValidationResult(game_id="401547417")
+        warn_result.add_warning("clock_seconds", "Unusual clock value")
+
+        with patch.object(poller._validator, "validate_game_state", return_value=warn_result):
+            poller._poll_league_wrapper("nfl")
+
+        assert poller._validation_stats["validation_errors"] == 0
+        assert poller._validation_stats["validation_warnings"] == 1
+        assert poller._validation_stats["error_rate_pct_last_cycle"] == 0.0
+
+    def test_wrapper_counter_increments(self, mock_espn_client: MagicMock) -> None:
+        """Test _poll_league_wrapper increments the validation counter each call."""
+        mock_espn_client.get_scoreboard.return_value = []
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        # Reset counter to 0
+        poller._polls_since_validation = 0
+
+        poller._poll_league_wrapper("nfl")
+        assert poller._polls_since_validation == 1
+
+        poller._poll_league_wrapper("nfl")
+        assert poller._polls_since_validation == 2
+
+    def test_wrapper_counter_resets_at_interval(self, mock_espn_client: MagicMock) -> None:
+        """Test counter resets to 0 when VALIDATION_INTERVAL reached."""
+        mock_espn_client.get_scoreboard.return_value = []
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        # Set counter just below threshold
+        poller._polls_since_validation = ESPNGamePoller.VALIDATION_INTERVAL - 1
+
+        poller._poll_league_wrapper("nfl")
+
+        assert poller._polls_since_validation == 0
+
+
+class TestDataGapDetection:
+    """Tests for per-league last_successful_poll tracking and data gap detection.
+
+    The supervisor's _determine_health() checks stats["last_successful_poll"]
+    for staleness. These tests verify the key is set correctly.
+    """
+
+    def test_last_successful_poll_initialized_none(self, mock_espn_client: MagicMock) -> None:
+        """Test last_successful_poll starts as None."""
+        poller = ESPNGamePoller(espn_client=mock_espn_client)
+        stats = poller.get_stats()
+
+        assert stats["last_successful_poll"] is None
+        assert stats["league_last_successful_poll"] == {}
+
+    @patch("precog.schedulers.espn_game_poller.update_game_result")
+    @patch("precog.schedulers.espn_game_poller.get_or_create_game")
+    @patch("precog.schedulers.espn_game_poller.get_team_by_espn_id")
+    @patch("precog.schedulers.espn_game_poller.upsert_game_state")
+    @patch("precog.schedulers.espn_game_poller.create_venue")
+    def test_last_successful_poll_set_on_success(
+        self,
+        mock_create_venue: MagicMock,
+        mock_upsert: MagicMock,
+        mock_get_team: MagicMock,
+        mock_get_or_create_game: MagicMock,
+        mock_update_result: MagicMock,
+        mock_espn_client: MagicMock,
+        sample_game_data: dict[str, Any],
+    ) -> None:
+        """Test last_successful_poll is set after a clean poll."""
+        mock_espn_client.get_scoreboard.return_value = [sample_game_data]
+        mock_get_team.return_value = {"team_id": 1}
+        mock_create_venue.return_value = 100
+        mock_get_or_create_game.return_value = 42
+
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        poller._polls_since_validation = 0
+
+        poller._poll_league_wrapper("nfl")
+
+        stats = poller.get_stats()
+        assert stats["last_successful_poll"] is not None
+        assert stats["league_last_successful_poll"]["nfl"] is not None
+
+    def test_last_successful_poll_not_set_on_api_error(self, mock_espn_client: MagicMock) -> None:
+        """Test last_successful_poll is NOT set when ESPN API fails."""
+        mock_espn_client.get_scoreboard.side_effect = Exception("API down")
+
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        poller._polls_since_validation = 0
+
+        poller._poll_league_wrapper("nfl")
+
+        stats = poller.get_stats()
+        assert stats["last_successful_poll"] is None
+
+    @patch("precog.schedulers.espn_game_poller.update_game_result")
+    @patch("precog.schedulers.espn_game_poller.get_or_create_game")
+    @patch("precog.schedulers.espn_game_poller.get_team_by_espn_id")
+    @patch("precog.schedulers.espn_game_poller.upsert_game_state")
+    @patch("precog.schedulers.espn_game_poller.create_venue")
+    def test_per_league_timestamps_independent(
+        self,
+        mock_create_venue: MagicMock,
+        mock_upsert: MagicMock,
+        mock_get_team: MagicMock,
+        mock_get_or_create_game: MagicMock,
+        mock_update_result: MagicMock,
+        mock_espn_client: MagicMock,
+        sample_game_data: dict[str, Any],
+    ) -> None:
+        """Test each league gets its own timestamp."""
+        mock_espn_client.get_scoreboard.return_value = [sample_game_data]
+        mock_get_team.return_value = {"team_id": 1}
+        mock_create_venue.return_value = 100
+        mock_get_or_create_game.return_value = 42
+
+        poller = ESPNGamePoller(
+            leagues=["nfl", "nba"],
+            espn_client=mock_espn_client,
+        )
+        poller._polls_since_validation = 0
+
+        poller._poll_league_wrapper("nfl")
+
+        stats = poller.get_stats()
+        assert "nfl" in stats["league_last_successful_poll"]
+        assert "nba" not in stats["league_last_successful_poll"]
+
+    @patch("precog.schedulers.espn_game_poller.update_game_result")
+    @patch("precog.schedulers.espn_game_poller.get_or_create_game")
+    @patch("precog.schedulers.espn_game_poller.get_team_by_espn_id")
+    @patch("precog.schedulers.espn_game_poller.upsert_game_state")
+    @patch("precog.schedulers.espn_game_poller.create_venue")
+    def test_last_successful_poll_not_set_on_sync_errors(
+        self,
+        mock_create_venue: MagicMock,
+        mock_upsert: MagicMock,
+        mock_get_team: MagicMock,
+        mock_get_or_create_game: MagicMock,
+        mock_update_result: MagicMock,
+        mock_espn_client: MagicMock,
+        sample_game_data: dict[str, Any],
+    ) -> None:
+        """Test last_successful_poll not updated when sync errors occur."""
+        mock_espn_client.get_scoreboard.return_value = [sample_game_data]
+        mock_get_team.return_value = {"team_id": 1}
+        mock_create_venue.return_value = 100
+        mock_get_or_create_game.return_value = 42
+        mock_upsert.side_effect = Exception("DB write failed")
+
+        poller = ESPNGamePoller(
+            leagues=["nfl"],
+            espn_client=mock_espn_client,
+        )
+        poller._polls_since_validation = 0
+
+        poller._poll_league_wrapper("nfl")
+
+        stats = poller.get_stats()
+        assert stats["last_successful_poll"] is None


### PR DESCRIPTION
## Summary
- **D1**: Wire ESPNDataValidator into production `espn_game_poller` — rate-limited (every 20 polls), soft validation with error-rate escalation logging, mirrors Kalshi pattern
- **D2**: Per-league `last_successful_poll` tracking enables supervisor staleness detection (degraded at 2x interval, down at 5x, circuit breaker auto-trip)
- **D3**: `clock_seconds` float→Decimal at ESPN client source (Pattern 1 compliance), removed `Decimal(str())` workaround in poller
- **T1**: 10 Hypothesis property tests for `validate_decimal` (identity, rejection, error message quality — 800+ generated cases)
- **T3**: 20 credential-independent E2E tests for ServiceSupervisor lifecycle (DB IPC, health checks, circuit breakers, alerts, thread cleanup)

## Key Fix
ESPN validation counter was placed in `_poll_once()` which is **never called** by the per-league APScheduler — moved to `_poll_league_wrapper()` where actual execution happens. Caught during code review.

## Agent Review Trail
| Agent | Role | Finding | Grade |
|-------|------|---------|-------|
| Case | Builder (T5) | 20 E2E lifecycle tests | B |
| Spock | Reviewer (T5) | B1: mock start() doesn't reset counters, B2: conditional assertion silently passes | A- |
| Case | Builder (T1) | ESPN validation wiring, 15 tests | B+ |
| Explore | Reviewer (T1) | **CRITICAL**: _poll_once() dead code — counter never fires in production | A |
| Samwise | Builder (D3) | clock_seconds Decimal at source, 6 files | A |

## Test Plan
- [x] 2514 unit tests pass
- [x] 1002 integration + E2E pass (includes 20 new supervisor lifecycle E2E)
- [x] 1056 stress/chaos/race pass
- [x] 10 new Hypothesis property tests (800+ generated cases)
- [x] All pre-commit hooks pass (17/17)
- [ ] CI runs property + security + performance suites

Closes C4 items: D1, D2, D3, T1, T3

🤖 Generated with [Claude Code](https://claude.com/claude-code)