### PR TITLE
fix: Claude Review + S68 bugs — race condition, blocking acquire, priority wiring

### DIFF
--- a/src/precog/api_connectors/espn_client.py
+++ b/src/precog/api_connectors/espn_client.py
@@ -785,8 +785,11 @@ class ESPNClient:
         Returns:
             List of parsed ESPNGameFull dicts with metadata/state structure
         """
-        # Acquire rate limit token (blocks if bucket empty)
-        self.rate_limiter.acquire()
+        # Non-blocking acquire: raise immediately if bucket empty (preserves old contract)
+        if not self.rate_limiter.acquire(block=False):
+            raise RateLimitExceededError(
+                "ESPN rate limit exceeded (token bucket empty). Try again shortly."
+            )
 
         # Build URL with optional date parameter
         url = self.ENDPOINTS[league]

--- a/src/precog/backup/orchestrator.py
+++ b/src/precog/backup/orchestrator.py
@@ -25,6 +25,7 @@ import platform
 import shutil
 import subprocess
 import tempfile
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -143,7 +144,7 @@ class BackupOrchestrator:
             if result.returncode == 0:
                 # Parse "abc123 (head)" format
                 for line in result.stdout.strip().splitlines():
-                    if "head" in line or line.strip():
+                    if "head" in line:
                         return line.strip().split()[0]
         except Exception as e:
             logger.debug("Could not determine migration head: %s", e)
@@ -278,16 +279,7 @@ class BackupOrchestrator:
 
                 # Step 4: Store via backend
                 storage_id = self._backend.store(dump_path, metadata)
-                metadata = BackupMetadata(
-                    **{
-                        **metadata.to_dict(),
-                        "storage_id": storage_id,
-                        "backup_type": metadata.backup_type,
-                        "status": metadata.status,
-                        "created_at": metadata.created_at,
-                        "completed_at": metadata.completed_at,
-                    }
-                )
+                metadata = replace(metadata, storage_id=storage_id)
 
                 logger.info(
                     "Backup complete: %s (%d bytes, checksum=%s, verified=%s)",
@@ -546,8 +538,6 @@ class BackupOrchestrator:
             logger.info("pg_restore completed successfully")
         except subprocess.TimeoutExpired as e:
             raise BackupError(f"pg_restore timed out after {_PG_TIMEOUT}s.") from e
-        except subprocess.CalledProcessError as e:
-            raise BackupError(f"pg_restore failed:\n  stderr: {e.stderr}") from e
 
     def _record_health(
         self,

--- a/src/precog/cli/scheduler.py
+++ b/src/precog/cli/scheduler.py
@@ -294,6 +294,9 @@ def _start_supervised_mode(
         raise typer.Exit(code=1)
 
     try:
+        # Create priority calculator for ESPN adaptive polling
+        priority_calculator = _create_priority_calculator()
+
         # Create supervisor using factory function
         _supervisor = create_supervisor(
             environment=supervisor_env,
@@ -304,6 +307,7 @@ def _start_supervised_mode(
             espn_poll_interval=espn_interval,
             kalshi_poll_interval=kalshi_interval,
             health_check_interval=health_interval,
+            priority_calculator=priority_calculator,
         )
 
         # Register alert callback for console output

--- a/src/precog/database/crud_account.py
+++ b/src/precog/database/crud_account.py
@@ -167,30 +167,47 @@ def update_account_balance_with_versioning(
     if not isinstance(new_balance, Decimal):
         raise ValueError(f"Balance must be Decimal, got {type(new_balance).__name__}")
 
-    # Step 1: Close current row (set row_current_ind = FALSE, row_end_ts = NOW)
+    # Step 0: Lock current row to prevent concurrent close→insert races.
+    # Without FOR UPDATE, two concurrent calls can both close the current row
+    # before either inserts, leaving zero current rows for the platform.
+    lock_query = """
+        SELECT id FROM account_balance
+        WHERE platform_id = %s AND row_current_ind = TRUE
+        FOR UPDATE
+    """
+
+    # Step 1: Close current row — use a single NOW() for temporal continuity
+    # between the old row's end and new row's start.
     close_query = """
         UPDATE account_balance
         SET row_current_ind = FALSE,
-            row_end_ts = NOW()
+            row_end_ts = %s
         WHERE platform_id = %s AND row_current_ind = TRUE
     """
 
-    # Step 2: Insert new balance record with row_start_ts
+    # Step 2: Insert new balance record with matching row_start_ts
     insert_query = """
         INSERT INTO account_balance (
             platform_id, balance, currency,
             row_current_ind, row_start_ts, created_at
         )
