### PR TITLE
feat: Pre-push docs-only fast path skips test gate (#616)

### DIFF
--- a/scripts/pre-push-validation.sh
+++ b/scripts/pre-push-validation.sh
@@ -131,6 +131,96 @@ export PRECOG_ENV=test
 find tests/ -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
 
 # ==============================================================================
+# STEP 0.5: Docs-Only Fast Path (#616)
+# ==============================================================================
+# If 100% of changed files match documentation patterns, skip the test gate.
+#
+# Why this is safe:
+#   - Pre-commit hooks (.pre-commit-config.yaml) already enforce credential
+#     scans, file size limits, EOF, trailing whitespace, and merge markers at
+#     COMMIT time, so the pre-push test gate adds zero safety value for pushes
+#     that touch only markdown/text files.
+#   - Branch verification (above) still runs.
+#   - Pre-commit ran on every individual commit before this push.
+#
+# Detection uses STRICT EXTENSION/FILENAME matching ONLY (no directory prefixes).
+# This is intentional: a .py file inside docs/ (e.g., a renamed module) MUST
+# trigger the full gate, even though its parent directory is "docs/". The issue
+# body explicitly warned about this failure mode.
+#
+# A file qualifies as docs ONLY if it matches:
+#   - Extensions: .md, .txt, .rst (anywhere in the tree)
+#   - Special filenames at any path: README, README.{md,txt,rst,...},
+#     LICENSE, LICENSE.{md,txt,rst,...}, AUTHORS, CHANGELOG, CHANGELOG.{...}
+#
+# Any other file — .py, .yaml, .toml, .cfg, .ini, .sh, .sql, .json, .zip,
+# binary blobs, etc. — triggers the full gate. We err on the side of running
+# the gate when in doubt.
+#
+# Override: SKIP_DOCS_FAST_PATH=1 git push  (forces full gate even on docs)
+#
+# Reference: issue #616, memory/feedback_pre_push_docs_only_skip.md
+if [[ "${SKIP_DOCS_FAST_PATH:-0}" != "1" ]]; then
+    # Get the list of files changed in this push.
+    # Try multiple strategies to handle: existing branch with upstream, new
+    # branch first push, no upstream configured, etc.
+    CHANGED_FILES=""
+
+    # Strategy 1: against upstream tracking branch (existing branch with @{u})
+    if git rev-parse --abbrev-ref --symbolic-full-name @{u} > /dev/null 2>&1; then
+        CHANGED_FILES=$(git diff --name-only @{u}..HEAD 2>/dev/null || true)
+    fi
+
+    # Strategy 2: against merge-base with origin/main (new branch first push)
+    if [[ -z "$CHANGED_FILES" ]]; then
+        MERGE_BASE=$(git merge-base HEAD origin/main 2>/dev/null || true)
+        if [[ -n "$MERGE_BASE" ]]; then
+            CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" HEAD 2>/dev/null || true)
+        fi
+    fi
+
+    # Strategy 3: just the last commit (final fallback)
+    if [[ -z "$CHANGED_FILES" ]]; then
+        CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+    fi
+
+    if [[ -n "$CHANGED_FILES" ]]; then
+        # Find any file that does NOT match docs/markdown patterns.
+        # If this returns even one line, the fast path does NOT activate.
+        # Strict extension/filename matching — directory prefix is irrelevant.
+        # This was tested with: docs/foo.md (docs), docs/foo.py (NOT docs),
+        # CLAUDE.md (docs), config/trading.yaml (NOT docs).
+        NON_DOCS=$(echo "$CHANGED_FILES" | grep -vE '(\.md$|\.txt$|\.rst$|^README$|^README\.[a-z]+$|^LICENSE$|^LICENSE\.[a-z]+$|^AUTHORS$|^CHANGELOG$|^CHANGELOG\.[a-z]+$)' | head -1 || true)
+
+        if [[ -z "$NON_DOCS" ]]; then
+            echo ""
+            echo "Docs-only push detected (#616) — skipping test gate."
+            echo ""
+            echo "Changed files (all match docs patterns):"
+            echo "$CHANGED_FILES" | sed 's/^/  /'
+            echo ""
+            echo "Pre-commit hooks (credential scan, EOF, whitespace, file size)"
+            echo "already ran at commit time. Test gate adds no safety value here."
+            echo ""
+            echo "To force full gate: SKIP_DOCS_FAST_PATH=1 git push"
+            echo ""
+
+            END_TIME=$(date +%s)
+            TOTAL_DURATION=$((END_TIME - START_TIME))
+            echo "Pre-push fast path complete (${TOTAL_DURATION}s)."
+
+            echo "" >> "$LOG_FILE"
+            echo "========================================" >> "$LOG_FILE"
+            echo "DOCS-ONLY FAST PATH: PASSED (${TOTAL_DURATION}s)" >> "$LOG_FILE"
+            echo "Changed files:" >> "$LOG_FILE"
+            echo "$CHANGED_FILES" >> "$LOG_FILE"
+
+            exit 0
+        fi
+    fi
+fi
+
+# ==============================================================================
 # STEP 1: Unit Tests (parallel, no DB)
 # ==============================================================================
 echo "Running tests (verbose output logged to $LOG_FILE)..."


### PR DESCRIPTION
## Summary

Adds a docs-only fast path to `scripts/pre-push-validation.sh` that detects when 100% of changed files match documentation patterns and skips the ~13-minute test gate. Documentation-only commits cannot affect the test suite by definition; the gate adds zero safety value for them.

This was the friction event that triggered #616: PRs #612 and #615 (both pure markdown changes) had to wait through the full test gate, and #615 even failed on flaky race tests completely unrelated to the docs change, requiring a 30-minute detour to fix the race tests just to push a documentation commit.

## Detection Logic — Strict Extension Matching

A file qualifies as docs **only** if it matches:
- **Extensions:** `.md`, `.txt`, `.rst` (anywhere in the tree)
- **Special filenames:** `README`, `README.<ext>`, `LICENSE`, `LICENSE.<ext>`, `AUTHORS`, `CHANGELOG`, `CHANGELOG.<ext>`

Any other file (`.py`, `.yaml`, `.toml`, `.cfg`, `.ini`, `.sh`, `.sql`, `.json`, `.zip`, binaries) triggers the full gate.

**Critically: directory prefixes are ignored.** A `.py` file inside `docs/` (e.g., a renamed module) triggers the full gate even though its parent directory is `docs/`. The original issue body explicitly warned about this failure mode; my first regex draft used `^docs/` as a docs pattern and incorrectly classified `docs/foo.py` as docs-only. Fixed before committing — see test case 4 below.

## Why This Is Safe

- **Pre-commit hooks** (`.pre-commit-config.yaml`) already enforce credential scans, file size limits, EOF, trailing whitespace, and merge marker checks at **commit time**, so docs-only pushes lose no security coverage.
- **Branch verification** still runs at push time.
- **Pre-commit ran on every individual commit** before this push.

The pre-push hook's only job in this codebase is the test gate (unit / integration+e2e / stress+chaos+race). Skipping that gate for docs-only pushes is genuinely risk-free.

## Override Mechanism

```bash
SKIP_DOCS_FAST_PATH=1 git push
```

Forces the full gate even on docs-only changes. Useful for paranoia, for verifying the gate still runs after hook modifications, or for debugging the fast path itself.

## Multi-Strategy Diff Detection

Three fallback strategies handle different push contexts:
1. **Existing branch with upstream tracking:** `git diff --name-only @{u}..HEAD`
2. **New branch first push:** `git diff --name-only $(git merge-base HEAD origin/main) HEAD`
3. **Final fallback:** `git diff --name-only HEAD~1 HEAD`

## Manual Validation — 7 Test Cases

| # | Input | Expected | Actual | Result |
|---|---|---|---|---|
| 1 | docs/foo.md, CLAUDE.md, README.md, docs/bar/baz.md, _archive/old.md, LICENSE, CHANGELOG.txt | empty (fast path) | empty | PASS |
| 2 | src/precog/foo.py, tests/unit/foo.py, scripts/audit.sh | full gate | src/precog/foo.py | PASS |
| 3 | docs/foo.md + src/precog/bar.py | full gate | src/precog/bar.py | PASS |
| 4 | **docs/foo.py (the bug case)** | full gate | docs/foo.py | **PASS — bug fixed** |
| 5 | config/trading.yaml | full gate | config/trading.yaml | PASS |
| 6 | src/precog/README.md (nested README) | empty (fast path) | empty | PASS |
| 7 | bare README at root | empty (fast path) | empty | PASS |

The first regex draft was: `(^docs/|^_archive/|\.md$|\.txt$|\.rst$|^CLAUDE\.md$|^README|^LICENSE|^AUTHORS$|^CHANGELOG)`

This **failed test 4** because `^docs/` matches `docs/foo.py`. The fixed regex is: `(\.md$|\.txt$|\.rst$|^README$|^README\.[a-z]+$|^LICENSE$|^LICENSE\.[a-z]+$|^AUTHORS$|^CHANGELOG$|^CHANGELOG\.[a-z]+$)` — strict extension/filename matching with no directory prefixes.

## Self-Test

This very PR is a `.sh` file change, so the **new logic in this PR runs the FULL gate** (not the fast path) for its own validation push. This is the desired behavior — changes to the hook itself are fully tested before merging. After merge, future docs-only pushes will skip the gate and complete in <30s.

## Test plan

- [x] Manual regex validation (7 test cases above, all pass)
- [x] Bash syntax check (`bash -n scripts/pre-push-validation.sh`)
- [x] Self-test: this push runs the full gate (validates the new logic doesn't break the existing flow)
- [ ] Post-merge validation: a docs-only commit on main (or a new feature branch) skips the test gate and completes in <30s
- [ ] CI checks pass

## Expected Behavior After Merge

- **docs/foo.md commit:** push completes in <30s (branch check + bytecode cleanup + fast path detection)
- **src/foo.py commit:** push runs full gate (~11-13 min)
- **mixed commit:** push runs full gate
- **Override (`SKIP_DOCS_FAST_PATH=1`):** push runs full gate even on docs-only

## Related

- Issue #616 (this PR closes it)
- `memory/feedback_pre_push_docs_only_skip.md` — session 42c friction events that motivated this
- `feedback_fix_flaky_tests.md` — this PR does NOT bypass that rule; flaky tests still get fixed when encountered, this just decouples docs commits from race-test flake
- PRs #612, #615 — the friction events from session 42c

Closes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)
