### PR TITLE
feat: DB-level write-protection triggers (#371, #723)

### DIFF
--- a/src/precog/database/alembic/versions/0056_write_protection_triggers.py
+++ b/src/precog/database/alembic/versions/0056_write_protection_triggers.py
@@ -1,0 +1,274 @@
+"""Add write-protection triggers for immutability and append-only enforcement.
+
+Revision ID: 0056
+Revises: 0055
+Create Date: 2026-04-10
+
+Issues: #371, #723
+Epic: #745 (Schema Hardening Arc, Cohort C1)
+
+Council attribution (8 of 12 agents flagged #371 -- highest conviction):
+    Mulder, Leto II, Holden, Vader, Elrond, Daneel, Cassandra, Leto II (C1+C2)
+
+What this migration does:
+    1. Creates enforce_strategy_immutability() trigger function
+       - Blocks UPDATE on: config, strategy_version, strategy_name, strategy_type
+       - Allows UPDATE on mutable columns: status, activated_at, deactivated_at,
+         notes, description, paper_trades_count, paper_roi, live_trades_count,
+         live_roi, updated_at, created_by, domain, platform_id
+       - Columns intentionally NOT protected (mutable by design):
+         domain (reclassification), platform_id (lifecycle), created_at (immutable
+         by convention but NOT NULL DEFAULT NOW() prevents drift)
+    2. Creates enforce_model_immutability() trigger function
+       - Blocks UPDATE on: config, model_version, model_name, model_class
+       - Allows UPDATE on mutable columns: status, activated_at, deactivated_at,
+         notes, description, validation_accuracy, validation_calibration,
+         validation_sample_size, created_by, domain, training_start_date,
+         training_end_date, training_sample_size
+       - Columns intentionally NOT protected: domain (reclassification),
+         training_* (may be updated during retraining workflow)
+    3. Creates prevent_append_only_update() trigger function
+       - Blocks ALL UPDATE operations on append-only fact tables
+    4. Applies triggers to 7 tables:
+       - strategies (selective immutability)
+       - probability_models (selective immutability)
+       - trades (append-only)
+       - settlements (append-only)
+       - account_ledger (append-only)
+       - position_exits (append-only)
+       - exit_attempts (append-only)
+
+Why DB-level enforcement matters:
+    CLAUDE.md Rule 5 declares strategies and models immutable, but this was
+    Python-only enforcement via StrategyManager.ImmutabilityError. A single
+    stray UPDATE statement -- from a migration, manual SQL, or future code --
+    silently breaks every downstream trade's provenance chain. DB triggers
+    are the last line of defense and the only one that cannot be bypassed
+    by application code.
+
+    The 5 append-only tables (trades, settlements, account_ledger,
+    position_exits, exit_attempts) record historical facts that must never
+    be modified. No CRUD UPDATE functions exist for these tables, confirming
+    append-only is the intended semantic.
+
+IMPORTANT — Future migrations that backfill data:
+    Any future migration that needs to UPDATE rows in the 5 append-only
+    tables (e.g., backfilling a new column like migrations 0052-0055 did)
+    MUST temporarily disable the trigger:
+
+        ALTER TABLE trades DISABLE TRIGGER trg_trades_append_only;
+        UPDATE trades SET new_column = 'value' WHERE ...;
+        ALTER TABLE trades ENABLE TRIGGER trg_trades_append_only;
+
+    Similarly, migrations that need to ALTER immutable columns on strategies
+    or probability_models must drop and recreate the trigger function.
+
+    Without this, the migration will fail with a RaiseException.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0056"
+down_revision: str | None = "0055"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add write-protection triggers to 7 tables."""
+
+    # =========================================================================
+    # 1. IMMUTABILITY TRIGGER FUNCTION — strategies
+    # =========================================================================
+    op.execute("""
+        CREATE OR REPLACE FUNCTION enforce_strategy_immutability()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            IF NEW.config IS DISTINCT FROM OLD.config
+               OR NEW.strategy_version IS DISTINCT FROM OLD.strategy_version
+               OR NEW.strategy_name IS DISTINCT FROM OLD.strategy_name
+               OR NEW.strategy_type IS DISTINCT FROM OLD.strategy_type
+            THEN
+                RAISE EXCEPTION
+                    'Cannot modify immutable columns on strategies '
+                    '(config, strategy_version, strategy_name, strategy_type). '
+                    'Create a new version instead.';
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+    """)
+
+    op.execute("""
+        COMMENT ON FUNCTION enforce_strategy_immutability() IS
+        'Blocks UPDATE on immutable columns (config, version, name, type). '
+        'Mutable columns (status, timestamps, counters) remain updatable. '
+        'Issue #371, ADR-018.'
+    """)
+
+    # =========================================================================
+    # 2. IMMUTABILITY TRIGGER FUNCTION — probability_models
+    # =========================================================================
+    op.execute("""
+        CREATE OR REPLACE FUNCTION enforce_model_immutability()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            IF NEW.config IS DISTINCT FROM OLD.config
+               OR NEW.model_version IS DISTINCT FROM OLD.model_version
+               OR NEW.model_name IS DISTINCT FROM OLD.model_name
+               OR NEW.model_class IS DISTINCT FROM OLD.model_class
+            THEN
+                RAISE EXCEPTION
+                    'Cannot modify immutable columns on probability_models '
+                    '(config, model_version, model_name, model_class). '
+                    'Create a new version instead.';
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql
+    """)
+
+    op.execute("""
+        COMMENT ON FUNCTION enforce_model_immutability() IS
+        'Blocks UPDATE on immutable columns (config, version, name, class). '
+        'Mutable columns (status, timestamps, validation metrics) remain updatable. '
+        'Issue #371, ADR-018.'
+    """)
+
+    # =========================================================================
+    # 3. APPEND-ONLY TRIGGER FUNCTION — shared by 5 fact tables
+    # =========================================================================
+    op.execute("""
+        CREATE OR REPLACE FUNCTION prevent_append_only_update()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            RAISE EXCEPTION
+                'Table % is append-only. UPDATE not permitted. '
+                'Create a new row instead.',
+                TG_TABLE_NAME;
+        END;
+        $$ LANGUAGE plpgsql
+    """)
+
+    op.execute("""
+        COMMENT ON FUNCTION prevent_append_only_update() IS
+        'Blocks ALL UPDATE operations on append-only fact tables. '
+        'Applied to: trades, settlements, account_ledger, position_exits, exit_attempts. '
+        'Issue #723.'
+    """)
+
+    # =========================================================================
+    # 4. APPLY TRIGGERS — idempotent (DROP IF EXISTS before CREATE)
+    # =========================================================================
+
+    # --- strategies immutability ---
+    op.execute("DROP TRIGGER IF EXISTS trg_strategies_immutability ON strategies")
+    op.execute("""
+        CREATE TRIGGER trg_strategies_immutability
+            BEFORE UPDATE ON strategies
+            FOR EACH ROW
+            EXECUTE FUNCTION enforce_strategy_immutability()
+    """)
+    op.execute("""
+        COMMENT ON TRIGGER trg_strategies_immutability ON strategies IS
+        'Enforces immutability of config, version, name, type columns. Issue #371.'
+    """)
+
+    # --- probability_models immutability ---
+    op.execute("DROP TRIGGER IF EXISTS trg_models_immutability ON probability_models")
+    op.execute("""
+        CREATE TRIGGER trg_models_immutability
+            BEFORE UPDATE ON probability_models
+            FOR EACH ROW
+            EXECUTE FUNCTION enforce_model_immutability()
+    """)
+    op.execute("""
+        COMMENT ON TRIGGER trg_models_immutability ON probability_models IS
+        'Enforces immutability of config, version, name, class columns. Issue #371.'
+    """)
+
+    # --- trades append-only ---
+    op.execute("DROP TRIGGER IF EXISTS trg_trades_append_only ON trades")
+    op.execute("""
+        CREATE TRIGGER trg_trades_append_only
+            BEFORE UPDATE ON trades
+            FOR EACH ROW
+            EXECUTE FUNCTION prevent_append_only_update()
+    """)
+    op.execute("""
+        COMMENT ON TRIGGER trg_trades_append_only ON trades IS
+        'Prevents UPDATE on append-only trade records. Issue #723.'
+    """)
+
+    # --- settlements append-only ---
+    op.execute("DROP TRIGGER IF EXISTS trg_settlements_append_only ON settlements")
+    op.execute("""
+        CREATE TRIGGER trg_settlements_append_only
+            BEFORE UPDATE ON settlements
+            FOR EACH ROW
+            EXECUTE FUNCTION prevent_append_only_update()
+    """)
+    op.execute("""
+        COMMENT ON TRIGGER trg_settlements_append_only ON settlements IS
+        'Prevents UPDATE on append-only settlement records. Issue #723.'
+    """)
+
+    # --- account_ledger append-only ---
+    op.execute("DROP TRIGGER IF EXISTS trg_account_ledger_append_only ON account_ledger")
+    op.execute("""
+        CREATE TRIGGER trg_account_ledger_append_only
+            BEFORE UPDATE ON account_ledger
+            FOR EACH ROW
+            EXECUTE FUNCTION prevent_append_only_update()
+    """)
+    op.execute("""
+        COMMENT ON TRIGGER trg_account_ledger_append_only ON account_ledger IS
+        'Prevents UPDATE on append-only ledger entries. Issue #723.'
+    """)
+
+    # --- position_exits append-only ---
+    op.execute("DROP TRIGGER IF EXISTS trg_position_exits_append_only ON position_exits")
+    op.execute("""
+        CREATE TRIGGER trg_position_exits_append_only
+            BEFORE UPDATE ON position_exits
+            FOR EACH ROW
+            EXECUTE FUNCTION prevent_append_only_update()
+    """)
+    op.execute("""
+        COMMENT ON TRIGGER trg_position_exits_append_only ON position_exits IS
+        'Prevents UPDATE on append-only exit records. Issue #723.'
+    """)
+
+    # --- exit_attempts append-only ---
+    op.execute("DROP TRIGGER IF EXISTS trg_exit_attempts_append_only ON exit_attempts")
+    op.execute("""
+        CREATE TRIGGER trg_exit_attempts_append_only
+            BEFORE UPDATE ON exit_attempts
+            FOR EACH ROW
+            EXECUTE FUNCTION prevent_append_only_update()
+    """)
+    op.execute("""
+        COMMENT ON TRIGGER trg_exit_attempts_append_only ON exit_attempts IS
+        'Prevents UPDATE on append-only exit attempt records. Issue #723.'
+    """)
+
+
+def downgrade() -> None:
+    """Remove all write-protection triggers and functions."""
+
+    # Drop triggers (reverse order of creation)
+    op.execute("DROP TRIGGER IF EXISTS trg_exit_attempts_append_only ON exit_attempts")
+    op.execute("DROP TRIGGER IF EXISTS trg_position_exits_append_only ON position_exits")
+    op.execute("DROP TRIGGER IF EXISTS trg_account_ledger_append_only ON account_ledger")
+    op.execute("DROP TRIGGER IF EXISTS trg_settlements_append_only ON settlements")
+    op.execute("DROP TRIGGER IF EXISTS trg_trades_append_only ON trades")
+    op.execute("DROP TRIGGER IF EXISTS trg_models_immutability ON probability_models")
+    op.execute("DROP TRIGGER IF EXISTS trg_strategies_immutability ON strategies")
+
+    # Drop functions
+    op.execute("DROP FUNCTION IF EXISTS prevent_append_only_update()")
+    op.execute("DROP FUNCTION IF EXISTS enforce_model_immutability()")
+    op.execute("DROP FUNCTION IF EXISTS enforce_strategy_immutability()")

--- a/tests/integration/database/test_migration_0056_write_protection_triggers.py
+++ b/tests/integration/database/test_migration_0056_write_protection_triggers.py
@@ -312,8 +312,8 @@ class TestStrategyImmutability:
     def test_update_immutable_config_raises(self, trigger_test_scaffold: dict) -> None:
         """UPDATE of config (immutable) must raise."""
         sid = trigger_test_scaffold["strategy_id"]
-        with get_cursor(commit=True) as cur:
-            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+        with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+            with get_cursor(commit=True) as cur:
                 cur.execute(
                     "UPDATE strategies SET config = %s WHERE strategy_id = %s",
                     (json.dumps({"param": "tampered"}), sid),
@@ -322,8 +322,8 @@ class TestStrategyImmutability:
     def test_update_immutable_version_raises(self, trigger_test_scaffold: dict) -> None:
         """UPDATE of strategy_version (immutable) must raise."""
         sid = trigger_test_scaffold["strategy_id"]
-        with get_cursor(commit=True) as cur:
-            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+        with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+            with get_cursor(commit=True) as cur:
                 cur.execute(
                     "UPDATE strategies SET strategy_version = '2.0' WHERE strategy_id = %s",
                     (sid,),
@@ -332,8 +332,8 @@ class TestStrategyImmutability:
     def test_update_immutable_name_raises(self, trigger_test_scaffold: dict) -> None:
         """UPDATE of strategy_name (immutable) must raise."""
         sid = trigger_test_scaffold["strategy_id"]
-        with get_cursor(commit=True) as cur:
-            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+        with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+            with get_cursor(commit=True) as cur:
                 cur.execute(
                     "UPDATE strategies SET strategy_name = 'tampered-name' WHERE strategy_id = %s",
                     (sid,),
@@ -346,8 +346,8 @@ class TestStrategyImmutability:
         constraint — is what blocks the change.
         """
         sid = trigger_test_scaffold["strategy_id"]
-        with get_cursor(commit=True) as cur:
-            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+        with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+            with get_cursor(commit=True) as cur:
                 cur.execute(
                     "UPDATE strategies SET strategy_type = 'arbitrage' WHERE strategy_id = %s",
                     (sid,),
@@ -372,8 +372,8 @@ class TestStrategyImmutability:
     def test_update_multiple_immutable_columns_raises(self, trigger_test_scaffold: dict) -> None:
         """UPDATE of multiple immutable columns at once must raise."""
         sid = trigger_test_scaffold["strategy_id"]
-        with get_cursor(commit=True) as cur:
-            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+        with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+            with get_cursor(commit=True) as cur:
                 cur.execute(
                     "UPDATE strategies SET config = %s, strategy_name = 'x' WHERE strategy_id = %s",
                     (json.dumps({"tampered": True}), sid),
@@ -423,8 +423,8 @@ class TestModelImmutability:
     def test_update_immutable_config_raises(self, trigger_test_scaffold: dict) -> None:
         """UPDATE of config (immutable) must raise."""
         mid = trigger_test_scaffold["model_id"]
-        with get_cursor(commit=True) as cur:
-            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+        with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+            with get_cursor(commit=True) as cur:
                 cur.execute(
                     "UPDATE probability_models SET config = %s WHERE model_id = %s",
                     (json.dumps({"learning_rate": "0.99"}), mid),
@@ -433,8 +433,8 @@ class TestModelImmutability:
     def test_update_immutable_version_raises(self, trigger_test_scaffold: dict) -> None:
         """UPDATE of model_version (immutable) must raise."""
         mid = trigger_test_scaffold["model_id"]
-        with get_cursor(commit=True) as cur:
-            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+        with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+            with get_cursor(commit=True) as cur:
                 cur.execute(
                     "UPDATE probability_models SET model_version = '2.0' WHERE model_id = %s",
                     (mid,),
@@ -443,8 +443,8 @@ class TestModelImmutability:
     def test_update_immutable_name_raises(self, trigger_test_scaffold: dict) -> None:
         """UPDATE of model_name (immutable) must raise."""
         mid = trigger_test_scaffold["model_id"]
-        with get_cursor(commit=True) as cur:
-            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+        with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+            with get_cursor(commit=True) as cur:
                 cur.execute(
                     "UPDATE probability_models SET model_name = 'tampered' WHERE model_id = %s",
                     (mid,),
@@ -457,8 +457,8 @@ class TestModelImmutability:
         constraint — is what blocks the change.
         """
         mid = trigger_test_scaffold["model_id"]
-        with get_cursor(commit=True) as cur:
-            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+        with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+            with get_cursor(commit=True) as cur:
                 cur.execute(
                     "UPDATE probability_models SET model_class = 'ensemble' WHERE model_id = %s",
                     (mid,),
@@ -474,6 +474,26 @@ class TestModelImmutability:
                 (mid,),
             )
             assert cur.fetchone() is not None
+
+    def test_update_multiple_immutable_columns_raises(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of multiple immutable columns at once must raise."""
+        mid = trigger_test_scaffold["model_id"]
+        with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+            with get_cursor(commit=True) as cur:
+                cur.execute(
+                    "UPDATE probability_models SET config = %s, model_name = 'x' "
+                    "WHERE model_id = %s",
+                    (json.dumps({"tampered": True}), mid),
+                )
+
+    def test_update_zero_rows_no_exception(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE matching zero rows must NOT raise (trigger fires per-row)."""
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "UPDATE probability_models SET config = %s WHERE model_id = -999",
+                (json.dumps({"tampered": True}),),
+            )
+            assert cur.rowcount == 0
 
 
 # =============================================================================
@@ -606,11 +626,11 @@ class TestAppendOnlyEnforcement:
         with get_cursor(commit=True) as cur:
             pk = _insert_append_only_row(cur, table, trigger_test_scaffold)
 
-        with get_cursor(commit=True) as cur:
-            pk_col = _PK_COLUMN[table]
-            upd_col = _UPDATE_COLUMN[table]
-            upd_val = _UPDATE_VALUE[table]
-            with pytest.raises(psycopg2.errors.RaiseException, match="append-only"):
+        pk_col = _PK_COLUMN[table]
+        upd_col = _UPDATE_COLUMN[table]
+        upd_val = _UPDATE_VALUE[table]
+        with pytest.raises(psycopg2.errors.RaiseException, match="append-only"):
+            with get_cursor(commit=True) as cur:
                 cur.execute(
                     f"UPDATE {table} SET {upd_col} = %s WHERE {pk_col} = %s",  # noqa: S608
                     (upd_val, pk),

--- a/tests/integration/database/test_migration_0056_write_protection_triggers.py
+++ b/tests/integration/database/test_migration_0056_write_protection_triggers.py
@@ -1,0 +1,634 @@
+"""Integration tests for migration 0056 (write-protection triggers).
+
+Issues: #371 (immutability), #723 (append-only)
+Epic: #745 (Schema Hardening Arc, Cohort C1)
+
+Test groups:
+    - TestTriggerFunctionsExist: verify all 3 trigger functions exist in pg_proc
+    - TestTriggersExist: verify all 7 triggers exist on their tables
+    - TestStrategyImmutability: mutable UPDATE succeeds, immutable UPDATE raises
+    - TestModelImmutability: mutable UPDATE succeeds, immutable UPDATE raises
+    - TestAppendOnlyEnforcement: INSERT succeeds, UPDATE raises on all 5 tables
+
+Markers:
+    @pytest.mark.integration: real DB required (testcontainer per ADR-057)
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from typing import Any
+
+import psycopg2
+import pytest
+
+from precog.database.connection import get_cursor
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+TRIGGER_FUNCTIONS = (
+    "enforce_strategy_immutability",
+    "enforce_model_immutability",
+    "prevent_append_only_update",
+)
+
+TRIGGER_MAP = {
+    "strategies": "trg_strategies_immutability",
+    "probability_models": "trg_models_immutability",
+    "trades": "trg_trades_append_only",
+    "settlements": "trg_settlements_append_only",
+    "account_ledger": "trg_account_ledger_append_only",
+    "position_exits": "trg_position_exits_append_only",
+    "exit_attempts": "trg_exit_attempts_append_only",
+}
+
+APPEND_ONLY_TABLES = (
+    "trades",
+    "settlements",
+    "account_ledger",
+    "position_exits",
+    "exit_attempts",
+)
+
+# Unique platform_id for test isolation.
+TEST_PLATFORM_ID = "mig-0056-trigger-test"
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def trigger_test_scaffold(db_pool: Any) -> Any:
+    """Create platform + market + position + strategy + model for trigger tests.
+
+    Yields a dict with all surrogate IDs needed by the test table INSERTs.
+    Cleans up in reverse FK order on teardown.
+    """
+    with get_cursor(commit=True) as cur:
+        # Defensive cleanup of prior run artifacts.
+        _cleanup(cur, TEST_PLATFORM_ID)
+
+        # Platform
+        cur.execute(
+            """
+            INSERT INTO platforms (
+                platform_id, platform_type, display_name, base_url, status
+            )
+            VALUES (%s, 'trading', 'Migration 0056 Trigger Test',
+                    'https://trigger-test.example.com', 'active')
+            """,
+            (TEST_PLATFORM_ID,),
+        )
+
+        # Strategy (we test trigger on this row).
+        # strategy_type FK -> strategy_types(strategy_type_code); use 'value'.
+        cur.execute(
+            """
+            INSERT INTO strategies (
+                platform_id, strategy_name, strategy_version,
+                strategy_type, config, status
+            )
+            VALUES (%s, 'trigger-test-strat', '1.0', 'value',
+                    %s, 'draft')
+            RETURNING strategy_id
+            """,
+            (TEST_PLATFORM_ID, json.dumps({"param": "original"})),
+        )
+        strategy_id = cur.fetchone()["strategy_id"]
+
+        # Probability model (we test trigger on this row).
+        # model_class FK -> model_classes(model_class_code); use 'elo'.
+        cur.execute(
+            """
+            INSERT INTO probability_models (
+                model_name, model_version, model_class, config, status
+            )
+            VALUES ('trigger-test-model', '1.0', 'elo',
+                    %s, 'draft')
+            RETURNING model_id
+            """,
+            (json.dumps({"learning_rate": "0.01"}),),
+        )
+        model_id = cur.fetchone()["model_id"]
+
+        # Market (FK target for trades, settlements)
+        cur.execute(
+            """
+            INSERT INTO markets (
+                platform_id, external_id, ticker, title, market_type, status
+            )
+            VALUES (%s, 'MIG-0056-TEST', 'MIG-0056-TEST',
+                    'Migration 0056 trigger test market', 'binary', 'open')
+            RETURNING id
+            """,
+            (TEST_PLATFORM_ID,),
+        )
+        market_internal_id = cur.fetchone()["id"]
+
+        # Position (FK target for trades, position_exits, exit_attempts)
+        cur.execute(
+            """
+            INSERT INTO positions (
+                position_id, platform_id, market_internal_id, side, quantity,
+                entry_price, current_price, status, entry_time, last_check_time,
+                row_current_ind, row_start_ts, execution_environment
+            )
+            VALUES (
+                'MIG-0056-POS', %s, %s, 'YES', 10,
+                %s, %s, 'open', NOW(), NOW(),
+                TRUE, NOW(), 'live'
+            )
+            RETURNING id
+            """,
+            (
+                TEST_PLATFORM_ID,
+                market_internal_id,
+                Decimal("0.5000"),
+                Decimal("0.5000"),
+            ),
+        )
+        position_internal_id = cur.fetchone()["id"]
+
+    yield {
+        "platform_id": TEST_PLATFORM_ID,
+        "strategy_id": strategy_id,
+        "model_id": model_id,
+        "market_internal_id": market_internal_id,
+        "position_internal_id": position_internal_id,
+    }
+
+    # Teardown in reverse FK order.
+    with get_cursor(commit=True) as cur:
+        _cleanup(cur, TEST_PLATFORM_ID)
+
+
+def _cleanup(cur: Any, platform_id: str) -> None:
+    """Delete all test artifacts in reverse FK order."""
+    cur.execute(
+        "DELETE FROM exit_attempts WHERE position_internal_id IN "
+        "(SELECT id FROM positions WHERE platform_id = %s)",
+        (platform_id,),
+    )
+    cur.execute(
+        "DELETE FROM position_exits WHERE position_internal_id IN "
+        "(SELECT id FROM positions WHERE platform_id = %s)",
+        (platform_id,),
+    )
+    cur.execute(
+        "DELETE FROM trades WHERE platform_id = %s",
+        (platform_id,),
+    )
+    cur.execute(
+        "DELETE FROM account_ledger WHERE platform_id = %s",
+        (platform_id,),
+    )
+    cur.execute(
+        "DELETE FROM settlements WHERE platform_id = %s",
+        (platform_id,),
+    )
+    cur.execute(
+        "DELETE FROM positions WHERE platform_id = %s",
+        (platform_id,),
+    )
+    cur.execute(
+        "DELETE FROM markets WHERE platform_id = %s",
+        (platform_id,),
+    )
+    cur.execute(
+        "DELETE FROM strategies WHERE platform_id = %s",
+        (platform_id,),
+    )
+    cur.execute(
+        "DELETE FROM probability_models WHERE model_name = 'trigger-test-model'",
+    )
+    cur.execute(
+        "DELETE FROM platforms WHERE platform_id = %s",
+        (platform_id,),
+    )
+
+
+# =============================================================================
+# Test: Trigger functions exist in pg_proc
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestTriggerFunctionsExist:
+    """Verify all 3 trigger functions are installed."""
+
+    @pytest.mark.parametrize("func_name", TRIGGER_FUNCTIONS)
+    def test_function_exists(self, db_pool: Any, func_name: str) -> None:
+        with get_cursor() as cur:
+            cur.execute(
+                """
+                SELECT proname FROM pg_proc
+                WHERE proname = %s
+                  AND prorettype = 'trigger'::regtype
+                """,
+                (func_name,),
+            )
+            row = cur.fetchone()
+            assert row is not None, f"Trigger function {func_name} not found"
+
+
+# =============================================================================
+# Test: Triggers exist on their tables
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestTriggersExist:
+    """Verify all 7 triggers are attached to the correct tables."""
+
+    @pytest.mark.parametrize(
+        ("table_name", "trigger_name"),
+        list(TRIGGER_MAP.items()),
+    )
+    def test_trigger_exists(self, db_pool: Any, table_name: str, trigger_name: str) -> None:
+        with get_cursor() as cur:
+            cur.execute(
+                """
+                SELECT trigger_name, event_manipulation, action_timing
+                FROM information_schema.triggers
+                WHERE trigger_name = %s
+                  AND event_object_table = %s
+                """,
+                (trigger_name, table_name),
+            )
+            row = cur.fetchone()
+            assert row is not None, f"Trigger {trigger_name} not found on {table_name}"
+            assert row["action_timing"] == "BEFORE"
+            assert row["event_manipulation"] == "UPDATE"
+
+
+# =============================================================================
+# Test: Strategy immutability — mutable columns OK, immutable columns blocked
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestStrategyImmutability:
+    """Verify selective immutability on strategies table."""
+
+    def test_update_mutable_status_succeeds(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of status (mutable) must succeed."""
+        sid = trigger_test_scaffold["strategy_id"]
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "UPDATE strategies SET status = 'testing' WHERE strategy_id = %s "
+                "RETURNING strategy_id",
+                (sid,),
+            )
+            assert cur.fetchone() is not None
+
+    def test_update_mutable_activated_at_succeeds(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of activated_at (mutable) must succeed."""
+        sid = trigger_test_scaffold["strategy_id"]
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "UPDATE strategies SET activated_at = NOW() WHERE strategy_id = %s "
+                "RETURNING strategy_id",
+                (sid,),
+            )
+            assert cur.fetchone() is not None
+
+    def test_update_mutable_counters_succeeds(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of performance counters (mutable) must succeed."""
+        sid = trigger_test_scaffold["strategy_id"]
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "UPDATE strategies SET paper_trades_count = 5, "
+                "paper_roi = %s WHERE strategy_id = %s "
+                "RETURNING strategy_id",
+                (Decimal("0.1234"), sid),
+            )
+            assert cur.fetchone() is not None
+
+    def test_update_immutable_config_raises(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of config (immutable) must raise."""
+        sid = trigger_test_scaffold["strategy_id"]
+        with get_cursor(commit=True) as cur:
+            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+                cur.execute(
+                    "UPDATE strategies SET config = %s WHERE strategy_id = %s",
+                    (json.dumps({"param": "tampered"}), sid),
+                )
+
+    def test_update_immutable_version_raises(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of strategy_version (immutable) must raise."""
+        sid = trigger_test_scaffold["strategy_id"]
+        with get_cursor(commit=True) as cur:
+            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+                cur.execute(
+                    "UPDATE strategies SET strategy_version = '2.0' WHERE strategy_id = %s",
+                    (sid,),
+                )
+
+    def test_update_immutable_name_raises(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of strategy_name (immutable) must raise."""
+        sid = trigger_test_scaffold["strategy_id"]
+        with get_cursor(commit=True) as cur:
+            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+                cur.execute(
+                    "UPDATE strategies SET strategy_name = 'tampered-name' WHERE strategy_id = %s",
+                    (sid,),
+                )
+
+    def test_update_immutable_type_raises(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of strategy_type (immutable) must raise.
+
+        Uses a valid FK value ('arbitrage') so the trigger — not the FK
+        constraint — is what blocks the change.
+        """
+        sid = trigger_test_scaffold["strategy_id"]
+        with get_cursor(commit=True) as cur:
+            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+                cur.execute(
+                    "UPDATE strategies SET strategy_type = 'arbitrage' WHERE strategy_id = %s",
+                    (sid,),
+                )
+
+    def test_noop_update_of_immutable_column_succeeds(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE that sets an immutable column to its SAME value must succeed.
+
+        IS DISTINCT FROM returns FALSE when old == new, so the trigger
+        allows no-op updates. This is important for ORM bulk-save patterns
+        that SET all columns even when only one changed.
+        """
+        sid = trigger_test_scaffold["strategy_id"]
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "UPDATE strategies SET config = config, status = 'active' "
+                "WHERE strategy_id = %s RETURNING strategy_id",
+                (sid,),
+            )
+            assert cur.fetchone() is not None
+
+    def test_update_multiple_immutable_columns_raises(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of multiple immutable columns at once must raise."""
+        sid = trigger_test_scaffold["strategy_id"]
+        with get_cursor(commit=True) as cur:
+            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+                cur.execute(
+                    "UPDATE strategies SET config = %s, strategy_name = 'x' WHERE strategy_id = %s",
+                    (json.dumps({"tampered": True}), sid),
+                )
+
+    def test_update_zero_rows_no_exception(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE matching zero rows must NOT raise (trigger fires per-row)."""
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "UPDATE strategies SET config = %s WHERE strategy_id = -999",
+                (json.dumps({"tampered": True}),),
+            )
+            assert cur.rowcount == 0
+
+
+# =============================================================================
+# Test: Model immutability — mutable columns OK, immutable columns blocked
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestModelImmutability:
+    """Verify selective immutability on probability_models table."""
+
+    def test_update_mutable_status_succeeds(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of status (mutable) must succeed."""
+        mid = trigger_test_scaffold["model_id"]
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "UPDATE probability_models SET status = 'testing' "
+                "WHERE model_id = %s RETURNING model_id",
+                (mid,),
+            )
+            assert cur.fetchone() is not None
+
+    def test_update_mutable_validation_succeeds(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of validation_accuracy (mutable) must succeed."""
+        mid = trigger_test_scaffold["model_id"]
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "UPDATE probability_models SET validation_accuracy = %s "
+                "WHERE model_id = %s RETURNING model_id",
+                (Decimal("0.8765"), mid),
+            )
+            assert cur.fetchone() is not None
+
+    def test_update_immutable_config_raises(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of config (immutable) must raise."""
+        mid = trigger_test_scaffold["model_id"]
+        with get_cursor(commit=True) as cur:
+            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+                cur.execute(
+                    "UPDATE probability_models SET config = %s WHERE model_id = %s",
+                    (json.dumps({"learning_rate": "0.99"}), mid),
+                )
+
+    def test_update_immutable_version_raises(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of model_version (immutable) must raise."""
+        mid = trigger_test_scaffold["model_id"]
+        with get_cursor(commit=True) as cur:
+            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+                cur.execute(
+                    "UPDATE probability_models SET model_version = '2.0' WHERE model_id = %s",
+                    (mid,),
+                )
+
+    def test_update_immutable_name_raises(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of model_name (immutable) must raise."""
+        mid = trigger_test_scaffold["model_id"]
+        with get_cursor(commit=True) as cur:
+            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+                cur.execute(
+                    "UPDATE probability_models SET model_name = 'tampered' WHERE model_id = %s",
+                    (mid,),
+                )
+
+    def test_update_immutable_class_raises(self, trigger_test_scaffold: dict) -> None:
+        """UPDATE of model_class (immutable) must raise.
+
+        Uses a valid FK value ('ensemble') so the trigger — not the FK
+        constraint — is what blocks the change.
+        """
+        mid = trigger_test_scaffold["model_id"]
+        with get_cursor(commit=True) as cur:
+            with pytest.raises(psycopg2.errors.RaiseException, match="immutable"):
+                cur.execute(
+                    "UPDATE probability_models SET model_class = 'ensemble' WHERE model_id = %s",
+                    (mid,),
+                )
+
+    def test_noop_update_of_immutable_column_succeeds(self, trigger_test_scaffold: dict) -> None:
+        """No-op UPDATE (same value) must succeed — IS DISTINCT FROM semantics."""
+        mid = trigger_test_scaffold["model_id"]
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "UPDATE probability_models SET config = config, status = 'active' "
+                "WHERE model_id = %s RETURNING model_id",
+                (mid,),
+            )
+            assert cur.fetchone() is not None
+
+
+# =============================================================================
+# Test: Append-only enforcement — INSERT OK, UPDATE blocked
+# =============================================================================
+
+
+def _insert_append_only_row(
+    cur: Any,
+    table: str,
+    scaffold: dict,
+) -> int:
+    """INSERT a minimal valid row into an append-only table. Returns PK."""
+    pid = scaffold["platform_id"]
+    pos_id = scaffold["position_internal_id"]
+    mkt_id = scaffold["market_internal_id"]
+
+    if table == "trades":
+        cur.execute(
+            """
+            INSERT INTO trades (
+                platform_id, market_internal_id, side, price,
+                quantity, execution_environment
+            )
+            VALUES (%s, %s, 'buy', %s, 1, 'live')
+            RETURNING id
+            """,
+            (pid, mkt_id, Decimal("0.5000")),
+        )
+        return cur.fetchone()["id"]
+
+    if table == "settlements":
+        cur.execute(
+            """
+            INSERT INTO settlements (
+                platform_id, market_internal_id, outcome, payout,
+                execution_environment
+            )
+            VALUES (%s, %s, 'yes', %s, 'live')
+            RETURNING id
+            """,
+            (pid, mkt_id, Decimal("1.0000")),
+        )
+        return cur.fetchone()["id"]
+
+    if table == "account_ledger":
+        cur.execute(
+            """
+            INSERT INTO account_ledger (
+                platform_id, transaction_type, amount,
+                running_balance, execution_environment
+            )
+            VALUES (%s, 'deposit', %s, %s, 'live')
+            RETURNING id
+            """,
+            (pid, Decimal("100.0000"), Decimal("100.0000")),
+        )
+        return cur.fetchone()["id"]
+
+    if table == "position_exits":
+        cur.execute(
+            """
+            INSERT INTO position_exits (
+                position_internal_id, exit_reason, execution_environment
+            )
+            VALUES (%s, 'test_trigger', 'live')
+            RETURNING exit_id
+            """,
+            (pos_id,),
+        )
+        return cur.fetchone()["exit_id"]
+
+    if table == "exit_attempts":
+        cur.execute(
+            """
+            INSERT INTO exit_attempts (
+                position_internal_id, exit_reason, execution_environment
+            )
+            VALUES (%s, 'test_trigger', 'live')
+            RETURNING attempt_id
+            """,
+            (pos_id,),
+        )
+        return cur.fetchone()["attempt_id"]
+
+    raise ValueError(f"Unknown table: {table}")
+
+
+# PK column name per table (for the UPDATE WHERE clause).
+_PK_COLUMN = {
+    "trades": "id",
+    "settlements": "id",
+    "account_ledger": "id",
+    "position_exits": "exit_id",
+    "exit_attempts": "attempt_id",
+}
+
+# A harmless column to attempt UPDATE on (exists on all 5 tables).
+_UPDATE_COLUMN = {
+    "trades": "price",
+    "settlements": "payout",
+    "account_ledger": "amount",
+    "position_exits": "exit_reason",
+    "exit_attempts": "exit_reason",
+}
+
+_UPDATE_VALUE = {
+    "trades": Decimal("0.9999"),
+    "settlements": Decimal("0.0001"),
+    "account_ledger": Decimal("999.0000"),
+    "position_exits": "tampered",
+    "exit_attempts": "tampered",
+}
+
+
+@pytest.mark.integration
+class TestAppendOnlyEnforcement:
+    """Verify INSERT succeeds and UPDATE is blocked on all 5 append-only tables."""
+
+    @pytest.mark.parametrize("table", APPEND_ONLY_TABLES)
+    def test_insert_succeeds(self, trigger_test_scaffold: dict, table: str) -> None:
+        """INSERT into append-only table must succeed normally."""
+        with get_cursor(commit=True) as cur:
+            pk = _insert_append_only_row(cur, table, trigger_test_scaffold)
+            assert pk is not None
+
+    @pytest.mark.parametrize("table", APPEND_ONLY_TABLES)
+    def test_update_raises(self, trigger_test_scaffold: dict, table: str) -> None:
+        """UPDATE on append-only table must raise with clear message."""
+        with get_cursor(commit=True) as cur:
+            pk = _insert_append_only_row(cur, table, trigger_test_scaffold)
+
+        with get_cursor(commit=True) as cur:
+            pk_col = _PK_COLUMN[table]
+            upd_col = _UPDATE_COLUMN[table]
+            upd_val = _UPDATE_VALUE[table]
+            with pytest.raises(psycopg2.errors.RaiseException, match="append-only"):
+                cur.execute(
+                    f"UPDATE {table} SET {upd_col} = %s WHERE {pk_col} = %s",  # noqa: S608
+                    (upd_val, pk),
+                )
+
+    @pytest.mark.parametrize("table", APPEND_ONLY_TABLES)
+    def test_delete_still_works(self, trigger_test_scaffold: dict, table: str) -> None:
+        """DELETE must still work — triggers only block UPDATE, not DELETE.
+
+        This confirms cleanup and administrative corrections remain possible.
+        """
+        with get_cursor(commit=True) as cur:
+            pk = _insert_append_only_row(cur, table, trigger_test_scaffold)
+
+        with get_cursor(commit=True) as cur:
+            pk_col = _PK_COLUMN[table]
+            cur.execute(
+                f"DELETE FROM {table} WHERE {pk_col} = %s RETURNING {pk_col}",  # noqa: S608
+                (pk,),
+            )
+            assert cur.fetchone() is not None


### PR DESCRIPTION
## Summary

- **Migration 0056**: Adds BEFORE UPDATE triggers enforcing immutability on `strategies` and `probability_models` (selective — config/version/name/type blocked, status/counters remain mutable) and append-only enforcement on 5 fact tables (`trades`, `settlements`, `account_ledger`, `position_exits`, `exit_attempts`)
- **42 integration tests** against ephemeral testcontainer: DDL existence, mutable UPDATE succeeds, immutable UPDATE raises, append-only UPDATE raises, DELETE still works, no-op passthrough, multi-column mutation, zero-row match
- Highest-conviction item in Schema Hardening Arc — 8 of 12 council agents flagged #371

## Agent Review Trail

| Agent | Role | Key Findings |
|-------|------|-------------|
| **Samwise** (Builder) | Pattern compliance | Followed 0002 trigger pattern, idempotent DROP IF EXISTS + CREATE |
| **Glokta** (Reviewer) | Adversarial review | 0 blocking, 6 warnings: (1) added future-migration warning to docstring, (2) documented `domain`/`platform_id`/`training_*` as intentionally unprotected, (3) fixed docstring `updated_at` error for models, (4) added multi-column mutation test, (5) added zero-row match test |
| **Ripley** (QA) | Pre-push validation | 3,682 passed (unit+integration+e2e), 0 failed, 0 regressions |

## Test Plan

- [x] 42 integration tests pass (testcontainer)
- [x] 2,581 unit tests pass (no regressions)
- [x] 3,682 pre-push tier tests pass (unit+integration+e2e)
- [x] Migration applied to both dev and test DBs
- [x] `update_strategy_status()` verified compatible (updates mutable columns only)
- [x] Ruff lint + format clean
- [x] Pre-commit hooks pass

Closes #371
Closes #723

🤖 Generated with [Claude Code](https://claude.com/claude-code)