-        VALUES (%s, %s, %s, TRUE, NOW(), NOW())
+        VALUES (%s, %s, %s, TRUE, %s, %s)
         RETURNING id
     """
 
     with get_cursor(commit=True) as cur:
+        # Capture timestamp once for temporal continuity
+        cur.execute("SELECT NOW() AS ts")
+        now = cur.fetchone()["ts"]
+
+        # Lock current row (serializes concurrent updates)
+        cur.execute(lock_query, (platform_id,))
+
         # Close old balance version
-        cur.execute(close_query, (platform_id,))
+        cur.execute(close_query, (now, platform_id))
 
         # Insert new balance version
-        cur.execute(insert_query, (platform_id, new_balance, currency))
+        cur.execute(insert_query, (platform_id, new_balance, currency, now, now))
         result = cur.fetchone()
         return result["id"] if result else None
 

--- a/src/precog/schedulers/espn_game_poller.py
+++ b/src/precog/schedulers/espn_game_poller.py
@@ -685,7 +685,8 @@ class ESPNGamePoller(BasePoller):
                         self._validator.validate_game_state(game) for game in games
                     ]
                     error_count = sum(1 for r in validation_results if r.has_errors)
-                    warning_count = sum(
+                    # Games with warnings but no errors (error-only games are in error_count)
+                    warning_only_count = sum(
                         1 for r in validation_results if r.has_warnings and not r.has_errors
                     )
                     total_checked = len(games)
@@ -696,32 +697,32 @@ class ESPNGamePoller(BasePoller):
                     if error_rate >= self.VALIDATION_ERROR_RATE:
                         logger.error(
                             "ESPN validation [%s]: ERROR RATE %.1f%% - %d/%d games failed "
-                            "(%d errors, %d warnings) [ACTION: investigate data source]",
+                            "(%d errors, %d warning-only) [ACTION: investigate data source]",
                             league.upper(),
                             error_rate * 100,
                             error_count,
                             total_checked,
                             error_count,
-                            warning_count,
+                            warning_only_count,
                         )
                     elif error_rate >= self.VALIDATION_WARN_RATE:
                         logger.warning(
                             "ESPN validation [%s]: error rate %.1f%% - %d/%d games failed "
-                            "(%d errors, %d warnings)",
+                            "(%d errors, %d warning-only)",
                             league.upper(),
                             error_rate * 100,
                             error_count,
                             total_checked,
                             error_count,
-                            warning_count,
+                            warning_only_count,
                         )
-                    elif error_count or warning_count:
+                    elif error_count or warning_only_count:
                         logger.info(
-                            "ESPN validation [%s]: %d games checked, %d errors, %d warnings",
+                            "ESPN validation [%s]: %d games checked, %d errors, %d warning-only",
                             league.upper(),
                             total_checked,
                             error_count,
-                            warning_count,
+                            warning_only_count,
                         )
                     else:
                         logger.debug(
@@ -733,7 +734,7 @@ class ESPNGamePoller(BasePoller):
                     # Track cumulative validation stats
                     with self._lock:
                         self._validation_stats["validation_errors"] += error_count
-                        self._validation_stats["validation_warnings"] += warning_count
+                        self._validation_stats["validation_warnings"] += warning_only_count
                         self._validation_stats["validation_runs"] += 1
                         self._validation_stats["games_checked_last_cycle"] = total_checked
                         self._validation_stats["error_rate_pct_last_cycle"] = round(
@@ -1680,6 +1681,7 @@ def create_espn_poller(
     idle_interval: int = 300,
     persist_jobs: bool = False,
     job_store_url: str | None = None,
+    priority_calculator: Any | None = None,
 ) -> ESPNGamePoller:
     """
     Factory function to create a configured ESPNGamePoller.
@@ -1718,6 +1720,7 @@ def create_espn_poller(
         idle_interval=idle_interval,
         persist_jobs=persist_jobs,
         job_store_url=job_store_url,
+        priority_calculator=priority_calculator,
     )
 
 

--- a/src/precog/schedulers/kalshi_poller.py
+++ b/src/precog/schedulers/kalshi_poller.py
@@ -730,14 +730,15 @@ class KalshiMarketPoller(BasePoller):
                     cast("list[dict[str, Any]]", all_markets)
                 )
                 error_count = sum(1 for r in validation_results if r.has_errors)
