### PR TITLE
feat: Temporal alignment writer service (#722)

### DIFF
--- a/scripts/audit_test_type_coverage.py
+++ b/scripts/audit_test_type_coverage.py
@@ -153,6 +153,7 @@ MODULE_TIERS = {
     # TUI entries removed — TUI deleted in PR #563 (#558)
     # Schedulers
     "schedulers/espn_game_poller": "business",
+    "schedulers/temporal_alignment_writer": "business",
     # Priority-based polling (#560) — new module, promote to business when test suite expands
     "schedulers/league_priority": "experimental",
     # Validation

--- a/src/precog/database/crud_ledger.py
+++ b/src/precog/database/crud_ledger.py
@@ -452,9 +452,12 @@ def insert_temporal_alignment_batch(alignments: list[dict]) -> int:
             - game_id (int | None) -- FK to games(id), denormalized from events
 
     Returns:
-        Count of rows inserted (duplicates are silently skipped via
-        ON CONFLICT DO NOTHING on the unique constraint
-        uq_alignment_snapshot_game).
+        Count of rows actually inserted (not rows submitted). Duplicates
+        on the unique constraint uq_alignment_snapshot_game are silently
+        skipped via ON CONFLICT DO NOTHING. The returned count comes from
+        psycopg2's cur.rowcount after execute_values, so retry cycles that
+        catch up within the lookback window correctly report the net-new
+        row count rather than the submitted count.
 
     Raises:
         TypeError: If Decimal fields are not Decimal type
@@ -547,13 +550,19 @@ def insert_temporal_alignment_batch(alignments: list[dict]) -> int:
             game_status, home_score, away_score, period, clock,
             game_id
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        VALUES %s
         ON CONFLICT (market_snapshot_id, game_state_id) DO NOTHING
     """
+    template = "(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)"
 
+    # Use execute_values + cur.rowcount (mirrors upsert_market_trades_batch)
+    # so the return value reflects rows *actually inserted* rather than rows
+    # submitted. ON CONFLICT DO NOTHING will skip duplicates; cur.rowcount
+    # on execute_values reports the effective count, unlike executemany
+    # where DB-API 2.0 leaves rowcount undefined across iterations.
     with get_cursor(commit=True) as cur:
-        cur.executemany(insert_query, validated_params)
-        return len(validated_params)
+        execute_values(cur, insert_query, validated_params, template=template)
+        return cast("int", cur.rowcount)
 
 
 def get_alignments_by_market(

--- a/src/precog/database/crud_ledger.py
+++ b/src/precog/database/crud_ledger.py
@@ -452,8 +452,9 @@ def insert_temporal_alignment_batch(alignments: list[dict]) -> int:
             - game_id (int | None) -- FK to games(id), denormalized from events
 
     Returns:
-        Count of rows submitted for insertion (not deduplicated -- this table
-        has no ON CONFLICT clause, so all submitted rows are inserted).
+        Count of rows inserted (duplicates are silently skipped via
+        ON CONFLICT DO NOTHING on the unique constraint
+        uq_alignment_snapshot_game).
 
     Raises:
         TypeError: If Decimal fields are not Decimal type
@@ -547,6 +548,7 @@ def insert_temporal_alignment_batch(alignments: list[dict]) -> int:
             game_id
         )
         VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (market_snapshot_id, game_state_id) DO NOTHING
     """
 
     with get_cursor(commit=True) as cur:

--- a/src/precog/database/crud_shared.py
+++ b/src/precog/database/crud_shared.py
@@ -66,6 +66,8 @@ VALID_EXECUTION_ENVIRONMENTS_TRADE_POSITION: frozenset[str] = frozenset(
 #   - 'edge_detector':   Edge detection engine
 #   - 'trading_engine':  Trade execution engine
 #   - 'websocket':       WebSocket connections
+# Internal services:
+#   - 'temporal_alignment': Temporal alignment writer (links snapshots to game states)
 # Planned Tier A components (not yet active):
 #   - 'polymarket_api':  Polymarket prediction market API
 SystemHealthComponent = Literal[
@@ -77,6 +79,7 @@ SystemHealthComponent = Literal[
     "edge_detector",
     "trading_engine",
     "websocket",
+    "temporal_alignment",
 ]
 
 # Runtime set for O(1) validation in upsert_system_health.

--- a/src/precog/schedulers/service_supervisor.py
+++ b/src/precog/schedulers/service_supervisor.py
@@ -58,6 +58,10 @@ from precog.database.crud_system import (
 from precog.schedulers.espn_game_poller import ESPNGamePoller, create_espn_poller
 from precog.schedulers.kalshi_poller import KalshiMarketPoller, create_kalshi_poller
 from precog.schedulers.kalshi_websocket import KalshiWebSocketHandler, create_websocket_handler
+from precog.schedulers.temporal_alignment_writer import (
+    TemporalAlignmentWriter,
+    create_temporal_alignment_writer,
+)
 
 # Set up logging early for helper functions
 logger = logging.getLogger(__name__)
@@ -77,11 +81,13 @@ SERVICE_TO_COMPONENT: dict[str, str] = {
     ESPNGamePoller.SERVICE_KEY: ESPNGamePoller.HEALTH_COMPONENT,
     KalshiMarketPoller.SERVICE_KEY: KalshiMarketPoller.HEALTH_COMPONENT,
     KalshiWebSocketHandler.SERVICE_KEY: KalshiWebSocketHandler.HEALTH_COMPONENT,
+    TemporalAlignmentWriter.SERVICE_KEY: TemporalAlignmentWriter.HEALTH_COMPONENT,
 }
 COMPONENT_TO_BREAKER_TYPE: dict[str, str] = {
     ESPNGamePoller.HEALTH_COMPONENT: ESPNGamePoller.BREAKER_TYPE,
     KalshiMarketPoller.HEALTH_COMPONENT: KalshiMarketPoller.BREAKER_TYPE,
     KalshiWebSocketHandler.HEALTH_COMPONENT: KalshiWebSocketHandler.BREAKER_TYPE,
+    TemporalAlignmentWriter.HEALTH_COMPONENT: TemporalAlignmentWriter.BREAKER_TYPE,
 }
 
 
@@ -1198,6 +1204,16 @@ def _create_kalshi_ws(
     )
 
 
+def _create_temporal_alignment(
+    **_kwargs: Any,
+) -> EventLoopService:
+    """Factory for Temporal Alignment Writer."""
+    return cast(
+        "EventLoopService",
+        create_temporal_alignment_writer(),
+    )
+
+
 # Registry mapping service names to factory callables.
 # To add a new service (e.g., Polymarket):
 #   1. Add SERVICE_KEY/HEALTH_COMPONENT/BREAKER_TYPE class vars to the poller
@@ -1208,6 +1224,7 @@ SERVICE_FACTORIES: dict[str, Callable[..., EventLoopService | None]] = {
     "espn": _create_espn,
     "kalshi_rest": _create_kalshi_rest,
     "kalshi_ws": _create_kalshi_ws,
+    "temporal_alignment": _create_temporal_alignment,
 }
 
 

--- a/src/precog/schedulers/temporal_alignment_writer.py
+++ b/src/precog/schedulers/temporal_alignment_writer.py
@@ -99,6 +99,8 @@ _UNALIGNED_QUERY = """
         LIMIT 1
     ) gs
     WHERE e.game_id IS NOT NULL
+      -- psycopg2 substitutes %s inside the string literal, producing
+      -- e.g. INTERVAL '600 seconds'. Safe: lookback_seconds is typed int.
       AND ms.row_start_ts > NOW() - INTERVAL '%s seconds'
       AND NOT EXISTS (
           SELECT 1 FROM temporal_alignment ta
@@ -131,6 +133,12 @@ def find_unaligned_pairs(
 
     Returns list of dicts ready for insert_temporal_alignment_batch().
     """
+    if lookback_seconds <= 0 or batch_limit <= 0:
+        raise ValueError(
+            f"lookback_seconds and batch_limit must be positive, "
+            f"got {lookback_seconds=}, {batch_limit=}"
+        )
+
     with get_cursor() as cur:
         cur.execute(_UNALIGNED_QUERY, (lookback_seconds, batch_limit))
         rows = cur.fetchall()

--- a/src/precog/schedulers/temporal_alignment_writer.py
+++ b/src/precog/schedulers/temporal_alignment_writer.py
@@ -99,9 +99,14 @@ _UNALIGNED_QUERY = """
         LIMIT 1
     ) gs
     WHERE e.game_id IS NOT NULL
-      -- psycopg2 substitutes %s inside the string literal, producing
-      -- e.g. INTERVAL '600 seconds'. Safe: lookback_seconds is typed int.
-      AND ms.row_start_ts > NOW() - INTERVAL '%s seconds'
+      -- Idiomatic parameterized interval: pass the seconds count as a
+      -- plain integer parameter and let PostgreSQL multiply. Prior
+      -- versions used INTERVAL '%s seconds' which embedded the parameter
+      -- inside a string literal -- safe while lookback_seconds was
+      -- int-typed, but brittle if the type were ever loosened and
+      -- unconventional psycopg2 usage (parameters should be values, not
+      -- SQL fragments).
+      AND ms.row_start_ts > NOW() - (%s * INTERVAL '1 second')
       AND NOT EXISTS (
           SELECT 1 FROM temporal_alignment ta
           WHERE ta.market_snapshot_id = ms.id

--- a/src/precog/schedulers/temporal_alignment_writer.py
+++ b/src/precog/schedulers/temporal_alignment_writer.py
@@ -1,0 +1,241 @@
+"""Temporal alignment writer service.
+
+Background service that links market_snapshots to game_states by timestamp
+proximity, populating the temporal_alignment table. Runs alongside the
+ESPN and Kalshi pollers in the ServiceSupervisor.
+
+Issue: #722 (URGENT — irreversible data loss per unplayed game)
+Epic: #745 (Schema Hardening Arc, Cohort C0)
+
+Architecture:
+    ESPN Poller (30s) --> game_states (SCD Type 2)
+                                                    |
+                                            Temporal Alignment Writer (30s)
+                                                    |
+    Kalshi Poller (15s) --> market_snapshots (SCD Type 2)
+                                                    |
+                                              temporal_alignment table
+
+FK chain: market_snapshots -> markets -> events -> games <- game_states
+
+Quality thresholds (time_delta_seconds):
+    exact:  <= 1s   (both polled within the same second)
+    good:   <= 15s  (within Kalshi poll interval)
+    fair:   <= 60s  (within a minute)
+    poor:   <= 120s (noticeable lag)
+    stale:  > 120s  (too old for reliable correlation)
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from typing import Any, ClassVar
+
+from precog.database.connection import get_cursor
+from precog.database.crud_ledger import insert_temporal_alignment_batch
+from precog.schedulers.base_poller import BasePoller
+
+logger = logging.getLogger(__name__)
+
+# Quality thresholds in seconds.
+_QUALITY_EXACT = Decimal("1")
+_QUALITY_GOOD = Decimal("15")
+_QUALITY_FAIR = Decimal("60")
+_QUALITY_POOR = Decimal("120")
+
+# Maximum age (seconds) of snapshots to consider. Prevents full-table scans
+# when the writer has been down for a long time. For historical reconstruction,
+# use a separate batch job instead.
+_LOOKBACK_SECONDS = 600  # 10 minutes
+
+# Maximum alignments per poll cycle.
+_BATCH_LIMIT = 1000
+
+# Query to find unaligned market_snapshot + game_state pairs.
+# Follows the FK chain: market_snapshots -> markets -> events -> games <- game_states.
+# Only processes snapshots created within the lookback window.
+#
+# IMPORTANT (Glokta review B1): We do NOT filter ms.row_current_ind = TRUE.
+# In SCD Type 2, a snapshot becomes non-current when the next snapshot arrives
+# (every ~15s). If the writer falls behind by even one cycle, non-current
+# snapshots would be permanently unaligned. The lookback window + NOT EXISTS
+# are sufficient to prevent reprocessing.
+#
+# For game_states, we use a LATERAL subquery to find the closest game_state
+# by timestamp for each snapshot, rather than just the current one. This
+# produces accurate alignments even when the writer runs slightly behind
+# the pollers.
+_UNALIGNED_QUERY = """
+    SELECT
+        ms.id AS market_snapshot_id,
+        ms.market_id,
+        ms.row_start_ts AS snapshot_time,
+        ms.yes_ask_price,
+        ms.no_ask_price,
+        ms.spread,
+        ms.volume,
+        gs.id AS game_state_id,
+        gs.row_start_ts AS game_state_time,
+        gs.game_status,
+        gs.home_score,
+        gs.away_score,
+        gs.period::VARCHAR AS period,
+        gs.clock_display AS clock,
+        g.id AS game_id,
+        ABS(EXTRACT(EPOCH FROM (ms.row_start_ts - gs.row_start_ts)))::DECIMAL(10,2)
+            AS time_delta_raw
+    FROM market_snapshots ms
+    JOIN markets m ON ms.market_id = m.id
+    JOIN events e ON m.event_internal_id = e.id
+    JOIN games g ON e.game_id = g.id
+    CROSS JOIN LATERAL (
+        SELECT gs_inner.id, gs_inner.row_start_ts, gs_inner.game_status,
+               gs_inner.home_score, gs_inner.away_score,
+               gs_inner.period, gs_inner.clock_display
+        FROM game_states gs_inner
+        WHERE gs_inner.game_id = g.id
+        ORDER BY ABS(EXTRACT(EPOCH FROM (ms.row_start_ts - gs_inner.row_start_ts)))
+        LIMIT 1
+    ) gs
+    WHERE e.game_id IS NOT NULL
+      AND ms.row_start_ts > NOW() - INTERVAL '%s seconds'
+      AND NOT EXISTS (
+          SELECT 1 FROM temporal_alignment ta
+          WHERE ta.market_snapshot_id = ms.id
+            AND ta.game_state_id = gs.id
+      )
+    ORDER BY ms.row_start_ts DESC
+    LIMIT %s
+"""
+
+
+def _classify_quality(time_delta: Decimal) -> str:
+    """Classify alignment quality based on time delta."""
+    if time_delta <= _QUALITY_EXACT:
+        return "exact"
+    if time_delta <= _QUALITY_GOOD:
+        return "good"
+    if time_delta <= _QUALITY_FAIR:
+        return "fair"
+    if time_delta <= _QUALITY_POOR:
+        return "poor"
+    return "stale"
+
+
+def find_unaligned_pairs(
+    lookback_seconds: int = _LOOKBACK_SECONDS,
+    batch_limit: int = _BATCH_LIMIT,
+) -> list[dict[str, Any]]:
+    """Find market_snapshot + game_state pairs without temporal alignments.
+
+    Returns list of dicts ready for insert_temporal_alignment_batch().
+    """
+    with get_cursor() as cur:
+        cur.execute(_UNALIGNED_QUERY, (lookback_seconds, batch_limit))
+        rows = cur.fetchall()
+
+    alignments = []
+    for row in rows:
+        time_delta = Decimal(str(row["time_delta_raw"]))
+        quality = _classify_quality(time_delta)
+
+        alignments.append(
+            {
+                "market_id": row["market_id"],
+                "market_snapshot_id": row["market_snapshot_id"],
+                "game_state_id": row["game_state_id"],
+                "snapshot_time": row["snapshot_time"],
+                "game_state_time": row["game_state_time"],
+                "time_delta_seconds": time_delta,
+                "alignment_quality": quality,
+                "yes_ask_price": (
+                    Decimal(str(row["yes_ask_price"])) if row["yes_ask_price"] is not None else None
+                ),
+                "no_ask_price": (
+                    Decimal(str(row["no_ask_price"])) if row["no_ask_price"] is not None else None
+                ),
+                "spread": (Decimal(str(row["spread"])) if row["spread"] is not None else None),
+                "volume": row["volume"],
+                "game_status": row["game_status"],
+                "home_score": row["home_score"],
+                "away_score": row["away_score"],
+                "period": row["period"],
+                "clock": row["clock"],
+                "game_id": row["game_id"],
+            }
+        )
+
+    return alignments
+
+
+class TemporalAlignmentWriter(BasePoller):
+    """Background service that populates the temporal_alignment table.
+
+    Polls for unaligned market_snapshot + game_state pairs and creates
+    temporal_alignment rows with timestamp-based quality classification.
+
+    Requires both ESPN and Kalshi pollers to be running to produce data.
+    """
+
+    SERVICE_KEY: ClassVar[str] = "temporal_alignment"
+    HEALTH_COMPONENT: ClassVar[str] = "temporal_alignment"
+    BREAKER_TYPE: ClassVar[str] = "data_stale"
+
+    MIN_POLL_INTERVAL: ClassVar[int] = 5
+    DEFAULT_POLL_INTERVAL: ClassVar[int] = 30
+
+    def __init__(
+        self,
+        poll_interval: int | None = None,
+        lookback_seconds: int = _LOOKBACK_SECONDS,
+        batch_limit: int = _BATCH_LIMIT,
+    ) -> None:
+        super().__init__(poll_interval=poll_interval)
+        self._lookback_seconds = lookback_seconds
+        self._batch_limit = batch_limit
+
+    def _get_job_name(self) -> str:
+        return "Temporal Alignment Writer"
+
+    def _poll_once(self) -> dict[str, int]:
+        """Execute a single alignment cycle.
+
+        Returns:
+            Stats dict with items_created count (key matches BasePoller stats).
+        """
+        try:
+            pairs = find_unaligned_pairs(
+                lookback_seconds=self._lookback_seconds,
+                batch_limit=self._batch_limit,
+            )
+
+            if not pairs:
+                self.logger.debug("No unaligned pairs found")
+                return {"items_created": 0}
+
+            count = insert_temporal_alignment_batch(pairs)
+
+            self.logger.info(
+                "Created %d temporal alignments (%d pairs found)",
+                count,
+                len(pairs),
+            )
+            return {"items_created": count}
+
+        except Exception:
+            self.logger.exception("Temporal alignment cycle failed")
+            raise
+
+
+def create_temporal_alignment_writer(
+    poll_interval: int = TemporalAlignmentWriter.DEFAULT_POLL_INTERVAL,
+    lookback_seconds: int = _LOOKBACK_SECONDS,
+    batch_limit: int = _BATCH_LIMIT,
+) -> TemporalAlignmentWriter:
+    """Factory function for ServiceSupervisor registration."""
+    return TemporalAlignmentWriter(
+        poll_interval=poll_interval,
+        lookback_seconds=lookback_seconds,
+        batch_limit=batch_limit,
+    )

--- a/tests/e2e/cli/test_cli_scheduler_e2e.py
+++ b/tests/e2e/cli/test_cli_scheduler_e2e.py
@@ -100,22 +100,31 @@ class TestSchedulerStartStopWorkflow:
     def test_scheduler_restart_workflow(self, isolated_app) -> None:
         """Test scheduler restart workflow.
 
-        E2E: Tests stop then start sequence.
+        E2E: Tests stop then start sequence via the supervised path. See
+        the docstring on test_complete_scheduler_lifecycle for why the
+        mock targets create_supervisor and the invocation passes
+        --supervised.
         """
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
+        with (
+            patch(
+                "precog.schedulers.service_supervisor.create_supervisor"
+            ) as mock_create_supervisor,
+            patch("precog.cli.scheduler._validate_startup", return_value=True),
+            patch("precog.cli.scheduler._prevent_system_sleep_for_supervised"),
+        ):
             mock_instance = MagicMock()
-            mock_instance.start.return_value = True
+            mock_instance.start_all.return_value = None
             mock_instance.stop.return_value = True
-            mock_supervisor.return_value = mock_instance
+            mock_create_supervisor.return_value = mock_instance
 
-            # Stop (should handle not running)
+            # Stop (should handle not running — module globals are all None)
             result = runner.invoke(isolated_app, ["scheduler", "stop"])
             assert result.exit_code in [0, 1, 2]
 
-            # Start
-            result = runner.invoke(isolated_app, ["scheduler", "start"])
+            # Start via supervised path so create_supervisor mock is effective
+            result = runner.invoke(isolated_app, ["scheduler", "start", "--supervised"])
             assert result.exit_code in [0, 1, 2]
 
 
@@ -126,15 +135,37 @@ class TestSchedulerPollingWorkflow:
         """Test single poll execution workflow.
 
         E2E: Tests poll-once from CLI through database.
+
+        The poll_once CLI command does not go through create_supervisor --
+        it imports ESPNGamePoller and KalshiMarketPoller directly from
+        precog.schedulers and instantiates them. Patch those poller
+        classes at the package re-export path so the delayed function-
+        scoped import inside poll_once picks up the mocks.
         """
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.poll_once.return_value = {"games": 5, "updated": 3}
-            mock_supervisor.return_value = mock_instance
+        with (
+            patch("precog.schedulers.ESPNGamePoller") as mock_espn,
+            patch("precog.schedulers.KalshiMarketPoller") as mock_kalshi,
+        ):
+            mock_espn_instance = MagicMock()
+            mock_espn_instance.poll_once.return_value = {
+                "items_fetched": 5,
+                "items_updated": 3,
+            }
+            mock_espn.return_value = mock_espn_instance
 
-            result = runner.invoke(isolated_app, ["scheduler", "poll-once", "--league", "nfl"])
+            mock_kalshi_instance = MagicMock()
+            mock_kalshi_instance.poll_once.return_value = {
+                "items_fetched": 10,
+                "items_updated": 8,
+                "items_created": 2,
+            }
+            mock_kalshi.return_value = mock_kalshi_instance
+
+            # Note: scheduler poll-once takes --leagues (comma-separated string),
+            # not --league, per src/precog/cli/scheduler.py::poll_once.
+            result = runner.invoke(isolated_app, ["scheduler", "poll-once", "--leagues", "nfl"])
             assert result.exit_code in [0, 1, 2]
 
     def test_poll_multiple_leagues_workflow(self, isolated_app) -> None:
@@ -144,14 +175,28 @@ class TestSchedulerPollingWorkflow:
         """
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.poll_once.return_value = {"games": 10, "updated": 8}
-            mock_supervisor.return_value = mock_instance
+        with (
+            patch("precog.schedulers.ESPNGamePoller") as mock_espn,
+            patch("precog.schedulers.KalshiMarketPoller") as mock_kalshi,
+        ):
+            mock_espn_instance = MagicMock()
+            mock_espn_instance.poll_once.return_value = {
+                "items_fetched": 20,
+                "items_updated": 12,
+            }
+            mock_espn.return_value = mock_espn_instance
+
+            mock_kalshi_instance = MagicMock()
+            mock_kalshi_instance.poll_once.return_value = {
+                "items_fetched": 30,
+                "items_updated": 18,
+                "items_created": 4,
+            }
+            mock_kalshi.return_value = mock_kalshi_instance
 
             result = runner.invoke(
                 isolated_app,
-                ["scheduler", "poll-once", "--league", "nfl", "--league", "nba", "--save"],
+                ["scheduler", "poll-once", "--leagues", "nfl,nba"],
             )
             assert result.exit_code in [0, 1, 2]
 
@@ -162,20 +207,33 @@ class TestSchedulerErrorRecovery:
     def test_scheduler_recovers_from_poll_error(self, isolated_app) -> None:
         """Test scheduler recovers from polling errors.
 
-        E2E: Tests error recovery workflow.
+        E2E: Tests error recovery workflow. See test_poll_once_workflow
+        for the mock-at-package-level pattern rationale.
         """
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.poll_once.side_effect = [
-                Exception("API error"),
-                {"games": 3, "updated": 2},
-            ]
-            mock_supervisor.return_value = mock_instance
+        with (
+            patch("precog.schedulers.ESPNGamePoller") as mock_espn,
+            patch("precog.schedulers.KalshiMarketPoller") as mock_kalshi,
+        ):
+            # ESPN poller raises on poll_once -- the CLI catches it and logs
+            # but does not crash, so exit code should still be in the normal
+            # range.
+            mock_espn_instance = MagicMock()
+            mock_espn_instance.poll_once.side_effect = Exception("API error")
+            mock_espn.return_value = mock_espn_instance
 
-            # First poll fails
-            result = runner.invoke(isolated_app, ["scheduler", "poll-once", "--league", "nfl"])
+            # Kalshi poller succeeds so the overall command still reports some
+            # progress.
+            mock_kalshi_instance = MagicMock()
+            mock_kalshi_instance.poll_once.return_value = {
+                "items_fetched": 3,
+                "items_updated": 2,
+                "items_created": 1,
+            }
+            mock_kalshi.return_value = mock_kalshi_instance
+
+            result = runner.invoke(isolated_app, ["scheduler", "poll-once", "--leagues", "nfl"])
             # CLI should handle error gracefully
             assert result.exit_code in [0, 1, 2, 3, 4, 5]
 
@@ -183,13 +241,18 @@ class TestSchedulerErrorRecovery:
         """Test scheduler handles stop request during poll.
 
         E2E: Tests graceful shutdown during operation.
+
+        The stop CLI command calls _scheduler_stop_impl() which accesses
+        module-global references to pollers/supervisor. With no prior
+        start command in this test, all those globals are None and the
+        stop command is a no-op -- no real I/O -- so no mocks are
+        required. We keep the test to document the expected exit code
+        behavior and to guard against regressions if stop ever gains
+        real I/O in the absence of running services.
         """
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.stop.return_value = True
-            mock_supervisor.return_value = mock_instance
-
-            result = runner.invoke(isolated_app, ["scheduler", "stop", "--force"])
-            assert result.exit_code in [0, 1, 2]
+        # scheduler stop does not accept a --force flag -- that belongs to
+        # scheduler start. Removing it to match the actual CLI signature.
+        result = runner.invoke(isolated_app, ["scheduler", "stop"])
+        assert result.exit_code in [0, 1, 2]

--- a/tests/e2e/cli/test_cli_scheduler_e2e.py
+++ b/tests/e2e/cli/test_cli_scheduler_e2e.py
@@ -43,18 +43,43 @@ class TestSchedulerStartStopWorkflow:
         """Test complete scheduler start-stop-status workflow.
 
         E2E: Tests full lifecycle from start to stop.
+
+        IMPORTANT: The CLI ``scheduler start`` command calls
+        ``create_supervisor(...)`` (a factory function), not
+        ``ServiceSupervisor(...)`` directly. The factory does
+        substantial setup work before instantiating the supervisor --
+        it creates Kalshi/ESPN pollers, rate limiters, circuit
+        breakers, and tests network connectivity. Patching only
+        ``ServiceSupervisor`` the class leaves all of that real setup
+        intact, which on CI causes the Kalshi poller to hit rate-limit
+        429s and hang inside ``time.sleep`` until pytest's per-test
+        timeout fires. The fix is to patch ``create_supervisor`` so
+        the factory itself is replaced.
+
+        In addition, ``_validate_startup`` must be patched to return
+        True so the CLI does not short-circuit with exit code 1 before
+        reaching the factory call. This test was previously "passing"
+        on many environments only because _validate_startup happened
+        to return False and the test accepted exit code 1 -- a silent
+        no-op that masked the real execution path.
         """
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
+        with (
+            patch(
+                "precog.schedulers.service_supervisor.create_supervisor"
+            ) as mock_create_supervisor,
+            patch("precog.cli.scheduler._validate_startup", return_value=True),
+            patch("precog.cli.scheduler._prevent_system_sleep_for_supervised"),
+        ):
             mock_instance = MagicMock()
-            mock_instance.start.return_value = True
+            mock_instance.start_all.return_value = None
             mock_instance.stop.return_value = True
-            mock_instance.is_running.return_value = True
+            mock_instance.is_running = True
             mock_instance.get_status.return_value = {"running": True, "pollers": []}
-            mock_supervisor.return_value = mock_instance
+            mock_create_supervisor.return_value = mock_instance
 
-            # Start scheduler
+            # Start scheduler (non-foreground so it returns immediately)
             result = runner.invoke(isolated_app, ["scheduler", "start"])
             assert result.exit_code in [0, 1, 2]
 

--- a/tests/e2e/cli/test_cli_scheduler_e2e.py
+++ b/tests/e2e/cli/test_cli_scheduler_e2e.py
@@ -79,8 +79,14 @@ class TestSchedulerStartStopWorkflow:
             mock_instance.get_status.return_value = {"running": True, "pollers": []}
             mock_create_supervisor.return_value = mock_instance
 
-            # Start scheduler (non-foreground so it returns immediately)
-            result = runner.invoke(isolated_app, ["scheduler", "start"])
+            # Start scheduler via the supervised code path. The non-supervised
+            # path at src/precog/cli/scheduler.py:619+ instantiates
+            # KalshiMarketPoller and ESPNGamePoller directly rather than going
+            # through create_supervisor(), so the mocks above would not cover
+            # it and the real pollers would spin up and hang on 429 retries.
+            # --supervised routes through _start_supervised_mode which is the
+            # code path our mocks actually replace.
+            result = runner.invoke(isolated_app, ["scheduler", "start", "--supervised"])
             assert result.exit_code in [0, 1, 2]
 
             # Check status

--- a/tests/unit/database/test_temporal_alignment_crud.py
+++ b/tests/unit/database/test_temporal_alignment_crud.py
@@ -217,10 +217,17 @@ class TestInsertTemporalAlignment:
 class TestInsertTemporalAlignmentBatch:
     """Unit tests for insert_temporal_alignment_batch function."""
 
+    @patch("precog.database.crud_ledger.execute_values")
     @patch("precog.database.crud_ledger.get_cursor")
-    def test_batch_insert_returns_count(self, mock_get_cursor):
-        """Test batch insert returns count of rows inserted."""
-        _mock_cursor_context(mock_get_cursor)
+    def test_batch_insert_returns_rowcount(self, mock_get_cursor, mock_exec_values):
+        """Batch insert returns cur.rowcount (actually inserted, not submitted).
+
+        The earlier implementation returned len(validated_params), which
+        inflated the count under ON CONFLICT DO NOTHING retries. This test
+        pins the rowcount-based return value to prevent regression.
+        """
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 2
 
         rows = [_default_alignment_dict(), _default_alignment_dict()]
         rows[1]["market_snapshot_id"] = 1002
@@ -229,6 +236,23 @@ class TestInsertTemporalAlignmentBatch:
         result = insert_temporal_alignment_batch(rows)
 
         assert result == 2
+        mock_exec_values.assert_called_once()
+
+    @patch("precog.database.crud_ledger.execute_values")
+    @patch("precog.database.crud_ledger.get_cursor")
+    def test_batch_insert_returns_rowcount_under_conflict(self, mock_get_cursor, mock_exec_values):
+        """rowcount=0 (all duplicates skipped) must return 0, not submitted count."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 0  # all rows were ON CONFLICT DO NOTHING
+
+        rows = [_default_alignment_dict(), _default_alignment_dict()]
+        rows[1]["market_snapshot_id"] = 1002
+        rows[1]["game_state_id"] = 502
+
+        result = insert_temporal_alignment_batch(rows)
+
+        assert result == 0
+        mock_exec_values.assert_called_once()
 
     def test_batch_insert_empty_list_returns_zero(self):
         """Test that empty list returns 0 without DB interaction."""
@@ -258,18 +282,21 @@ class TestInsertTemporalAlignmentBatch:
         with pytest.raises(ValueError, match="alignment_quality must be one of"):
             insert_temporal_alignment_batch([row])
 
+    @patch("precog.database.crud_ledger.execute_values")
     @patch("precog.database.crud_ledger.get_cursor")
-    def test_batch_insert_defaults_quality_to_good(self, mock_get_cursor):
+    def test_batch_insert_defaults_quality_to_good(self, mock_get_cursor, mock_exec_values):
         """Test that batch rows without alignment_quality default to 'good'."""
         mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
 
         row = _default_alignment_dict()
         # alignment_quality NOT set -- should default to 'good'
 
         insert_temporal_alignment_batch([row])
 
-        call_args = mock_cursor.executemany.call_args
-        params_list = call_args[0][1]
+        # execute_values(cur, sql, argslist, template=template)
+        call_args = mock_exec_values.call_args
+        params_list = call_args[0][2]
         # alignment_quality is the 7th param (index 6)
         assert params_list[0][6] == "good"
 
@@ -284,15 +311,39 @@ class TestInsertTemporalAlignmentBatch:
         with pytest.raises(TypeError, match="yes_ask_price must be Decimal"):
             insert_temporal_alignment_batch([row])
 
+    @patch("precog.database.crud_ledger.execute_values")
     @patch("precog.database.crud_ledger.get_cursor")
-    def test_batch_insert_calls_executemany(self, mock_get_cursor):
-        """Test that batch insert uses executemany for efficiency."""
+    def test_batch_insert_calls_execute_values(self, mock_get_cursor, mock_exec_values):
+        """Batch insert uses execute_values (matches upsert_market_trades_batch).
+
+        Switched from executemany in the S68 audit remediation: execute_values
+        supports well-defined cur.rowcount so the return value can reflect
+        actually-inserted rows (not submitted rows) under ON CONFLICT DO NOTHING.
+        """
         mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
 
         rows = [_default_alignment_dict()]
         insert_temporal_alignment_batch(rows)
 
-        mock_cursor.executemany.assert_called_once()
+        mock_exec_values.assert_called_once()
+        # First positional arg to execute_values is the cursor
+        assert mock_exec_values.call_args[0][0] is mock_cursor
+
+    @patch("precog.database.crud_ledger.execute_values")
+    @patch("precog.database.crud_ledger.get_cursor")
+    def test_batch_insert_sql_has_on_conflict_do_nothing(self, mock_get_cursor, mock_exec_values):
+        """Batch insert SQL uses ON CONFLICT DO NOTHING on uq_alignment_snapshot_game."""
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 1
+
+        insert_temporal_alignment_batch([_default_alignment_dict()])
+
+        # execute_values(cur, sql, argslist, template=template)
+        sql = mock_exec_values.call_args[0][1]
+        assert "ON CONFLICT" in sql
+        assert "DO NOTHING" in sql
+        assert "market_snapshot_id, game_state_id" in sql
 
 
 # =============================================================================

--- a/tests/unit/schedulers/test_temporal_alignment_writer.py
+++ b/tests/unit/schedulers/test_temporal_alignment_writer.py
@@ -199,10 +199,13 @@ class TestTemporalAlignmentWriter:
     ) -> None:
         """poll_once with no unaligned pairs inserts nothing."""
         mock_find.return_value = []
-        writer = TemporalAlignmentWriter()
+        writer = TemporalAlignmentWriter(lookback_seconds=450, batch_limit=250)
         result = writer._poll_once()
         assert result == {"items_created": 0}
         mock_insert.assert_not_called()
+        # _poll_once must forward the instance's configured lookback/batch
+        # values to find_unaligned_pairs, not default module constants.
+        mock_find.assert_called_once_with(lookback_seconds=450, batch_limit=250)
 
     @patch("precog.schedulers.temporal_alignment_writer.insert_temporal_alignment_batch")
     @patch("precog.schedulers.temporal_alignment_writer.find_unaligned_pairs")
@@ -214,10 +217,23 @@ class TestTemporalAlignmentWriter:
         """poll_once with pairs calls batch insert and returns count."""
         mock_find.return_value = [{"market_snapshot_id": 1}, {"market_snapshot_id": 2}]
         mock_insert.return_value = 2
-        writer = TemporalAlignmentWriter()
+        writer = TemporalAlignmentWriter(lookback_seconds=600, batch_limit=1000)
         result = writer._poll_once()
         assert result == {"items_created": 2}
         mock_insert.assert_called_once()
+        mock_find.assert_called_once_with(lookback_seconds=600, batch_limit=1000)
+
+    @patch("precog.schedulers.temporal_alignment_writer.find_unaligned_pairs")
+    def test_poll_once_reraises_exceptions(self, mock_find: MagicMock) -> None:
+        """poll_once must re-raise exceptions so the supervisor observes them.
+
+        Swallowing the exception would let the writer silently fail while
+        the circuit breaker and health component still report healthy.
+        """
+        mock_find.side_effect = RuntimeError("simulated DB failure")
+        writer = TemporalAlignmentWriter()
+        with pytest.raises(RuntimeError, match="simulated DB failure"):
+            writer._poll_once()
 
 
 class TestFactory:
@@ -236,3 +252,4 @@ class TestFactory:
         )
         assert writer.poll_interval == 60
         assert writer._lookback_seconds == 300
+        assert writer._batch_limit == 500

--- a/tests/unit/schedulers/test_temporal_alignment_writer.py
+++ b/tests/unit/schedulers/test_temporal_alignment_writer.py
@@ -1,0 +1,229 @@
+"""Unit tests for temporal_alignment_writer.
+
+Tests the quality classification logic and alignment record building.
+DB interactions are mocked — real DB tests are in integration/.
+
+Issue: #722
+"""
+
+from __future__ import annotations
+
+from datetime import UTC
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from precog.schedulers.temporal_alignment_writer import (
+    TemporalAlignmentWriter,
+    _classify_quality,
+    create_temporal_alignment_writer,
+    find_unaligned_pairs,
+)
+
+
+class TestClassifyQuality:
+    """Verify quality thresholds are correct."""
+
+    @pytest.mark.parametrize(
+        ("delta", "expected"),
+        [
+            (Decimal("0"), "exact"),
+            (Decimal("0.5"), "exact"),
+            (Decimal("1"), "exact"),
+            (Decimal("1.01"), "good"),
+            (Decimal("10"), "good"),
+            (Decimal("15"), "good"),
+            (Decimal("15.01"), "fair"),
+            (Decimal("30"), "fair"),
+            (Decimal("60"), "fair"),
+            (Decimal("60.01"), "poor"),
+            (Decimal("90"), "poor"),
+            (Decimal("120"), "poor"),
+            (Decimal("120.01"), "stale"),
+            (Decimal("300"), "stale"),
+            (Decimal("9999"), "stale"),
+        ],
+    )
+    def test_quality_classification(self, delta: Decimal, expected: str) -> None:
+        assert _classify_quality(delta) == expected
+
+    def test_boundaries_are_inclusive(self) -> None:
+        """Boundary values (1, 15, 60, 120) belong to the better tier."""
+        assert _classify_quality(Decimal("1")) == "exact"
+        assert _classify_quality(Decimal("15")) == "good"
+        assert _classify_quality(Decimal("60")) == "fair"
+        assert _classify_quality(Decimal("120")) == "poor"
+
+
+class TestFindUnalignedPairs:
+    """Test the query-to-dict transformation in find_unaligned_pairs."""
+
+    @patch("precog.schedulers.temporal_alignment_writer.get_cursor")
+    def test_empty_result(self, mock_get_cursor: MagicMock) -> None:
+        """No unaligned pairs returns empty list."""
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = find_unaligned_pairs()
+        assert result == []
+
+    @patch("precog.schedulers.temporal_alignment_writer.get_cursor")
+    def test_transforms_rows_to_dicts(self, mock_get_cursor: MagicMock) -> None:
+        """Rows from the query are transformed into alignment dicts."""
+        from datetime import datetime
+
+        now = datetime.now(tz=UTC)
+        mock_row = {
+            "market_snapshot_id": 42,
+            "market_id": 10,
+            "snapshot_time": now,
+            "yes_ask_price": Decimal("0.6500"),
+            "no_ask_price": Decimal("0.3800"),
+            "spread": Decimal("0.0300"),
+            "volume": 1500,
+            "game_state_id": 99,
+            "game_state_time": now,
+            "game_status": "in",
+            "home_score": 21,
+            "away_score": 14,
+            "period": "3",
+            "clock": "8:42",
+            "game_id": 5,
+            "time_delta_raw": Decimal("2.34"),
+        }
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [mock_row]
+        mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = find_unaligned_pairs()
+        assert len(result) == 1
+
+        alignment = result[0]
+        assert alignment["market_snapshot_id"] == 42
+        assert alignment["game_state_id"] == 99
+        assert alignment["time_delta_seconds"] == Decimal("2.34")
+        assert alignment["alignment_quality"] == "good"  # 2.34s is within 15s
+        assert alignment["yes_ask_price"] == Decimal("0.6500")
+        assert alignment["game_id"] == 5
+        assert alignment["home_score"] == 21
+        assert alignment["clock"] == "8:42"
+
+    @patch("precog.schedulers.temporal_alignment_writer.get_cursor")
+    def test_null_prices_handled(self, mock_get_cursor: MagicMock) -> None:
+        """NULL price fields remain None (not Decimal)."""
+        from datetime import datetime
+
+        now = datetime.now(tz=UTC)
+        mock_row = {
+            "market_snapshot_id": 1,
+            "market_id": 1,
+            "snapshot_time": now,
+            "yes_ask_price": None,
+            "no_ask_price": None,
+            "spread": None,
+            "volume": None,
+            "game_state_id": 1,
+            "game_state_time": now,
+            "game_status": "pre",
+            "home_score": 0,
+            "away_score": 0,
+            "period": "0",
+            "clock": None,
+            "game_id": 1,
+            "time_delta_raw": Decimal("0.5"),
+        }
+
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [mock_row]
+        mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = find_unaligned_pairs()
+        assert result[0]["yes_ask_price"] is None
+        assert result[0]["no_ask_price"] is None
+        assert result[0]["spread"] is None
+
+
+class TestTemporalAlignmentWriter:
+    """Test the writer service class."""
+
+    def test_default_construction(self) -> None:
+        writer = TemporalAlignmentWriter()
+        assert writer.poll_interval == 30
+        assert writer._lookback_seconds == 600
+        assert writer._batch_limit == 1000
+
+    def test_custom_construction(self) -> None:
+        writer = TemporalAlignmentWriter(
+            poll_interval=60,
+            lookback_seconds=300,
+            batch_limit=500,
+        )
+        assert writer.poll_interval == 60
+        assert writer._lookback_seconds == 300
+        assert writer._batch_limit == 500
+
+    def test_min_poll_interval_enforced(self) -> None:
+        with pytest.raises(ValueError, match="at least 5"):
+            TemporalAlignmentWriter(poll_interval=2)
+
+    def test_job_name(self) -> None:
+        writer = TemporalAlignmentWriter()
+        assert writer._get_job_name() == "Temporal Alignment Writer"
+
+    def test_service_metadata(self) -> None:
+        assert TemporalAlignmentWriter.SERVICE_KEY == "temporal_alignment"
+        assert TemporalAlignmentWriter.HEALTH_COMPONENT == "temporal_alignment"
+        assert TemporalAlignmentWriter.BREAKER_TYPE == "data_stale"
+
+    @patch("precog.schedulers.temporal_alignment_writer.insert_temporal_alignment_batch")
+    @patch("precog.schedulers.temporal_alignment_writer.find_unaligned_pairs")
+    def test_poll_once_no_pairs(
+        self,
+        mock_find: MagicMock,
+        mock_insert: MagicMock,
+    ) -> None:
+        """poll_once with no unaligned pairs inserts nothing."""
+        mock_find.return_value = []
+        writer = TemporalAlignmentWriter()
+        result = writer._poll_once()
+        assert result == {"items_created": 0}
+        mock_insert.assert_not_called()
+
+    @patch("precog.schedulers.temporal_alignment_writer.insert_temporal_alignment_batch")
+    @patch("precog.schedulers.temporal_alignment_writer.find_unaligned_pairs")
+    def test_poll_once_with_pairs(
+        self,
+        mock_find: MagicMock,
+        mock_insert: MagicMock,
+    ) -> None:
+        """poll_once with pairs calls batch insert and returns count."""
+        mock_find.return_value = [{"market_snapshot_id": 1}, {"market_snapshot_id": 2}]
+        mock_insert.return_value = 2
+        writer = TemporalAlignmentWriter()
+        result = writer._poll_once()
+        assert result == {"items_created": 2}
+        mock_insert.assert_called_once()
+
+
+class TestFactory:
+    """Test the factory function."""
+
+    def test_creates_writer(self) -> None:
+        writer = create_temporal_alignment_writer()
+        assert isinstance(writer, TemporalAlignmentWriter)
+        assert writer.poll_interval == 30
+
+    def test_custom_params(self) -> None:
+        writer = create_temporal_alignment_writer(
+            poll_interval=60,
+            lookback_seconds=300,
+            batch_limit=500,
+        )
+        assert writer.poll_interval == 60
+        assert writer._lookback_seconds == 300

--- a/tests/unit/schedulers/test_temporal_alignment_writer.py
+++ b/tests/unit/schedulers/test_temporal_alignment_writer.py
@@ -113,6 +113,15 @@ class TestFindUnalignedPairs:
         assert alignment["home_score"] == 21
         assert alignment["clock"] == "8:42"
 
+    @pytest.mark.parametrize(
+        ("lookback", "limit"),
+        [(0, 100), (-1, 100), (600, 0), (600, -5), (0, 0)],
+    )
+    def test_rejects_non_positive_params(self, lookback: int, limit: int) -> None:
+        """Zero or negative lookback_seconds / batch_limit raises ValueError."""
+        with pytest.raises(ValueError, match="must be positive"):
+            find_unaligned_pairs(lookback_seconds=lookback, batch_limit=limit)
+
     @patch("precog.schedulers.temporal_alignment_writer.get_cursor")
     def test_null_prices_handled(self, mock_get_cursor: MagicMock) -> None:
         """NULL price fields remain None (not Decimal)."""


### PR DESCRIPTION
## Summary

- **New service**: `TemporalAlignmentWriter` — background service that links `market_snapshots` to `game_states` by timestamp proximity, populating the `temporal_alignment` table
- **URGENT fix**: Every game played without this writer permanently loses ~430 cross-source observations needed for Phase 4 ML training
- Registered in ServiceSupervisor alongside ESPN + Kalshi pollers
- Uses LATERAL subquery for closest-in-time game_state matching (not just current)
- Quality classification: exact (<=1s), good (<=15s), fair (<=60s), poor (<=120s), stale (>120s)

## Agent Review Trail

| Agent | Role | Key Findings |
|-------|------|-------------|
| **Case** (Builder) | Data pipeline | Built writer with LATERAL subquery, quality classification, batch insert |
| **Glokta** (Reviewer) | Adversarial | 2 BLOCKING fixed: (1) removed `row_current_ind` filter on snapshots — prevents permanent data loss from superseded snapshots; (2) noted ON CONFLICT gap in batch insert; 5 WARNINGS: fixed stats key, SQL DECIMAL cast, documented INTERVAL pattern |

## Files Changed

| File | Change |
|------|--------|
| `src/precog/schedulers/temporal_alignment_writer.py` | **NEW** — writer service (~200 lines) |
| `tests/unit/schedulers/test_temporal_alignment_writer.py` | **NEW** — 28 unit tests |
| `src/precog/schedulers/service_supervisor.py` | Register in SERVICE_TO_COMPONENT, COMPONENT_TO_BREAKER_TYPE, SERVICE_FACTORIES |
| `src/precog/database/crud_shared.py` | Add `"temporal_alignment"` to SystemHealthComponent |
| `scripts/audit_test_type_coverage.py` | Register module in MODULE_TIERS |

## Test Plan

- [x] 28 unit tests pass (quality classification, row transformation, null handling, poll cycle, factory)
- [x] 2,609 unit tests pass (no regressions)
- [x] Pre-push hooks pass (lint, format, mypy, security)
- [x] Pre-commit hooks pass

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)