### PR TITLE
docs: CLAUDE.md phase doc reference V1.15 -> ERA2_V1.1 (held from 42c)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ precog-repo/
 **Architecture & Planning:**
 - `docs/foundation/MASTER_REQUIREMENTS_V2.25.md` - All requirements
 - `docs/foundation/ARCHITECTURE_DECISIONS_V2.35.md` - 114 ADRs
-- `docs/foundation/DEVELOPMENT_PHASES_V1.15.md` - Phase roadmap
+- `docs/foundation/DEVELOPMENT_PHASES_ERA2_V1.1.md` - Phase roadmap (Era 2: current)
 
 **Implementation:**
 - `docs/guides/DEVELOPMENT_PATTERNS_V1.30.md` - 50 development patterns with examples


### PR DESCRIPTION
Carryover from PR #612 Claude Review feedback (Session 42c). Single-line CLAUDE.md update changing the phase doc reference from the archived Era 1 doc (DEVELOPMENT_PHASES_V1.15.md) to the current Era 2 doc (DEVELOPMENT_PHASES_ERA2_V1.1.md).

## Why this PR is special

This is the **first production validation of #616** (pre-push docs-only fast path) that merged earlier in this session as PR #652.

**Push timing comparison:**
- Before #616: ~666 seconds (11 minutes) for full pre-push gate on a 1-line docs commit
- After #616: **1 second** (this PR's push log)

The fast path correctly:
- Detected branch `docs/claude-md-phase-doc-ref`
- Identified all changed files as matching docs patterns (CLAUDE.md)
- Skipped the test gate
- Logged the skip for future audit
- Exited cleanly in 1 second

## Test plan

- [x] Pre-push fast path activated (1 second)
- [x] CI checks (will run as normal — pytest-cov known issue #632 expected)

Closes Task 1 from Session 42d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)