### PR TITLE
fix: Preserve execution_environment in update_position_price SCD INSERT (#662)

### DIFF
--- a/src/precog/database/crud_positions.py
+++ b/src/precog/database/crud_positions.py
@@ -535,6 +535,11 @@ def update_position_price(
             # Step 4: Insert new version with same position_id (business
             # key) but new id (surrogate). row_start_ts matches row_end_ts
             # on the historical row for Pattern 49 temporal continuity.
+            # execution_environment is preserved from the original position
+            # (Issue #662: Marvin sentinel pass found that omitting this
+            # column silently flipped non-'live' positions to the column's
+            # DEFAULT 'live' on every price update -- cross-environment
+            # contamination with no audit signal).
             cur.execute(
                 """
                 INSERT INTO positions (
@@ -543,9 +548,10 @@ def update_position_price(
                     current_price, unrealized_pnl,
                     target_price, stop_loss_price,
                     trailing_stop_state, position_metadata,
-                    status, entry_time, last_check_time, row_start_ts
+                    status, entry_time, last_check_time, execution_environment,
+                    row_start_ts
                 )
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 RETURNING id
                 """,
                 (
@@ -565,8 +571,9 @@ def update_position_price(
                     current["position_metadata"],
                     current["status"],
                     current["entry_time"],
-                    now,
-                    now,
+                    now,  # last_check_time
+                    current["execution_environment"],  # Preserve execution environment
+                    now,  # row_start_ts
                 ),
             )
             result = cur.fetchone()

--- a/tests/integration/database/test_crud_positions_trailing_stop_integration.py
+++ b/tests/integration/database/test_crud_positions_trailing_stop_integration.py
@@ -59,7 +59,7 @@ from typing import Any
 import pytest
 
 from precog.database.connection import get_cursor
-from precog.database.crud_positions import set_trailing_stop_state
+from precog.database.crud_positions import set_trailing_stop_state, update_position_price
 
 # Test identifiers reserved for this integration suite. Use the TEST- prefix
 # so the suite-wide ``clean_test_data`` regex picks up any orphaned rows the
@@ -575,3 +575,168 @@ class TestSetTrailingStopStateIntegration:
         # as Decimal — psycopg2 reads DECIMAL(10,4) as Decimal natively.
         assert row["current_price"] == Decimal("0.6500")
         assert row["unrealized_pnl"] == Decimal("1.5000")
+
+
+@pytest.mark.integration
+class TestUpdatePositionPriceIntegration:
+    """Single-threaded integration coverage for ``update_position_price``.
+
+    Issue #662 (Marvin sentinel pass on PR #665, session 42e):
+
+    The pre-fix INSERT column list in ``update_position_price`` omitted
+    ``execution_environment``. The column is ``NOT NULL DEFAULT 'live'``
+    (migrations 0008 + 0024), so every SCD version produced by a price
+    update silently stamped the new row with ``'live'`` regardless of
+    the original position's environment. A position opened in ``'paper'``
+    or ``'backtest'`` mode flipped to ``'live'`` on its very first price
+    tick -- cross-environment contamination with no audit signal except
+    the SCD history itself.
+
+    This test pins the fix. It would have failed loudly on the pre-fix
+    code because the fixture seeds the position with
+    ``execution_environment='paper'`` and then asserts the new SCD
+    version is still ``'paper'``. Pre-fix, the new row would carry the
+    DEFAULT ``'live'``.
+
+    Reuses the ``trailing_stop_position`` fixture from this file because
+    that fixture already seeds an open position with a non-default
+    ``execution_environment='paper'`` -- the exact setup needed to
+    detect the regression.
+
+    Reference:
+        - Issue #662: update_position_price drops execution_environment.
+        - PR #665: SCD retry helper batch adoption (the PR Marvin
+          reviewed when she found this latent bug).
+        - close_position at crud_positions.py:760: the canonical
+          reference -- it has handled execution_environment correctly
+          since the SCD pattern was first introduced.
+    """
+
+    def test_preserves_execution_environment_across_price_update(
+        self, trailing_stop_position: tuple[int, str, int]
+    ) -> None:
+        """A price update on a 'paper' position must keep execution_environment='paper'.
+
+        Pre-fix behavior: the INSERT column list omitted
+        ``execution_environment``, so the new SCD row picked up the
+        column DEFAULT ``'live'``. This test would fail with
+        ``assert 'live' == 'paper'`` against pre-fix code.
+
+        Post-fix behavior: the INSERT column list explicitly includes
+        ``execution_environment`` and the values tuple copies
+        ``current["execution_environment"]`` from the re-fetched current
+        row, mirroring ``close_position``'s pattern.
+        """
+        surrogate_id, position_bk, _market_pk = trailing_stop_position
+
+        # Sanity check: the fixture seeds 'paper'. If this assertion ever
+        # fails, the fixture has drifted and the rest of the test is
+        # meaningless.
+        with get_cursor(commit=False) as cur:
+            cur.execute(
+                """
+                SELECT execution_environment
+                FROM positions
+                WHERE id = %s AND row_current_ind = TRUE
+                """,
+                (surrogate_id,),
+            )
+            seed_row = cur.fetchone()
+        assert seed_row is not None
+        assert seed_row["execution_environment"] == "paper", (
+            "fixture must seed execution_environment='paper' for this test "
+            "to detect the #662 regression"
+        )
+
+        # Trigger an SCD version write via update_position_price. The
+        # fixture's current_price is Decimal('0.5500'); use a different
+        # value so the early-return optimization (price_unchanged AND
+        # trailing_stop_unchanged) does NOT short-circuit and skip the
+        # INSERT we want to test.
+        new_id = update_position_price(
+            position_id=surrogate_id,
+            current_price=Decimal("0.6000"),
+        )
+
+        assert new_id is not None
+        assert new_id != surrogate_id, "must allocate a new surrogate id"
+
+        # Read back the new current row and verify execution_environment
+        # was preserved (not silently flipped to the DEFAULT 'live').
+        with get_cursor(commit=False) as cur:
+            cur.execute(
+                """
+                SELECT id, current_price, execution_environment, row_current_ind
+                FROM positions
+                WHERE position_id = %s AND row_current_ind = TRUE
+                """,
+                (position_bk,),
+            )
+            current = cur.fetchone()
+
+        assert current is not None
+        assert current["id"] == new_id
+        assert current["current_price"] == Decimal("0.6000")
+        assert current["execution_environment"] == "paper", (
+            f"execution_environment must be preserved across SCD price "
+            f"updates; expected 'paper', got "
+            f"{current['execution_environment']!r}. This is the #662 bug "
+            f"Marvin found in PR #665 review: update_position_price's "
+            f"INSERT column list omitted execution_environment, so the "
+            f"new SCD row picked up the column DEFAULT 'live' and "
+            f"silently flipped paper-mode positions to live."
+        )
+
+        # Also verify the historical row still carries 'paper' (the
+        # close path doesn't touch execution_environment, but assert it
+        # explicitly so a future regression that mutates the historical
+        # row gets caught here too).
+        with get_cursor(commit=False) as cur:
+            cur.execute(
+                """
+                SELECT execution_environment
+                FROM positions
+                WHERE position_id = %s AND row_current_ind = FALSE
+                ORDER BY row_start_ts DESC
+                LIMIT 1
+                """,
+                (position_bk,),
+            )
+            historical = cur.fetchone()
+        assert historical is not None
+        assert historical["execution_environment"] == "paper"
+
+        # Marvin sentinel pass: a SECOND price update on the surviving
+        # 'paper' row. This catches "partial fix" regressions where one
+        # call site is fixed but a downstream refactor reintroduces the
+        # bug on a follow-up update -- the canonical failure mode for
+        # SCD chains, where the first version preserves the value but
+        # the chain drops it on subsequent versions. Pre-fix code would
+        # flip the new row to 'live' here exactly the same way as on the
+        # first update, so this assertion is independent evidence (not
+        # just a re-check of the first assertion).
+        second_new_id = update_position_price(
+            position_id=new_id,
+            current_price=Decimal("0.6500"),
+        )
+        assert second_new_id != new_id, "second update must allocate a new surrogate id"
+
+        with get_cursor(commit=False) as cur:
+            cur.execute(
+                """
+                SELECT id, current_price, execution_environment
+                FROM positions
+                WHERE position_id = %s AND row_current_ind = TRUE
+                """,
+                (position_bk,),
+            )
+            after_second = cur.fetchone()
+        assert after_second is not None
+        assert after_second["id"] == second_new_id
+        assert after_second["current_price"] == Decimal("0.6500")
+        assert after_second["execution_environment"] == "paper", (
+            f"execution_environment must be preserved across the FULL SCD "
+            f"chain, not just the first update; expected 'paper', got "
+            f"{after_second['execution_environment']!r} after the second "
+            f"price update"
+        )


### PR DESCRIPTION
## Summary

Three-line CRUD fix to `update_position_price` in `src/precog/database/crud_positions.py`. Adds `execution_environment` to the SCD INSERT column list, copying from `current["execution_environment"]` to mirror `close_position`'s canonical pattern.

## The Bug

`update_position_price`'s INSERT column list omitted `execution_environment`. Since the column is `NOT NULL DEFAULT 'live'` (migrations 0008 + 0024), every SCD version produced by a price update silently stamped the new row with `'live'` regardless of the original position's environment. A position opened in `'paper'` or `'backtest'` mode would flip to `'live'` on its very first price tick — cross-environment contamination with no audit signal except the SCD history itself.

Bug found by **Marvin sentinel pass on PR #665 in session 42e**. Pre-existing — confirmed by git that the column has been missing from this INSERT since `update_position_price` was first written. NOT introduced by the SCD retry helper batch in PR #665.

## Why this is shippable as a standalone fix today

The dev `positions` table is **empty** (verified by forensic query during this fix: `SELECT COUNT(*) FROM positions` returns 0). The bug has been provably latent — no contamination has occurred to date. The fix is purely forward-looking, closing the gap before Phase 2 manual trading lands real positions.

Forensic query (Marvin's recommendation) — runnable against any environment to detect contamination:

```sql
SELECT
    position_id,
    COUNT(*) AS scd_row_count,
    COUNT(DISTINCT execution_environment) AS distinct_envs,
    array_agg(DISTINCT execution_environment ORDER BY execution_environment) AS envs,
    MIN(row_start_ts) AS first_seen,
    MAX(COALESCE(row_end_ts, NOW())) AS last_seen
FROM positions
GROUP BY position_id
HAVING COUNT(DISTINCT execution_environment) > 1
ORDER BY scd_row_count DESC;
```

A contaminated chain has more than one distinct value in the SCD history. Returns zero rows on dev today.

## The Fix

Added `execution_environment` to the INSERT column list and `current["execution_environment"]` to the values tuple at matching position 17, mirroring `close_position`'s pattern at lines 737/760. Three-line core change plus disambiguation comments on the two `now` values to make column-vs-value alignment auditable now that there's a non-`now` column squeezed between them.

## Verification

| Check | Result |
|---|---|
| Test fails on **pre-fix** code (stashed CRUD fix, ran new test) | PASS — `AssertionError: assert 'live' == 'paper'` reproduced bug against testcontainer |
| Test passes on **post-fix** code | PASS — 1 passed in 4.53s |
| All 6 integration tests in modified file | PASS |
| All 979 unit tests in `tests/unit/database/` | PASS |
| `ruff check` + `ruff format` | clean |
| Forensic contamination query against dev DB | 0 rows (provably latent) |

## Test design

Single regression integration test (`TestUpdatePositionPriceIntegration::test_preserves_execution_environment_across_price_update`) in `tests/integration/database/test_crud_positions_trailing_stop_integration.py`:

1. **Reuses `trailing_stop_position` fixture** which already seeds `execution_environment='paper'` — exactly the setup needed to detect this bug
2. **Sanity-checks the fixture** before asserting the fix (catches future fixture drift)
3. **Picks `current_price=Decimal("0.6000")`** to defeat the early-return optimization (fixture seeds `0.5500`, so prices differ and the INSERT path executes)
4. **Asserts BOTH the new current row AND the historical row** preserve `'paper'`
5. **Marvin's nice-to-have applied:** runs a SECOND price update on the surviving row and asserts `execution_environment` is still `'paper'` after BOTH updates — catches "partial fix" regressions where the chain drops the value on a follow-up update (the canonical SCD failure mode)

## Pipeline

This fix went through the full Tier 2 pipeline despite being a 3-line change because money-touching SCD code is a Tier 2 override on the line-count rule:

- **Samwise (Builder, pattern-compliance frame):** produced the diff, verified migration 0024 NOT NULL DEFAULT, confirmed `set_trailing_stop_state` in PR #671 already handles the column correctly, flagged #666 (dict-adapter) as coresident-but-out-of-scope.
- **Glokta (Reviewer, adversarial frame):** APPROVE, no blockers. Audited all 4 `INSERT INTO positions` and 1 `INSERT INTO trades` sites; all preserve the column. Verified all 7 callers; no caller asserts post-update value of `'live'`. Counted 18/18/18 column-list / VALUES / tuple consistency.
- **Marvin (Sentinel, paranoid frame):** APPROVE with one nice-to-have applied (multi-update-chain assertion above). Found a major adjacent issue surfaced as #686.

## Adjacent issues discovered (filed separately)

- **#686 [HIGH PRIORITY] `PositionManager.open_position` drops execution_environment at the caller layer.** Marvin discovered this while paranoid-checking upstream of `update_position_price`. The canonical position-creation entry point never sets the column at all — every position is silently stamped `'live'` regardless of intent. This is the third leg of the cross-environment-contamination story (after #622 schema-layer and #662 CRUD-layer). **Phase 2 blocker.** Should be bundled with #622's design pass.
- **#687 [MEDIUM] Pattern 49 docs missing the "Schema Column Exhaustion Rule".** A reviewer following Pattern 49 literally would not have caught the original #662 bug. Doc update prevents the entire bug class going forward. Pairs with the pending V1.30->V1.31 patterns bump.

## Future work (not filed as separate issues — captured here)

- Race tests for `update_position_price` / `close_position` / `set_trailing_stop_state` should seed a non-`'live'` execution_environment in the fixture and assert preservation across concurrent updates. Currently the fixture defaults to `'live'` so these race tests cannot detect a regression of this archetype. Trivial 4-line fix; can land in a future test-hygiene pass.
- A `contaminated_positions` SQL view or `scripts/audit/` helper would preserve the forensic query for future audits without re-inventing it.
- The multi-update-chain test in this PR could be parametrized across `'live' / 'paper' / 'backtest'` for symmetry; one mode covered today is sufficient for the regression but parametrize is cheap.

## Test plan

- [x] Local: `python -m ruff check` passes
- [x] Local: `python -m ruff format --check` clean
- [x] Local: new integration test passes against testcontainer PostgreSQL (4.53s)
- [x] Local: pre-fix code with new test FAILS (`assert 'live' == 'paper'`) — bug reproduced
- [x] Local: all 6 integration tests in the modified file pass
- [x] Local: all 979 unit tests in `tests/unit/database/` pass
- [x] Local: forensic contamination query returns 0 rows on dev DB
- [ ] CI: full pipeline green (will verify on push)

Closes #662
Related: #622 (schema-layer execution_environment gap, separate design pass scheduled this session)
Related: #686 (caller-layer execution_environment gap, filed during this PR's QA)
Related: #687 (Pattern 49 doc gap, filed during this PR's QA)
Related: #666 (dict-adapter latent bug also in `update_position_price`; not touched here, separate scope)
