### PR TITLE
fix(ci): Add parallel mode to coverage config for pytest-xdist (#632)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -380,8 +380,17 @@ omit = [
 # Branch coverage (not just line coverage)
 branch = true
 
-# Measure concurrency (thread only - greenlet not supported on Windows)
-concurrency = ["thread"]
+# Parallel mode: each worker writes to .coverage.<suffix> then pytest-cov combines.
+# REQUIRED when running with pytest-xdist (-n auto); without this, xdist workers
+# race on a single .coverage file and combine() crashes with "Can't combine
+# statement coverage data with branch data" on Linux (fork). See #632.
+parallel = true
+
+# Concurrency models coverage.py must track:
+# - multiprocessing: required for pytest-xdist workers (spawn/fork subprocesses)
+# - thread: required for race/chaos tests that exercise threaded code paths
+# greenlet is NOT listed (not supported on Windows; we don't use it).
+concurrency = ["multiprocessing", "thread"]
 
 [tool.coverage.report]
 # Reporting precision


### PR DESCRIPTION
## Summary

Two-line config fix for `[tool.coverage.run]` in `pyproject.toml`. Adds `parallel = true` and broadens `concurrency` to `["multiprocessing", "thread"]`. This is the canonical pytest-xdist + coverage configuration.

## Diagnosis

CI's unit test job runs `pytest -n auto`, which uses pytest-xdist to spawn parallel workers. Without `parallel = true`, all xdist workers race on a single `.coverage` file. On Linux (fork semantics), the master + worker processes end up with mixed branch/statement coverage data, and `coverage.combine()` crashes during teardown with:

```
INTERNALERROR> DataError: Can't combine statement coverage data with branch data
INTERNALERROR> Plugin: _cov, Hook: pytest_runtestloop
```

Windows (spawn semantics) escapes the race because each worker initializes cleanly from `pyproject.toml`. That's why the failure was Linux-only across both Python 3.12 and 3.14 on `ubuntu-latest`.

## Why this matters

This bug has been blocking every code-bearing PR since at least 2026-04-06:

- **PR #631** (`#613` SCD race helper) was admin-merged against the failure yesterday.
- **PRs #652, #653, #654** "passed" CI only because the docs-only fast path (#616) bypassed the test job entirely.
- **PRs #665 and #671** are currently stuck on the same root cause.

Issue #632 was filed during PR #631's diagnosis but its body described the symptom (`combine_parallel_data`) rather than the actual root cause (`parallel = true` missing + wrong `concurrency` model for xdist).

## Why these specific values

- `parallel = true` — each xdist worker writes to `.coverage.<unique-suffix>` instead of racing on a single file. pytest-cov then calls `coverage.combine()` after all workers finish.
- `concurrency = ["multiprocessing", "thread"]` — multiprocessing for the xdist subprocess workers, thread retained because race/chaos tests exercise threaded code paths internally (removing it would lose coverage on those tests). `greenlet` is not listed because it isn't supported on Windows and we don't use it.

## Test plan

- [x] Local: `python -m ruff check pyproject.toml` passes
- [x] Local: `tomllib.load(pyproject.toml)` parses
- [ ] CI: ubuntu 3.12 unit/property tests pass (was failing)
- [ ] CI: ubuntu 3.14 unit/property tests pass (was failing)
- [ ] CI: windows 3.14 unit/property tests still pass (was passing — regression check)
- [ ] CI: integration tests still pass

After this merges to `main`, PRs #665 and #671 will be rebased onto main and re-run CI. If they go green, both merge cleanly without admin override.

Closes #632