-                warning_count = sum(
+                # Markets with warnings but no errors (error markets are in error_count)
+                warning_only_count = sum(
                     1 for r in validation_results if r.has_warnings and not r.has_errors
                 )
                 valid_count = len(all_markets) - error_count
 
                 # Build warning type breakdown by field (#485)
                 warning_breakdown: dict[str, int] = {}
-                if warning_count:
+                if warning_only_count:
                     for vr in validation_results:
                         for issue in vr.warnings:
                             warning_breakdown[issue.field] = (
@@ -776,13 +777,13 @@ class KalshiMarketPoller(BasePoller):
                 if error_rate >= self.VALIDATION_ERROR_RATE:
                     logger.error(
                         "Validation [%s]: ERROR RATE %.1f%% - %d/%d markets failed "
-                        "(%d errors, %d warnings%s) [ACTION: investigate data source]",
+                        "(%d errors, %d warning-only%s) [ACTION: investigate data source]",
                         series_ticker,
                         error_rate * 100,
                         error_count,
                         total_checked,
                         error_count,
-                        warning_count,
+                        warning_only_count,
                         warning_detail,
                     )
                     try:
@@ -801,23 +802,23 @@ class KalshiMarketPoller(BasePoller):
                 elif error_rate >= self.VALIDATION_WARN_RATE:
                     logger.warning(
                         "Validation [%s]: error rate %.1f%% - %d/%d markets failed "
-                        "(%d errors, %d warnings%s)",
+                        "(%d errors, %d warning-only%s)",
                         series_ticker,
                         error_rate * 100,
                         error_count,
                         total_checked,
                         error_count,
-                        warning_count,
+                        warning_only_count,
                         warning_detail,
                     )
-                elif error_count or warning_count:
+                elif error_count or warning_only_count:
                     logger.info(
-                        "Validation [%s]: %d markets checked, %d valid, %d errors, %d warnings%s",
+                        "Validation [%s]: %d markets checked, %d valid, %d errors, %d warning-only%s",
                         series_ticker,
                         total_checked,
                         valid_count,
                         error_count,
-                        warning_count,
+                        warning_only_count,
                         warning_detail,
                     )
                 else:
@@ -830,9 +831,9 @@ class KalshiMarketPoller(BasePoller):
                 # Track validation stats
                 with self._lock:
                     self._validation_stats["validation_errors"] += error_count
-                    self._validation_stats["validation_warnings"] += warning_count
+                    self._validation_stats["validation_warnings"] += warning_only_count
                     self._validation_stats["validation_errors_last_cycle"] = error_count
-                    self._validation_stats["validation_warnings_last_cycle"] = warning_count
+                    self._validation_stats["validation_warnings_last_cycle"] = warning_only_count
                     self._validation_stats["markets_checked_last_cycle"] = total_checked
                     self._validation_stats["error_rate_pct_last_cycle"] = round(error_rate * 100, 1)
             except Exception as e:

--- a/src/precog/schedulers/service_supervisor.py
+++ b/src/precog/schedulers/service_supervisor.py
@@ -1143,6 +1143,7 @@ def _create_espn(
     config: RunnerConfig,
     leagues: list[str] | None = None,
     espn_poll_interval: int = 30,
+    priority_calculator: Any | None = None,
     **_kwargs: Any,
 ) -> EventLoopService:
     """Factory for ESPN Game Poller."""
@@ -1151,6 +1152,7 @@ def _create_espn(
         create_espn_poller(
             leagues=leagues,
             poll_interval=espn_poll_interval,
+            priority_calculator=priority_calculator,
         ),
     )
 
@@ -1217,6 +1219,7 @@ def create_services(
     series_tickers: list[str] | None = None,
     espn_poll_interval: int = 30,
     kalshi_poll_interval: int = 15,
+    priority_calculator: Any | None = None,
 ) -> dict[str, tuple[EventLoopService, ServiceConfig]]:
     """
     Create service instances based on configuration.
@@ -1260,6 +1263,7 @@ def create_services(
                 series_tickers=series_tickers,
                 espn_poll_interval=espn_poll_interval,
                 kalshi_poll_interval=kalshi_poll_interval,
+                priority_calculator=priority_calculator,
             )
 
             if service is not None:
@@ -1285,6 +1289,7 @@ def create_supervisor(
     kalshi_poll_interval: int = 15,
     health_check_interval: int = 60,
     metrics_interval: int = 300,
+    priority_calculator: Any | None = None,
 ) -> ServiceSupervisor:
     """
     Create and configure a ServiceSupervisor with services.
@@ -1330,6 +1335,7 @@ def create_supervisor(
         series_tickers=series_tickers,
         espn_poll_interval=espn_poll_interval,
         kalshi_poll_interval=kalshi_poll_interval,
+        priority_calculator=priority_calculator,
     )
 
     # Create supervisor

--- a/src/precog/validation/kalshi_validation.py
+++ b/src/precog/validation/kalshi_validation.py
@@ -1261,7 +1261,8 @@ class KalshiDataValidator:
         total = len(results)
         valid_count = sum(1 for r in results if r.is_valid)
         error_count = sum(1 for r in results if r.has_errors)
-        warning_count = sum(1 for r in results if r.has_warnings and not r.has_errors)
+        # Entities with warnings-only (excludes entities also having errors)
+        warning_only_count = sum(1 for r in results if r.has_warnings and not r.has_errors)
 
         all_errors = [
             {"entity": r.entity_id, "issue": str(issue)} for r in results for issue in r.errors
@@ -1275,7 +1276,7 @@ class KalshiDataValidator:
             "total": total,
             "valid_count": valid_count,
             "error_count": error_count,
-            "warning_count": warning_count,
+            "warning_only_count": warning_only_count,
             "valid_percentage": (valid_count / total * 100) if total > 0 else 100,
             "errors": all_errors[:10],  # Limit to first 10
             "warnings": all_warnings[:10],  # Limit to first 10

--- a/tests/e2e/validation/test_kalshi_validation_e2e.py
+++ b/tests/e2e/validation/test_kalshi_validation_e2e.py
@@ -319,4 +319,4 @@ class TestCompleteValidationSummary:
         assert summary["total"] == 3
         assert summary["valid_count"] == 2
         assert "error_count" in summary
-        assert "warning_count" in summary
+        assert "warning_only_count" in summary

--- a/tests/unit/schedulers/test_espn_game_poller_unit.py
+++ b/tests/unit/schedulers/test_espn_game_poller_unit.py
@@ -1814,7 +1814,7 @@ class TestESPNDataValidationWiring:
                 # Should have logged at ERROR level for the aggregate
                 mock_logger.error.assert_any_call(
                     "ESPN validation [%s]: ERROR RATE %.1f%% - %d/%d games failed "
-                    "(%d errors, %d warnings) [ACTION: investigate data source]",
+                    "(%d errors, %d warning-only) [ACTION: investigate data source]",
                     "NFL",
                     100.0,
                     1,


### PR DESCRIPTION
## Summary

Session 42c: 7 fixes from Claude Review CI triage (PRs #585, #597) + 3 S68 priority-high bugs.

- **#587**: `account_balance` SCD race condition — added `SELECT ... FOR UPDATE` row lock + single `NOW()` for temporal continuity
- **#586**: ESPN `acquire()` blocking scheduler thread — restored non-blocking `RateLimitExceededError` contract
- **#588**: `priority_calculator` dead in production — threaded through supervised mode factory chain
- **Backup**: `_get_migration_head` parsing bug, fragile `to_dict()` spread → `dataclasses.replace()`, dead except removal
- **Pollers**: `warning_count` → `warning_only_count` for accurate operator log semantics

Closes #586, closes #587, closes #588. Closes #595 (false positive — teams not SCD Type 2).

Filed: #598 (shared validation counter), #599 (partial sync success), #600 (backup system gaps).

## Agent Review Trail

| Agent | Role | Verdict | Key Finding |
|-------|------|---------|-------------|
| Spock | Reviewer | APPROVE | All 7 fixes correct. FOR UPDATE lock safe with get_cursor(commit=True). No scope gaps. |
| Ripley | Sentinel | PASS | 574 targeted tests pass. FOR UPDATE on zero rows is safe (first balance). RateLimitExceededError caught at 3 call sites. |

## Test Plan

- [x] 2549 unit tests pass
- [x] 1002 integration + E2E tests pass (20 skipped)
- [x] 1056 stress/chaos/race tests pass
- [x] Ruff lint + format clean
- [x] Mypy type check pass
- [x] All 14 pre-commit hooks pass
- [ ] CI property + security + performance tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)