### PR TITLE
feat: Convert 59 FKs to RESTRICT + SCD Type 2 on teams/venues/series (#724)

### DIFF
--- a/src/precog/database/alembic/versions/0057_fk_restrict_conversion.py
+++ b/src/precog/database/alembic/versions/0057_fk_restrict_conversion.py
@@ -112,7 +112,7 @@ CASCADE -> RESTRICT (28):
 SCD Type 2 columns + indexes (3 tables):
   60. teams:  row_current_ind, row_start_ts, row_end_ts
             + idx_teams_current (partial on row_current_ind)
-            + idx_teams_unique_current (partial unique on team_code, sport)
+            + idx_teams_unique_current (partial unique on team_code, league)
   61. venues: row_current_ind, row_start_ts, row_end_ts
             + idx_venues_current (partial on row_current_ind)
             + idx_venues_unique_current (partial unique on espn_venue_id)
@@ -140,7 +140,12 @@ DISCREPANCIES vs original task brief:
     inventory (CASCADE, from 0022, explicitly named constraints)
   - teams business key: task brief said team_code alone, but team_code is NOT
     unique (migration 0003 changed to UNIQUE(team_code, sport), 0018 relaxed to
-    pro leagues only). Using (team_code, sport) to match existing uniqueness.
+    pro leagues only, 0039 introduced idx_teams_code_league_pro on
+    (team_code, league)). Design review chose (team_code, league) over
+    (team_code, sport) because league is more granular -- sport collapses
+    NFL+NCAAF under 'football' and would allow duplicate team_codes across
+    those two leagues. See the "Business key decisions" block above for the
+    full rationale.
 """
 
 from collections.abc import Sequence
@@ -502,6 +507,31 @@ def upgrade() -> None:
         'Always filter by row_current_ind = TRUE for current data.'
     """)
 
+    # =========================================================================
+    # Phase 4: Supporting indexes for consumers that depend on this migration
+    # =========================================================================
+    # Compound index for temporal_alignment_writer (#747) and Pattern 63
+    # (LATERAL subquery for SCD temporal matching). The writer's hot-path
+    # query ORDERs by the time delta between a market_snapshot and the
+    # closest game_state for a given game_id:
+    #
+    #     SELECT ... FROM game_states gs_inner
+    #     WHERE gs_inner.game_id = gs.game_id
+    #     ORDER BY ABS(EXTRACT(EPOCH FROM (ms.row_start_ts - gs_inner.row_start_ts)))
+    #     LIMIT 1
+    #
+    # The pre-existing idx_game_states_game_id covers the equality filter
+    # but not the ORDER BY, so without this compound index the planner has
+    # to sort every matching game_state per snapshot row. At NFL-season
+    # scale (hundreds of state rows per game) that becomes a sequential
+    # scan per outer row. The compound (game_id, row_start_ts) lets the
+    # planner read rows in row_start_ts order for each game_id bucket.
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_game_states_game_id_row_start_ts
+        ON game_states(game_id, row_start_ts)
+        WHERE game_id IS NOT NULL
+    """)
+
 
 def downgrade() -> None:
     """Reverse: drop SCD columns + indexes, re-create FKs with original ON DELETE."""
@@ -514,6 +544,9 @@ def downgrade() -> None:
     op.execute("DROP VIEW IF EXISTS current_series")
     op.execute("DROP VIEW IF EXISTS current_venues")
     op.execute("DROP VIEW IF EXISTS current_teams")
+
+    # Drop supporting indexes introduced by Phase 4
+    op.execute("DROP INDEX IF EXISTS idx_game_states_game_id_row_start_ts")
 
     # Drop SCD indexes (they depend on the columns)
     op.execute("DROP INDEX IF EXISTS idx_series_platform_external_current")

--- a/src/precog/database/alembic/versions/0057_fk_restrict_conversion.py
+++ b/src/precog/database/alembic/versions/0057_fk_restrict_conversion.py
@@ -1,0 +1,624 @@
+"""Convert all SET NULL and CASCADE foreign keys to ON DELETE RESTRICT.
+
+Prevents silent data orphaning (SET NULL) and silent cascade deletion
+(CASCADE) across the entire schema. Every FK should block parent deletion
+instead of silently destroying provenance or child data. Also adds
+SCD Type 2 columns (row_current_ind, row_start_ts, row_end_ts) to
+teams, venues, and series for versioned soft-delete lifecycle management.
+
+Revision ID: 0057
+Revises: 0056
+Create Date: 2026-04-10
+
+Issues: #724, #725 (partial)
+Epic: #745 (Schema Hardening Arc, Cohort C2)
+
+Council attribution (Session 44):
+    17 SET NULL FKs -> RESTRICT flagged by Holden, Vader, Cassandra (C1)
+    9 CASCADE FKs -> RESTRICT flagged by Elrond, Mulder, Leto II (C1+C2)
+
+Part A: FK RESTRICT Conversion (59 FKs)
+    Every SET NULL and CASCADE FK converted to ON DELETE RESTRICT.
+    Dynamic constraint name discovery via information_schema.
+    Pre-flight orphan check + fix before constraint tightening.
+
+Part B: SCD Type 2 Columns on teams, venues, series (3 tables)
+    Same pattern as markets (0001), game_states (0001), positions (0001),
+    edges (0001), account_balance (0001+0049):
+        row_current_ind BOOLEAN NOT NULL DEFAULT TRUE
+        row_start_ts    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        row_end_ts      TIMESTAMPTZ (nullable)
+    Plus partial unique indexes on business keys and current-row indexes.
+
+    Business key decisions:
+        teams:  (team_code, league) -- team_code alone is NOT unique across
+                sports (PHI = Eagles in NFL, 76ers in NBA; "WES" = 5 NCAAF
+                teams). Uses league (not sport) for granularity -- sport
+                groups NFL+NCAAF as 'football'. Matches the existing
+                idx_teams_code_league_pro constraint (0039), which is
+                dropped in this migration (it lacks row_current_ind filter).
+        venues: espn_venue_id -- nullable, so NULL venues are not uniqueness-
+                protected (PostgreSQL treats each NULL as distinct in UNIQUE).
+        series: series_id -- unique business key (constraint uq_series_series_id
+                from migration 0019).
+
+FK INVENTORY (verified against migration files, phantoms removed):
+
+SET NULL -> RESTRICT (31):
+  1.  events.series_internal_id -> series(id)                     [0019]
+  2.  edges.model_id -> probability_models(model_id)              [0001]
+  3.  edges.strategy_id -> strategies(strategy_id)                [0023]
+  4.  historical_epa.team_id -> teams(team_id)                    [0013]
+  5.  elo_calculation_log.game_state_id -> game_states(id)        [0013]
+  6.  elo_calculation_log.home_team_id -> teams(team_id)          [0013]
+  7.  elo_calculation_log.away_team_id -> teams(team_id)          [0013]
+  8.  elo_calculation_log.game_id -> games(id)                    [0035]
+  9.  game_odds.home_team_id -> teams(team_id)                    [0013]
+  10. game_odds.away_team_id -> teams(team_id)                    [0013]
+  11. game_odds.game_id -> games(id)                              [0035]
+  12. historical_stats.team_id -> teams(team_id)                  [0013]
+  13. historical_rankings.team_id -> teams(team_id)               [0013]
+  14. orders.strategy_id -> strategies(strategy_id)               [0025]
+  15. orders.model_id -> probability_models(model_id)             [0025]
+  16. orders.edge_id -> edges(id)                                 [0025]
+  17. orders.position_id -> positions(id)                         [0025]
+  18. trades.order_id -> orders(id)                               [0025]
+  19. account_ledger.order_id -> orders(id)                       [0026]
+  20. evaluation_runs.model_id -> probability_models(model_id)    [0031]
+  21. evaluation_runs.strategy_id -> strategies(strategy_id)      [0031]
+  22. backtesting_runs.strategy_id -> strategies(strategy_id)     [0031]
+  23. backtesting_runs.model_id -> probability_models(model_id)   [0031]
+  24. predictions.model_id -> probability_models(model_id)        [0031]
+  25. predictions.event_id -> events(id)                          [0031]
+  26. games.home_team_id -> teams(team_id)                        [0035]
+  27. games.away_team_id -> teams(team_id)                        [0035]
+  28. games.venue_id -> venues(venue_id)                          [0035]
+  29. game_states.game_id -> games(id)                            [0035]
+  30. events.game_id -> games(id)                                 [0038]
+  31. temporal_alignment.game_id -> games(id)                     [0035]
+
+CASCADE -> RESTRICT (28):
+  Platform CASCADEs (11):
+  32. series.platform_id -> platforms(platform_id)                [0001]
+  33. events.platform_id -> platforms(platform_id)                [0001]
+  34. markets.platform_id -> platforms(platform_id)               [0021]
+  35. strategies.platform_id -> platforms(platform_id)            [0001]
+  36. positions.platform_id -> platforms(platform_id)             [0001]
+  37. trades.platform_id -> platforms(platform_id)                [0001]
+  38. settlements.platform_id -> platforms(platform_id)           [0001]
+  39. account_balance.platform_id -> platforms(platform_id)       [0001]
+  40. orders.platform_id -> platforms(platform_id)                [0025]
+  41. account_ledger.platform_id -> platforms(platform_id)        [0026]
+  42. market_trades.platform_id -> platforms(platform_id)         [0028]
+  Non-platform CASCADEs (17):
+  43. markets.event_internal_id -> events(id)                     [0020]
+  44. team_rankings.team_id -> teams(team_id)                     [0001]
+  45. position_exits.position_internal_id -> positions(id)        [0001]
+  46. exit_attempts.position_internal_id -> positions(id)         [0001]
+  47. market_snapshots.market_id -> markets(id)                   [0021]
+  48. orders.market_internal_id -> markets(id)                    [0022]
+  49. market_trades.market_internal_id -> markets(id)             [0022/0028]
+  50. predictions.evaluation_run_id -> evaluation_runs(id)        [0031]
+  51. predictions.market_id -> markets(id)                        [0031]
+  52. orderbook_snapshots.market_internal_id -> markets(id)       [0034]
+  53. temporal_alignment.market_id -> markets(id)                 [0027]
+  54. temporal_alignment.market_snapshot_id -> market_snapshots(id)[0027]
+  55. temporal_alignment.game_state_id -> game_states(id)         [0027]
+  56. edges.market_internal_id -> markets(id)                     [0022]
+  57. positions.market_internal_id -> markets(id)                 [0022]
+  58. trades.market_internal_id -> markets(id)                    [0022]
+  59. settlements.market_internal_id -> markets(id)               [0022]
+
+SCD Type 2 columns + indexes (3 tables):
+  60. teams:  row_current_ind, row_start_ts, row_end_ts
+            + idx_teams_current (partial on row_current_ind)
+            + idx_teams_unique_current (partial unique on team_code, sport)
+  61. venues: row_current_ind, row_start_ts, row_end_ts
+            + idx_venues_current (partial on row_current_ind)
+            + idx_venues_unique_current (partial unique on espn_venue_id)
+  62. series: row_current_ind, row_start_ts, row_end_ts
+            + idx_series_current (partial on row_current_ind)
+            + idx_series_unique_current (partial unique on series_id)
+
+PHANTOM FKs EXCLUDED (verified absent from current schema):
+  - elo_rating_history.team_id (table dropped in 0015)
+  - historical_games.home_team_id / away_team_id (table dropped in 0035)
+  - elo_calculation_log.historical_game_id (column dropped in 0035)
+  - trades.edge_internal_id (column dropped in 0025)
+  - trades.position_internal_id (column dropped in 0025)
+  - market_snapshots.game_snapshot_id (column never existed)
+
+DISCREPANCIES vs original task brief:
+  - trades.position_internal_id: PHANTOM (column dropped in migration 0025,
+    replaced by trades.order_id -> orders(id))
+  - game_odds.game_id: MISSING from original inventory (SET NULL, from 0035)
+  - temporal_alignment.game_id: MISSING from original inventory (SET NULL, from 0035)
+  - temporal_alignment.market_id: MISSING from original inventory (CASCADE, from 0027)
+  - temporal_alignment.market_snapshot_id: MISSING from original inventory (CASCADE, from 0027)
+  - temporal_alignment.game_state_id: MISSING from original inventory (CASCADE, from 0027)
+  - edges/positions/trades/settlements.market_internal_id: MISSING from original
+    inventory (CASCADE, from 0022, explicitly named constraints)
+  - teams business key: task brief said team_code alone, but team_code is NOT
+    unique (migration 0003 changed to UNIQUE(team_code, sport), 0018 relaxed to
+    pro leagues only). Using (team_code, sport) to match existing uniqueness.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0057"
+down_revision: str = "0056"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# =============================================================================
+# FK conversion specification
+# =============================================================================
+# Each tuple: (child_table, child_column, parent_table, parent_column, old_behavior)
+# Constraint names follow PostgreSQL auto-naming: {table}_{column}_fkey
+# unless explicitly named in the migration that created them.
+
+SET_NULL_FKS: list[tuple[str, str, str, str]] = [
+    # events
+    ("events", "series_internal_id", "series", "id"),
+    ("events", "game_id", "games", "id"),
+    # edges
+    ("edges", "model_id", "probability_models", "model_id"),
+    ("edges", "strategy_id", "strategies", "strategy_id"),
+    # historical_epa
+    ("historical_epa", "team_id", "teams", "team_id"),
+    # elo_calculation_log
+    ("elo_calculation_log", "game_state_id", "game_states", "id"),
+    ("elo_calculation_log", "home_team_id", "teams", "team_id"),
+    ("elo_calculation_log", "away_team_id", "teams", "team_id"),
+    ("elo_calculation_log", "game_id", "games", "id"),
+    # game_odds (renamed from historical_odds in 0048)
+    ("game_odds", "home_team_id", "teams", "team_id"),
+    ("game_odds", "away_team_id", "teams", "team_id"),
+    ("game_odds", "game_id", "games", "id"),
+    # historical_stats
+    ("historical_stats", "team_id", "teams", "team_id"),
+    # historical_rankings
+    ("historical_rankings", "team_id", "teams", "team_id"),
+    # orders
+    ("orders", "strategy_id", "strategies", "strategy_id"),
+    ("orders", "model_id", "probability_models", "model_id"),
+    ("orders", "edge_id", "edges", "id"),
+    ("orders", "position_id", "positions", "id"),
+    # trades
+    ("trades", "order_id", "orders", "id"),
+    # account_ledger
+    ("account_ledger", "order_id", "orders", "id"),
+    # evaluation_runs
+    ("evaluation_runs", "model_id", "probability_models", "model_id"),
+    ("evaluation_runs", "strategy_id", "strategies", "strategy_id"),
+    # backtesting_runs
+    ("backtesting_runs", "strategy_id", "strategies", "strategy_id"),
+    ("backtesting_runs", "model_id", "probability_models", "model_id"),
+    # predictions
+    ("predictions", "model_id", "probability_models", "model_id"),
+    ("predictions", "event_id", "events", "id"),
+    # games
+    ("games", "home_team_id", "teams", "team_id"),
+    ("games", "away_team_id", "teams", "team_id"),
+    ("games", "venue_id", "venues", "venue_id"),
+    # game_states
+    ("game_states", "game_id", "games", "id"),
+    # temporal_alignment
+    ("temporal_alignment", "game_id", "games", "id"),
+]
+
+CASCADE_FKS: list[tuple[str, str, str, str]] = [
+    # Platform CASCADEs
+    ("series", "platform_id", "platforms", "platform_id"),
+    ("events", "platform_id", "platforms", "platform_id"),
+    ("markets", "platform_id", "platforms", "platform_id"),
+    ("strategies", "platform_id", "platforms", "platform_id"),
+    ("positions", "platform_id", "platforms", "platform_id"),
+    ("trades", "platform_id", "platforms", "platform_id"),
+    ("settlements", "platform_id", "platforms", "platform_id"),
+    ("account_balance", "platform_id", "platforms", "platform_id"),
+    ("orders", "platform_id", "platforms", "platform_id"),
+    ("account_ledger", "platform_id", "platforms", "platform_id"),
+    ("market_trades", "platform_id", "platforms", "platform_id"),
+    # Non-platform CASCADEs
+    ("markets", "event_internal_id", "events", "id"),
+    ("team_rankings", "team_id", "teams", "team_id"),
+    ("position_exits", "position_internal_id", "positions", "id"),
+    ("exit_attempts", "position_internal_id", "positions", "id"),
+    ("market_snapshots", "market_id", "markets", "id"),
+    ("orders", "market_internal_id", "markets", "id"),
+    ("market_trades", "market_internal_id", "markets", "id"),
+    ("predictions", "evaluation_run_id", "evaluation_runs", "id"),
+    ("predictions", "market_id", "markets", "id"),
+    ("orderbook_snapshots", "market_internal_id", "markets", "id"),
+    ("temporal_alignment", "market_id", "markets", "id"),
+    ("temporal_alignment", "market_snapshot_id", "market_snapshots", "id"),
+    ("temporal_alignment", "game_state_id", "game_states", "id"),
+    ("edges", "market_internal_id", "markets", "id"),
+    ("positions", "market_internal_id", "markets", "id"),
+    ("trades", "market_internal_id", "markets", "id"),
+    ("settlements", "market_internal_id", "markets", "id"),
+]
+
+# Explicitly named constraints (not following {table}_{column}_fkey pattern)
+NAMED_CONSTRAINTS: dict[tuple[str, str], str] = {
+    ("events", "series_internal_id"): "fk_events_series_internal",
+    ("markets", "event_internal_id"): "fk_markets_event_internal",
+    ("orders", "market_internal_id"): "orders_market_internal_id_fkey",
+    ("market_trades", "market_internal_id"): "market_trades_market_internal_id_fkey",
+    ("edges", "market_internal_id"): "edges_market_internal_id_fkey",
+    ("positions", "market_internal_id"): "positions_market_internal_id_fkey",
+    ("trades", "market_internal_id"): "trades_market_internal_id_fkey",
+    ("settlements", "market_internal_id"): "settlements_market_internal_id_fkey",
+}
+
+
+def _get_constraint_name(table: str, column: str) -> str:
+    """Return the constraint name for a given table+column FK.
+
+    Uses explicitly named constraints where known, otherwise falls
+    back to PostgreSQL auto-naming convention: {table}_{column}_fkey.
+    """
+    return NAMED_CONSTRAINTS.get((table, column), f"{table}_{column}_fkey")
+
+
+def _fix_orphans_and_convert(
+    conn: sa.engine.Connection,
+    child_table: str,
+    child_column: str,
+    parent_table: str,
+    parent_column: str,
+) -> None:
+    """Pre-flight orphan check, fix orphans, then convert FK to RESTRICT.
+
+    Steps:
+        1. Find the actual constraint name from information_schema
+           (handles cases where auto-naming assumptions are wrong)
+        2. Check for orphaned rows (child FK value pointing to
+           non-existent parent)
+        3. If orphans exist, SET NULL those specific rows
+        4. Drop old constraint
+        5. Add new constraint with ON DELETE RESTRICT
+    """
+    # Step 1: Discover actual constraint name from information_schema
+    result = conn.execute(
+        sa.text("""
+            SELECT tc.constraint_name
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.key_column_usage kcu
+                ON tc.constraint_name = kcu.constraint_name
+                AND tc.table_schema = kcu.table_schema
+            WHERE tc.table_name = :table_name
+                AND kcu.column_name = :column_name
+                AND tc.constraint_type = 'FOREIGN KEY'
+                AND tc.table_schema = 'public'
+        """),
+        {"table_name": child_table, "column_name": child_column},
+    )
+    row = result.fetchone()
+    if row is None:
+        # FK does not exist -- skip silently (may have been dropped in
+        # a later migration that we didn't account for)
+        return
+    actual_constraint_name = row[0]
+
+    # Step 2: Pre-flight orphan check
+    orphan_count = conn.execute(
+        sa.text(
+            f"SELECT COUNT(*) FROM {child_table} c "  # noqa: S608
+            f"LEFT JOIN {parent_table} p ON c.{child_column} = p.{parent_column} "
+            f"WHERE c.{child_column} IS NOT NULL AND p.{parent_column} IS NULL"
+        )
+    ).scalar()
+
+    # Step 3: Fix orphans if any exist
+    if orphan_count and orphan_count > 0:
+        # Use NOT EXISTS instead of NOT IN to avoid NULL pitfall
+        # (NOT IN with NULLs in the subquery returns no rows)
+        conn.execute(
+            sa.text(
+                f"UPDATE {child_table} SET {child_column} = NULL "  # noqa: S608
+                f"WHERE {child_column} IS NOT NULL "
+                f"AND NOT EXISTS ("
+                f"SELECT 1 FROM {parent_table} "
+                f"WHERE {parent_table}.{parent_column} = {child_table}.{child_column}"
+                f")"
+            )
+        )
+
+    # Step 4: Drop old constraint
+    conn.execute(sa.text(f"ALTER TABLE {child_table} DROP CONSTRAINT {actual_constraint_name}"))
+
+    # Step 5: Add new constraint with ON DELETE RESTRICT
+    conn.execute(
+        sa.text(
+            f"ALTER TABLE {child_table} "
+            f"ADD CONSTRAINT {actual_constraint_name} "
+            f"FOREIGN KEY ({child_column}) REFERENCES {parent_table}({parent_column}) "
+            f"ON DELETE RESTRICT"
+        )
+    )
+
+
+def upgrade() -> None:
+    """Convert all SET NULL and CASCADE FKs to RESTRICT; add SCD Type 2 columns."""
+    conn = op.get_bind()
+
+    # =========================================================================
+    # Phase 1: Convert SET NULL FKs to RESTRICT (31 FKs)
+    # =========================================================================
+    for child_table, child_column, parent_table, parent_column in SET_NULL_FKS:
+        _fix_orphans_and_convert(
+            conn,
+            child_table,
+            child_column,
+            parent_table,
+            parent_column,
+        )
+
+    # =========================================================================
+    # Phase 2: Convert CASCADE FKs to RESTRICT (28 FKs)
+    # =========================================================================
+    for child_table, child_column, parent_table, parent_column in CASCADE_FKS:
+        _fix_orphans_and_convert(
+            conn,
+            child_table,
+            child_column,
+            parent_table,
+            parent_column,
+        )
+
+    # =========================================================================
+    # Phase 3: Add SCD Type 2 columns to dimension tables (3 tables)
+    # Pattern match: markets, game_states, positions, edges, account_balance
+    # all use (row_current_ind, row_start_ts, row_end_ts) from migration 0001.
+    # =========================================================================
+    for table in ("teams", "venues", "series"):
+        op.execute(f"""
+            ALTER TABLE {table}
+            ADD COLUMN row_current_ind BOOLEAN NOT NULL DEFAULT TRUE,
+            ADD COLUMN row_start_ts TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            ADD COLUMN row_end_ts TIMESTAMPTZ
+        """)
+
+        # Backfill row_start_ts from created_at for existing rows
+        op.execute(
+            f"UPDATE {table} SET row_start_ts = created_at "  # noqa: S608
+            f"WHERE created_at IS NOT NULL"
+        )
+
+    # ── Drop existing UNIQUE constraints that conflict with SCD versioning ──
+    # SCD Type 2 requires multiple rows with the same business key (one
+    # current, N historical). Full UNIQUE constraints block this.
+    # The partial unique indexes below provide equivalent current-row
+    # protection.
+
+    # series: drop global UNIQUE on series_id and (platform_id, external_id)
+    # from migration 0019 — SCD versioning needs multiple rows per series_id
+    op.execute("ALTER TABLE series DROP CONSTRAINT IF EXISTS uq_series_series_id")
+    op.execute("ALTER TABLE series DROP CONSTRAINT IF EXISTS uq_series_platform_external")
+
+    # venues: drop global UNIQUE on espn_venue_id from migration 0001
+    op.execute("ALTER TABLE venues DROP CONSTRAINT IF EXISTS venues_espn_venue_id_key")
+
+    # teams: drop partial unique index on (team_code, league) for pro leagues
+    # from migration 0039 — it doesn't filter on row_current_ind so it
+    # blocks SCD historical rows
+    op.execute("DROP INDEX IF EXISTS idx_teams_code_league_pro")
+
+    # teams: drop global unique index on (espn_team_id, league) from
+    # migration 0017 — also blocks SCD historical rows (no row_current_ind)
+    op.execute("DROP INDEX IF EXISTS idx_teams_espn_id_league_unique")
+
+    # ── Current-row filter indexes (same pattern as idx_markets_current) ──
+    op.execute("""
+        CREATE INDEX idx_teams_current
+        ON teams(row_current_ind) WHERE row_current_ind = TRUE
+    """)
+    op.execute("""
+        CREATE INDEX idx_venues_current
+        ON venues(row_current_ind) WHERE row_current_ind = TRUE
+    """)
+    op.execute("""
+        CREATE INDEX idx_series_current
+        ON series(row_current_ind) WHERE row_current_ind = TRUE
+    """)
+
+    # ── Partial unique indexes on business keys (SCD Type 2 enforcement) ──
+    # Only ONE current row per business entity.
+
+    # teams: business key is (team_code, league) -- team_code alone is not
+    # unique (PHI = Eagles in NFL, 76ers in NBA). league is more granular
+    # than sport (sport='football' covers both NFL and NCAAF). Matches the
+    # existing idx_teams_code_league_pro constraint granularity (0039).
+    op.execute("""
+        CREATE UNIQUE INDEX idx_teams_unique_current
+        ON teams(team_code, league) WHERE row_current_ind = TRUE
+    """)
+
+    # venues: business key is espn_venue_id -- nullable, so multiple
+    # venues without ESPN IDs are permitted (PostgreSQL treats each NULL
+    # as distinct in UNIQUE indexes).
+    op.execute("""
+        CREATE UNIQUE INDEX idx_venues_unique_current
+        ON venues(espn_venue_id) WHERE row_current_ind = TRUE
+    """)
+
+    # teams: ESPN ID + league uniqueness (replaces idx_teams_espn_id_league_unique
+    # from 0017 which lacked row_current_ind filter)
+    op.execute("""
+        CREATE UNIQUE INDEX idx_teams_espn_id_league_current
+        ON teams(espn_team_id, league) WHERE row_current_ind = TRUE
+    """)
+
+    # series: business key is series_id -- replaces uq_series_series_id
+    # from migration 0019.
+    op.execute("""
+        CREATE UNIQUE INDEX idx_series_unique_current
+        ON series(series_id) WHERE row_current_ind = TRUE
+    """)
+
+    # series: platform + external_id composite -- replaces
+    # uq_series_platform_external from 0019. Prevents two current series
+    # from the same platform with the same external identifier.
+    op.execute("""
+        CREATE UNIQUE INDEX idx_series_platform_external_current
+        ON series(platform_id, external_id) WHERE row_current_ind = TRUE
+    """)
+
+    # ── Helper views (same pattern as current_markets, current_game_states) ──
+    op.execute("""
+        CREATE OR REPLACE VIEW current_teams AS
+        SELECT * FROM teams WHERE row_current_ind = TRUE
+    """)
+    op.execute("""
+        CREATE OR REPLACE VIEW current_venues AS
+        SELECT * FROM venues WHERE row_current_ind = TRUE
+    """)
+    op.execute("""
+        CREATE OR REPLACE VIEW current_series AS
+        SELECT * FROM series WHERE row_current_ind = TRUE
+    """)
+
+    # Column comments
+    op.execute("""
+        COMMENT ON COLUMN teams.row_current_ind IS
+        'SCD Type 2: TRUE = current version, FALSE = historical. '
+        'Always filter by row_current_ind = TRUE for current data.'
+    """)
+    op.execute("""
+        COMMENT ON COLUMN venues.row_current_ind IS
+        'SCD Type 2: TRUE = current version, FALSE = historical. '
+        'Always filter by row_current_ind = TRUE for current data.'
+    """)
+    op.execute("""
+        COMMENT ON COLUMN series.row_current_ind IS
+        'SCD Type 2: TRUE = current version, FALSE = historical. '
+        'Always filter by row_current_ind = TRUE for current data.'
+    """)
+
+
+def downgrade() -> None:
+    """Reverse: drop SCD columns + indexes, re-create FKs with original ON DELETE."""
+    conn = op.get_bind()
+
+    # =========================================================================
+    # Phase 1: Drop SCD Type 2 views, indexes, columns, restore constraints
+    # =========================================================================
+    # Drop helper views first
+    op.execute("DROP VIEW IF EXISTS current_series")
+    op.execute("DROP VIEW IF EXISTS current_venues")
+    op.execute("DROP VIEW IF EXISTS current_teams")
+
+    # Drop SCD indexes (they depend on the columns)
+    op.execute("DROP INDEX IF EXISTS idx_series_platform_external_current")
+    op.execute("DROP INDEX IF EXISTS idx_series_unique_current")
+    op.execute("DROP INDEX IF EXISTS idx_venues_unique_current")
+    op.execute("DROP INDEX IF EXISTS idx_teams_espn_id_league_current")
+    op.execute("DROP INDEX IF EXISTS idx_teams_unique_current")
+    op.execute("DROP INDEX IF EXISTS idx_series_current")
+    op.execute("DROP INDEX IF EXISTS idx_venues_current")
+    op.execute("DROP INDEX IF EXISTS idx_teams_current")
+
+    # Drop SCD columns
+    for table in ("series", "venues", "teams"):
+        op.execute(f"""
+            ALTER TABLE {table}
+            DROP COLUMN IF EXISTS row_end_ts,
+            DROP COLUMN IF EXISTS row_start_ts,
+            DROP COLUMN IF EXISTS row_current_ind
+        """)
+
+    # Restore the original UNIQUE constraints dropped in upgrade
+    op.execute("ALTER TABLE series ADD CONSTRAINT uq_series_series_id UNIQUE (series_id)")
+    op.execute(
+        "ALTER TABLE series ADD CONSTRAINT uq_series_platform_external "
+        "UNIQUE (platform_id, external_id)"
+    )
+    op.execute("ALTER TABLE venues ADD CONSTRAINT venues_espn_venue_id_key UNIQUE (espn_venue_id)")
+    # Restore ESPN ID + league unique index from migration 0017
+    op.execute("""
+        CREATE UNIQUE INDEX idx_teams_espn_id_league_unique
+        ON teams(espn_team_id, league)
+    """)
+    # Restore pro-league partial unique index from migration 0039
+    op.execute("""
+        CREATE UNIQUE INDEX idx_teams_code_league_pro
+        ON teams(team_code, league)
+        WHERE league IN ('nfl', 'nba', 'nhl', 'wnba', 'mlb', 'mls')
+    """)
+
+    # =========================================================================
+    # Phase 2: Revert CASCADE FKs (currently RESTRICT -> back to CASCADE)
+    # =========================================================================
+    for child_table, child_column, parent_table, parent_column in CASCADE_FKS:
+        # Discover actual constraint name
+        result = conn.execute(
+            sa.text("""
+                SELECT tc.constraint_name
+                FROM information_schema.table_constraints tc
+                JOIN information_schema.key_column_usage kcu
+                    ON tc.constraint_name = kcu.constraint_name
+                    AND tc.table_schema = kcu.table_schema
+                WHERE tc.table_name = :table_name
+                    AND kcu.column_name = :column_name
+                    AND tc.constraint_type = 'FOREIGN KEY'
+                    AND tc.table_schema = 'public'
+            """),
+            {"table_name": child_table, "column_name": child_column},
+        )
+        row = result.fetchone()
+        if row is None:
+            continue
+        actual_constraint_name = row[0]
+
+        conn.execute(sa.text(f"ALTER TABLE {child_table} DROP CONSTRAINT {actual_constraint_name}"))
+        conn.execute(
+            sa.text(
+                f"ALTER TABLE {child_table} "
+                f"ADD CONSTRAINT {actual_constraint_name} "
+                f"FOREIGN KEY ({child_column}) "
+                f"REFERENCES {parent_table}({parent_column}) "
+                f"ON DELETE CASCADE"
+            )
+        )
+
+    # =========================================================================
+    # Phase 3: Revert SET NULL FKs (currently RESTRICT -> back to SET NULL)
+    # =========================================================================
+    for child_table, child_column, parent_table, parent_column in SET_NULL_FKS:
+        # Discover actual constraint name
+        result = conn.execute(
+            sa.text("""
+                SELECT tc.constraint_name
+                FROM information_schema.table_constraints tc
+                JOIN information_schema.key_column_usage kcu
+                    ON tc.constraint_name = kcu.constraint_name
+                    AND tc.table_schema = kcu.table_schema
+                WHERE tc.table_name = :table_name
+                    AND kcu.column_name = :column_name
+                    AND tc.constraint_type = 'FOREIGN KEY'
+                    AND tc.table_schema = 'public'
+            """),
+            {"table_name": child_table, "column_name": child_column},
+        )
+        row = result.fetchone()
+        if row is None:
+            continue
+        actual_constraint_name = row[0]
+
+        conn.execute(sa.text(f"ALTER TABLE {child_table} DROP CONSTRAINT {actual_constraint_name}"))
+        conn.execute(
+            sa.text(
+                f"ALTER TABLE {child_table} "
+                f"ADD CONSTRAINT {actual_constraint_name} "
+                f"FOREIGN KEY ({child_column}) "
+                f"REFERENCES {parent_table}({parent_column}) "
+                f"ON DELETE SET NULL"
+            )
+        )

--- a/src/precog/database/crud_teams.py
+++ b/src/precog/database/crud_teams.py
@@ -83,7 +83,7 @@ def create_venue(
             espn_venue_id, venue_name, city, state, capacity, indoor
         )
         VALUES (%s, %s, %s, %s, %s, %s)
-        ON CONFLICT (espn_venue_id)
+        ON CONFLICT (espn_venue_id) WHERE row_current_ind = TRUE
         DO UPDATE SET
             venue_name = EXCLUDED.venue_name,
             city = EXCLUDED.city,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,44 +237,14 @@ def clean_test_data(db_cursor):
         pass  # Already rolled back or no active transaction
 
     # Cleanup before test (strict reverse FK order — RESTRICT requires children first).
-    # Migration 0057 converted all CASCADE/SET NULL FKs to RESTRICT, so deleting
-    # a parent with existing children raises ForeignKeyViolation. Must delete
-    # from leaf tables up to root tables.
-    #
-    # Dependency chain (leaf → root):
-    #   temporal_alignment → market_snapshots → markets → events → series
-    #   exit_attempts/position_exits → positions → markets
-    #   trades → orders → markets/strategies/models
-    #   account_ledger → orders
-    #   settlements → markets
-    #   edges → markets/strategies/models
-    #   orderbook_snapshots → markets
-    #   market_trades → markets
+    # Uses shared helper from tests/fixtures/cleanup_helpers.py.
+    from tests.fixtures.cleanup_helpers import delete_all_test_data
 
-    # Tier 1: Leaf tables (no children reference these)
-    db_cursor.execute("DELETE FROM temporal_alignment")
-    db_cursor.execute("DELETE FROM exit_attempts")
-    db_cursor.execute("DELETE FROM position_exits")
-    db_cursor.execute("DELETE FROM account_ledger")
-    db_cursor.execute("DELETE FROM settlements")
-    db_cursor.execute("DELETE FROM market_trades")
-    db_cursor.execute("DELETE FROM orderbook_snapshots")
-
-    # Tier 2: Tables with only leaf children (already cleared above)
-    db_cursor.execute("DELETE FROM trades")
-    db_cursor.execute("DELETE FROM orders")
-    db_cursor.execute("DELETE FROM market_snapshots")
-
-    # Tier 3: Core tables
-    db_cursor.execute("DELETE FROM edges")
-    db_cursor.execute("DELETE FROM positions")
+    delete_all_test_data(db_cursor)
+    # Delete markets (children already cleared by delete_all_test_data)
     db_cursor.execute("DELETE FROM markets WHERE ticker LIKE 'TEST-%'")
-
-    # Tier 4: Dimension/reference tables
     db_cursor.execute("DELETE FROM events WHERE external_id LIKE 'TEST-%'")
     db_cursor.execute("DELETE FROM series WHERE series_id LIKE 'TEST-%'")
-
-    # Tier 5: Root tables
     try:
         db_cursor.execute("DELETE FROM probability_models")
         db_cursor.execute("DELETE FROM strategies")
@@ -348,19 +318,9 @@ def clean_test_data(db_cursor):
     yield  # Test runs here
 
     # Cleanup after test (strict reverse FK order — RESTRICT, no CASCADE).
-    # Same tier structure as setup cleanup above.
-    db_cursor.execute("DELETE FROM temporal_alignment")
-    db_cursor.execute("DELETE FROM exit_attempts")
-    db_cursor.execute("DELETE FROM position_exits")
-    db_cursor.execute("DELETE FROM account_ledger")
-    db_cursor.execute("DELETE FROM settlements")
-    db_cursor.execute("DELETE FROM market_trades")
-    db_cursor.execute("DELETE FROM orderbook_snapshots")
-    db_cursor.execute("DELETE FROM trades")
-    db_cursor.execute("DELETE FROM orders")
-    db_cursor.execute("DELETE FROM market_snapshots")
-    db_cursor.execute("DELETE FROM edges")
-    db_cursor.execute("DELETE FROM positions")
+    from tests.fixtures.cleanup_helpers import delete_all_test_data
+
+    delete_all_test_data(db_cursor)
     db_cursor.execute("DELETE FROM markets WHERE ticker LIKE 'TEST-%'")
     db_cursor.execute("DELETE FROM events WHERE external_id LIKE 'TEST-%'")
     db_cursor.execute("DELETE FROM series WHERE series_id LIKE 'TEST-%'")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,37 +236,50 @@ def clean_test_data(db_cursor):
     except Exception:
         pass  # Already rolled back or no active transaction
 
-    # Cleanup before test (in reverse FK order)
-    # Delete child records first - trades/positions reference strategies/models/markets
-    # Migration 0022: downstream tables use market_internal_id INTEGER FK with ON DELETE CASCADE.
-    # Deleting from markets will CASCADE to trades/positions/edges/settlements.
-    # Still clean up by strategy/model references for non-market-linked test data.
+    # Cleanup before test (strict reverse FK order — RESTRICT requires children first).
+    # Migration 0057 converted all CASCADE/SET NULL FKs to RESTRICT, so deleting
+    # a parent with existing children raises ForeignKeyViolation. Must delete
+    # from leaf tables up to root tables.
+    #
+    # Dependency chain (leaf → root):
+    #   temporal_alignment → market_snapshots → markets → events → series
+    #   exit_attempts/position_exits → positions → markets
+    #   trades → orders → markets/strategies/models
+    #   account_ledger → orders
+    #   settlements → markets
+    #   edges → markets/strategies/models
+    #   orderbook_snapshots → markets
+    #   market_trades → markets
+
+    # Tier 1: Leaf tables (no children reference these)
+    db_cursor.execute("DELETE FROM temporal_alignment")
+    db_cursor.execute("DELETE FROM exit_attempts")
+    db_cursor.execute("DELETE FROM position_exits")
+    db_cursor.execute("DELETE FROM account_ledger")
     db_cursor.execute("DELETE FROM settlements")
-    # Try to delete orders/positions referencing test strategies/models (may fail in CI)
-    # Migration 0025: strategy_id/model_id moved from trades to orders table
-    # Delete fixture data (99901+) AND any SERIAL-generated data (1-99900)
-    try:
-        db_cursor.execute(
-            "DELETE FROM orders WHERE strategy_id IS NOT NULL OR model_id IS NOT NULL"
-        )
-        db_cursor.execute(
-            "DELETE FROM positions WHERE strategy_id IS NOT NULL OR model_id IS NOT NULL"
-        )
-    except Exception:
-        db_cursor.connection.rollback()  # CRITICAL: Clear aborted transaction state
-    # Delete markets by ticker pattern — CASCADE handles downstream tables
-    # (edges, positions, trades, settlements via market_internal_id FK)
+    db_cursor.execute("DELETE FROM market_trades")
+    db_cursor.execute("DELETE FROM orderbook_snapshots")
+
+    # Tier 2: Tables with only leaf children (already cleared above)
+    db_cursor.execute("DELETE FROM trades")
+    db_cursor.execute("DELETE FROM orders")
+    db_cursor.execute("DELETE FROM market_snapshots")
+
+    # Tier 3: Core tables
+    db_cursor.execute("DELETE FROM edges")
+    db_cursor.execute("DELETE FROM positions")
     db_cursor.execute("DELETE FROM markets WHERE ticker LIKE 'TEST-%'")
+
+    # Tier 4: Dimension/reference tables
     db_cursor.execute("DELETE FROM events WHERE external_id LIKE 'TEST-%'")
     db_cursor.execute("DELETE FROM series WHERE series_id LIKE 'TEST-%'")
-    # Clean up ALL test models and strategies (fixture data + SERIAL-generated)
-    # This ensures clean state for property tests that create many strategies
+
+    # Tier 5: Root tables
     try:
         db_cursor.execute("DELETE FROM probability_models")
         db_cursor.execute("DELETE FROM strategies")
     except Exception:
         db_cursor.connection.rollback()  # CRITICAL: Clear aborted transaction state
-    # Delete both uppercase TEST-PLATFORM- and lowercase test_ platforms
     db_cursor.execute(
         "DELETE FROM platforms WHERE platform_id LIKE 'test_%' OR platform_id LIKE 'TEST-PLATFORM-%'"
     )
@@ -334,26 +347,23 @@ def clean_test_data(db_cursor):
 
     yield  # Test runs here
 
-    # Cleanup after test (in reverse FK order)
-    # Migration 0022: downstream tables use market_internal_id INTEGER FK with ON DELETE CASCADE.
-    # Deleting from markets will CASCADE to trades/positions/edges/settlements.
-    # Still clean up by strategy/model references for non-market-linked test data.
-    # Migration 0025: strategy_id/model_id moved from trades to orders table
-    try:
-        db_cursor.execute(
-            "DELETE FROM orders WHERE strategy_id IS NOT NULL OR model_id IS NOT NULL"
-        )
-        db_cursor.execute(
-            "DELETE FROM positions WHERE strategy_id IS NOT NULL OR model_id IS NOT NULL"
-        )
-    except Exception:
-        db_cursor.connection.rollback()  # CRITICAL: Clear aborted transaction state
-    # Delete markets by ticker pattern — CASCADE handles downstream tables
+    # Cleanup after test (strict reverse FK order — RESTRICT, no CASCADE).
+    # Same tier structure as setup cleanup above.
+    db_cursor.execute("DELETE FROM temporal_alignment")
+    db_cursor.execute("DELETE FROM exit_attempts")
+    db_cursor.execute("DELETE FROM position_exits")
+    db_cursor.execute("DELETE FROM account_ledger")
+    db_cursor.execute("DELETE FROM settlements")
+    db_cursor.execute("DELETE FROM market_trades")
+    db_cursor.execute("DELETE FROM orderbook_snapshots")
+    db_cursor.execute("DELETE FROM trades")
+    db_cursor.execute("DELETE FROM orders")
+    db_cursor.execute("DELETE FROM market_snapshots")
+    db_cursor.execute("DELETE FROM edges")
+    db_cursor.execute("DELETE FROM positions")
     db_cursor.execute("DELETE FROM markets WHERE ticker LIKE 'TEST-%'")
     db_cursor.execute("DELETE FROM events WHERE external_id LIKE 'TEST-%'")
     db_cursor.execute("DELETE FROM series WHERE series_id LIKE 'TEST-%'")
-    # Clean up ALL test models and strategies (fixture data + SERIAL-generated)
-    # This ensures clean state for next test
     try:
         db_cursor.execute("DELETE FROM probability_models")
         db_cursor.execute("DELETE FROM strategies")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -282,7 +282,7 @@ def clean_test_data(db_cursor):
     db_cursor.execute("""
         INSERT INTO series (series_id, platform_id, external_id, title, category)
         VALUES ('TEST-SERIES-NFL', 'test_platform', 'TEST-EXT-SERIES', 'Test NFL Series', 'sports')
-        ON CONFLICT (series_id) DO NOTHING
+        ON CONFLICT (series_id) WHERE row_current_ind = TRUE DO NOTHING
     """)
 
     # Get series surrogate PK for event FK (migration 0019: series_internal_id)
@@ -717,7 +717,7 @@ def sample_series(db_pool, clean_test_data, sample_platform) -> str:
     query = """
         INSERT INTO series (series_id, platform_id, external_id, category, subcategory, title, frequency)
         VALUES ('NFL-2025', 'kalshi', 'NFL-2025-ext', 'sports', 'nfl', 'NFL 2025 Season', 'recurring')
-        ON CONFLICT (series_id) DO NOTHING
+        ON CONFLICT (series_id) WHERE row_current_ind = TRUE DO NOTHING
         RETURNING series_id
     """
     execute_query(query)

--- a/tests/e2e/cli/test_cli_scheduler_e2e.py
+++ b/tests/e2e/cli/test_cli_scheduler_e2e.py
@@ -100,22 +100,31 @@ class TestSchedulerStartStopWorkflow:
     def test_scheduler_restart_workflow(self, isolated_app) -> None:
         """Test scheduler restart workflow.
 
-        E2E: Tests stop then start sequence.
+        E2E: Tests stop then start sequence via the supervised path. See
+        the docstring on test_complete_scheduler_lifecycle for why the
+        mock targets create_supervisor and the invocation passes
+        --supervised.
         """
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
+        with (
+            patch(
+                "precog.schedulers.service_supervisor.create_supervisor"
+            ) as mock_create_supervisor,
+            patch("precog.cli.scheduler._validate_startup", return_value=True),
+            patch("precog.cli.scheduler._prevent_system_sleep_for_supervised"),
+        ):
             mock_instance = MagicMock()
-            mock_instance.start.return_value = True
+            mock_instance.start_all.return_value = None
             mock_instance.stop.return_value = True
-            mock_supervisor.return_value = mock_instance
+            mock_create_supervisor.return_value = mock_instance
 
-            # Stop (should handle not running)
+            # Stop (should handle not running — module globals are all None)
             result = runner.invoke(isolated_app, ["scheduler", "stop"])
             assert result.exit_code in [0, 1, 2]
 
-            # Start
-            result = runner.invoke(isolated_app, ["scheduler", "start"])
+            # Start via supervised path so create_supervisor mock is effective
+            result = runner.invoke(isolated_app, ["scheduler", "start", "--supervised"])
             assert result.exit_code in [0, 1, 2]
 
 
@@ -126,15 +135,37 @@ class TestSchedulerPollingWorkflow:
         """Test single poll execution workflow.
 
         E2E: Tests poll-once from CLI through database.
+
+        The poll_once CLI command does not go through create_supervisor --
+        it imports ESPNGamePoller and KalshiMarketPoller directly from
+        precog.schedulers and instantiates them. Patch those poller
+        classes at the package re-export path so the delayed function-
+        scoped import inside poll_once picks up the mocks.
         """
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.poll_once.return_value = {"games": 5, "updated": 3}
-            mock_supervisor.return_value = mock_instance
+        with (
+            patch("precog.schedulers.ESPNGamePoller") as mock_espn,
+            patch("precog.schedulers.KalshiMarketPoller") as mock_kalshi,
+        ):
+            mock_espn_instance = MagicMock()
+            mock_espn_instance.poll_once.return_value = {
+                "items_fetched": 5,
+                "items_updated": 3,
+            }
+            mock_espn.return_value = mock_espn_instance
 
-            result = runner.invoke(isolated_app, ["scheduler", "poll-once", "--league", "nfl"])
+            mock_kalshi_instance = MagicMock()
+            mock_kalshi_instance.poll_once.return_value = {
+                "items_fetched": 10,
+                "items_updated": 8,
+                "items_created": 2,
+            }
+            mock_kalshi.return_value = mock_kalshi_instance
+
+            # Note: scheduler poll-once takes --leagues (comma-separated string),
+            # not --league, per src/precog/cli/scheduler.py::poll_once.
+            result = runner.invoke(isolated_app, ["scheduler", "poll-once", "--leagues", "nfl"])
             assert result.exit_code in [0, 1, 2]
 
     def test_poll_multiple_leagues_workflow(self, isolated_app) -> None:
@@ -144,14 +175,28 @@ class TestSchedulerPollingWorkflow:
         """
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.poll_once.return_value = {"games": 10, "updated": 8}
-            mock_supervisor.return_value = mock_instance
+        with (
+            patch("precog.schedulers.ESPNGamePoller") as mock_espn,
+            patch("precog.schedulers.KalshiMarketPoller") as mock_kalshi,
+        ):
+            mock_espn_instance = MagicMock()
+            mock_espn_instance.poll_once.return_value = {
+                "items_fetched": 20,
+                "items_updated": 12,
+            }
+            mock_espn.return_value = mock_espn_instance
+
+            mock_kalshi_instance = MagicMock()
+            mock_kalshi_instance.poll_once.return_value = {
+                "items_fetched": 30,
+                "items_updated": 18,
+                "items_created": 4,
+            }
+            mock_kalshi.return_value = mock_kalshi_instance
 
             result = runner.invoke(
                 isolated_app,
-                ["scheduler", "poll-once", "--league", "nfl", "--league", "nba", "--save"],
+                ["scheduler", "poll-once", "--leagues", "nfl,nba"],
             )
             assert result.exit_code in [0, 1, 2]
 
@@ -162,20 +207,33 @@ class TestSchedulerErrorRecovery:
     def test_scheduler_recovers_from_poll_error(self, isolated_app) -> None:
         """Test scheduler recovers from polling errors.
 
-        E2E: Tests error recovery workflow.
+        E2E: Tests error recovery workflow. See test_poll_once_workflow
+        for the mock-at-package-level pattern rationale.
         """
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.poll_once.side_effect = [
-                Exception("API error"),
-                {"games": 3, "updated": 2},
-            ]
-            mock_supervisor.return_value = mock_instance
+        with (
+            patch("precog.schedulers.ESPNGamePoller") as mock_espn,
+            patch("precog.schedulers.KalshiMarketPoller") as mock_kalshi,
+        ):
+            # ESPN poller raises on poll_once -- the CLI catches it and logs
+            # but does not crash, so exit code should still be in the normal
+            # range.
+            mock_espn_instance = MagicMock()
+            mock_espn_instance.poll_once.side_effect = Exception("API error")
+            mock_espn.return_value = mock_espn_instance
 
-            # First poll fails
-            result = runner.invoke(isolated_app, ["scheduler", "poll-once", "--league", "nfl"])
+            # Kalshi poller succeeds so the overall command still reports some
+            # progress.
+            mock_kalshi_instance = MagicMock()
+            mock_kalshi_instance.poll_once.return_value = {
+                "items_fetched": 3,
+                "items_updated": 2,
+                "items_created": 1,
+            }
+            mock_kalshi.return_value = mock_kalshi_instance
+
+            result = runner.invoke(isolated_app, ["scheduler", "poll-once", "--leagues", "nfl"])
             # CLI should handle error gracefully
             assert result.exit_code in [0, 1, 2, 3, 4, 5]
 
@@ -183,13 +241,18 @@ class TestSchedulerErrorRecovery:
         """Test scheduler handles stop request during poll.
 
         E2E: Tests graceful shutdown during operation.
+
+        The stop CLI command calls _scheduler_stop_impl() which accesses
+        module-global references to pollers/supervisor. With no prior
+        start command in this test, all those globals are None and the
+        stop command is a no-op -- no real I/O -- so no mocks are
+        required. We keep the test to document the expected exit code
+        behavior and to guard against regressions if stop ever gains
+        real I/O in the absence of running services.
         """
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.stop.return_value = True
-            mock_supervisor.return_value = mock_instance
-
-            result = runner.invoke(isolated_app, ["scheduler", "stop", "--force"])
-            assert result.exit_code in [0, 1, 2]
+        # scheduler stop does not accept a --force flag -- that belongs to
+        # scheduler start. Removing it to match the actual CLI signature.
+        result = runner.invoke(isolated_app, ["scheduler", "stop"])
+        assert result.exit_code in [0, 1, 2]

--- a/tests/e2e/cli/test_cli_scheduler_e2e.py
+++ b/tests/e2e/cli/test_cli_scheduler_e2e.py
@@ -43,18 +43,43 @@ class TestSchedulerStartStopWorkflow:
         """Test complete scheduler start-stop-status workflow.
 
         E2E: Tests full lifecycle from start to stop.
+
+        IMPORTANT: The CLI ``scheduler start`` command calls
+        ``create_supervisor(...)`` (a factory function), not
+        ``ServiceSupervisor(...)`` directly. The factory does
+        substantial setup work before instantiating the supervisor --
+        it creates Kalshi/ESPN pollers, rate limiters, circuit
+        breakers, and tests network connectivity. Patching only
+        ``ServiceSupervisor`` the class leaves all of that real setup
+        intact, which on CI causes the Kalshi poller to hit rate-limit
+        429s and hang inside ``time.sleep`` until pytest's per-test
+        timeout fires. The fix is to patch ``create_supervisor`` so
+        the factory itself is replaced.
+
+        In addition, ``_validate_startup`` must be patched to return
+        True so the CLI does not short-circuit with exit code 1 before
+        reaching the factory call. This test was previously "passing"
+        on many environments only because _validate_startup happened
+        to return False and the test accepted exit code 1 -- a silent
+        no-op that masked the real execution path.
         """
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
+        with (
+            patch(
+                "precog.schedulers.service_supervisor.create_supervisor"
+            ) as mock_create_supervisor,
+            patch("precog.cli.scheduler._validate_startup", return_value=True),
+            patch("precog.cli.scheduler._prevent_system_sleep_for_supervised"),
+        ):
             mock_instance = MagicMock()
-            mock_instance.start.return_value = True
+            mock_instance.start_all.return_value = None
             mock_instance.stop.return_value = True
-            mock_instance.is_running.return_value = True
+            mock_instance.is_running = True
             mock_instance.get_status.return_value = {"running": True, "pollers": []}
-            mock_supervisor.return_value = mock_instance
+            mock_create_supervisor.return_value = mock_instance
 
-            # Start scheduler
+            # Start scheduler (non-foreground so it returns immediately)
             result = runner.invoke(isolated_app, ["scheduler", "start"])
             assert result.exit_code in [0, 1, 2]
 

--- a/tests/e2e/cli/test_cli_scheduler_e2e.py
+++ b/tests/e2e/cli/test_cli_scheduler_e2e.py
@@ -79,8 +79,14 @@ class TestSchedulerStartStopWorkflow:
             mock_instance.get_status.return_value = {"running": True, "pollers": []}
             mock_create_supervisor.return_value = mock_instance
 
-            # Start scheduler (non-foreground so it returns immediately)
-            result = runner.invoke(isolated_app, ["scheduler", "start"])
+            # Start scheduler via the supervised code path. The non-supervised
+            # path at src/precog/cli/scheduler.py:619+ instantiates
+            # KalshiMarketPoller and ESPNGamePoller directly rather than going
+            # through create_supervisor(), so the mocks above would not cover
+            # it and the real pollers would spin up and hang on 429 retries.
+            # --supervised routes through _start_supervised_mode which is the
+            # code path our mocks actually replace.
+            result = runner.invoke(isolated_app, ["scheduler", "start", "--supervised"])
             assert result.exit_code in [0, 1, 2]
 
             # Check status

--- a/tests/e2e/database/test_connection_e2e.py
+++ b/tests/e2e/database/test_connection_e2e.py
@@ -39,7 +39,7 @@ class TestConnectionE2E:
                 """
                 INSERT INTO venues (espn_venue_id, venue_name, city)
                 VALUES (%s, %s, %s)
-                ON CONFLICT (espn_venue_id) DO UPDATE
+                ON CONFLICT (espn_venue_id) WHERE row_current_ind = TRUE DO UPDATE
                 SET venue_name = EXCLUDED.venue_name
                 """,
                 (venue_id, "E2E Test Venue", "Test City"),
@@ -103,7 +103,7 @@ class TestConnectionE2E:
                     """
                     INSERT INTO venues (espn_venue_id, venue_name, city)
                     VALUES (%s, %s, %s)
-                    ON CONFLICT (espn_venue_id) DO NOTHING
+                    ON CONFLICT (espn_venue_id) WHERE row_current_ind = TRUE DO NOTHING
                     """,
                     (venue_id, f"Venue {venue_id}", "Batch City"),
                 )
@@ -134,7 +134,7 @@ class TestConnectionE2E:
                 """
                 INSERT INTO venues (espn_venue_id, venue_name, city)
                 VALUES (%s, %s, %s)
-                ON CONFLICT (espn_venue_id) DO NOTHING
+                ON CONFLICT (espn_venue_id) WHERE row_current_ind = TRUE DO NOTHING
                 """,
                 (venue_id, "Concurrent Venue", "Concurrent City"),
             )
@@ -199,7 +199,7 @@ class TestConnectionE2E:
                 """
                 INSERT INTO venues (espn_venue_id, venue_name, city)
                 VALUES (%s, %s, %s)
-                ON CONFLICT (espn_venue_id) DO NOTHING
+                ON CONFLICT (espn_venue_id) WHERE row_current_ind = TRUE DO NOTHING
                 """,
                 (venue_id, "Isolation Test", "Test City"),
             )

--- a/tests/e2e/database/test_connection_e2e.py
+++ b/tests/e2e/database/test_connection_e2e.py
@@ -72,10 +72,9 @@ class TestConnectionE2E:
 
         # Delete
         with get_cursor(commit=True) as cur:
-            cur.execute(
-                "DELETE FROM venues WHERE espn_venue_id = %s",
-                (venue_id,),
-            )
+            from tests.fixtures.cleanup_helpers import delete_venue_with_children
+
+            delete_venue_with_children(cur, "espn_venue_id = %s", (venue_id,))
 
         # Verify deletion
         with get_cursor() as cur:
@@ -116,7 +115,9 @@ class TestConnectionE2E:
 
         # Cleanup
         with get_cursor(commit=True) as cur:
-            cur.execute("DELETE FROM venues WHERE espn_venue_id LIKE 'E2E-BATCH-%'")
+            from tests.fixtures.cleanup_helpers import delete_venue_with_children
+
+            delete_venue_with_children(cur, "espn_venue_id LIKE %s", ("E2E-BATCH-%",))
 
     def test_concurrent_access_workflow(self, db_pool, clean_test_data):
         """
@@ -156,10 +157,9 @@ class TestConnectionE2E:
 
         # Cleanup
         with get_cursor(commit=True) as cur:
-            cur.execute(
-                "DELETE FROM venues WHERE espn_venue_id = %s",
-                (venue_id,),
-            )
+            from tests.fixtures.cleanup_helpers import delete_venue_with_children
+
+            delete_venue_with_children(cur, "espn_venue_id = %s", (venue_id,))
 
     def test_error_recovery_workflow(self, db_pool, clean_test_data):
         """

--- a/tests/e2e/database/test_crud_operations_e2e.py
+++ b/tests/e2e/database/test_crud_operations_e2e.py
@@ -80,7 +80,9 @@ def setup_e2e_teams(db_pool, clean_test_data):
         cur.execute("DELETE FROM game_states WHERE home_team_id IN (88001, 88002, 88003, 88004)")
         cur.execute("DELETE FROM team_rankings WHERE team_id IN (88001, 88002, 88003, 88004)")
         cur.execute("DELETE FROM teams WHERE team_id IN (88001, 88002, 88003, 88004)")
-        cur.execute("DELETE FROM venues WHERE espn_venue_id LIKE 'E2E-%'")
+        from tests.fixtures.cleanup_helpers import delete_venue_with_children
+
+        delete_venue_with_children(cur, "espn_venue_id LIKE %s", ("E2E-%",))
 
 
 # =============================================================================
@@ -417,7 +419,9 @@ class TestStateChangeDetectionWorkflow:
         # Clean up any existing test data
         with get_cursor(commit=True) as cur:
             cur.execute("DELETE FROM game_states WHERE espn_event_id = 'E2E-STATE-GAME-001'")
-            cur.execute("DELETE FROM venues WHERE espn_venue_id = 'E2E-STATE-001'")
+            from tests.fixtures.cleanup_helpers import delete_venue_with_children
+
+            delete_venue_with_children(cur, "espn_venue_id = %s", ("E2E-STATE-001",))
 
         # Create venue for the game
         venue_id = create_venue(
@@ -559,7 +563,9 @@ class TestStateChangeDetectionWorkflow:
         # Clean up any existing test data
         with get_cursor(commit=True) as cur:
             cur.execute("DELETE FROM game_states WHERE espn_event_id = 'E2E-SIT-GAME-001'")
-            cur.execute("DELETE FROM venues WHERE espn_venue_id = 'E2E-SIT-001'")
+            from tests.fixtures.cleanup_helpers import delete_venue_with_children
+
+            delete_venue_with_children(cur, "espn_venue_id = %s", ("E2E-SIT-001",))
 
         venue_id = create_venue(
             espn_venue_id="E2E-SIT-001",
@@ -653,7 +659,9 @@ class TestStateChangeDetectionWorkflow:
         # Clean up any existing test data
         with get_cursor(commit=True) as cur:
             cur.execute("DELETE FROM game_states WHERE espn_event_id = 'E2E-STATUS-GAME-001'")
-            cur.execute("DELETE FROM venues WHERE espn_venue_id = 'E2E-STATUS-001'")
+            from tests.fixtures.cleanup_helpers import delete_venue_with_children
+
+            delete_venue_with_children(cur, "espn_venue_id = %s", ("E2E-STATUS-001",))
 
         venue_id = create_venue(
             espn_venue_id="E2E-STATUS-001",

--- a/tests/e2e/schedulers/test_kalshi_poller_e2e.py
+++ b/tests/e2e/schedulers/test_kalshi_poller_e2e.py
@@ -114,17 +114,18 @@ def clean_test_markets():
         E2E tests that write to the database need cleanup to be idempotent.
         We delete markets created by the poller to allow re-running tests.
     """
-    # Cleanup before test
+    # Cleanup before test (RESTRICT-safe: delete children before parents)
+    from tests.fixtures.cleanup_helpers import delete_market_with_children
+
     with get_cursor(commit=True) as cur:
-        # Delete markets and events created by kalshi poller (platform_id='kalshi')
-        cur.execute("DELETE FROM markets WHERE platform_id = 'kalshi'")
+        delete_market_with_children(cur, "platform_id = %s", ("kalshi",))
         cur.execute("DELETE FROM events WHERE platform_id = 'kalshi'")
 
     yield
 
-    # Cleanup after test (optional - helps with debugging if commented out)
+    # Cleanup after test
     with get_cursor(commit=True) as cur:
-        cur.execute("DELETE FROM markets WHERE platform_id = 'kalshi'")
+        delete_market_with_children(cur, "platform_id = %s", ("kalshi",))
         cur.execute("DELETE FROM events WHERE platform_id = 'kalshi'")
 
 

--- a/tests/fixtures/cleanup_helpers.py
+++ b/tests/fixtures/cleanup_helpers.py
@@ -107,11 +107,10 @@ def delete_market_with_children(
 
     placeholders = ",".join(["%s"] * len(market_ids))
 
-    # Children referencing markets via market_internal_id
+    # Tables referencing markets via market_internal_id (from migrations 0022, 0028, 0034)
     for table in (
         "orderbook_snapshots",
         "market_trades",
-        "market_snapshots",
         "edges",
         "settlements",
     ):
@@ -120,12 +119,21 @@ def delete_market_with_children(
             tuple(market_ids),
         )
 
-    # Tables that use market_id (not market_internal_id)
-    for table in ("temporal_alignment", "predictions"):
-        cursor.execute(
-            f"DELETE FROM {table} WHERE market_id IN ({placeholders})",  # noqa: S608
-            tuple(market_ids),
-        )
+    # Tables that use market_id (from migrations 0021, 0027, 0031)
+    # NOTE: temporal_alignment must be deleted BEFORE market_snapshots
+    # because it has an FK to market_snapshots(id)
+    cursor.execute(
+        f"DELETE FROM temporal_alignment WHERE market_id IN ({placeholders})",  # noqa: S608
+        tuple(market_ids),
+    )
+    cursor.execute(
+        f"DELETE FROM predictions WHERE market_id IN ({placeholders})",  # noqa: S608
+        tuple(market_ids),
+    )
+    cursor.execute(
+        f"DELETE FROM market_snapshots WHERE market_id IN ({placeholders})",  # noqa: S608
+        tuple(market_ids),
+    )
 
     # Orders reference markets AND have their own children
     cursor.execute(

--- a/tests/fixtures/cleanup_helpers.py
+++ b/tests/fixtures/cleanup_helpers.py
@@ -109,16 +109,21 @@ def delete_market_with_children(
 
     # Children referencing markets via market_internal_id
     for table in (
-        "temporal_alignment",
         "orderbook_snapshots",
         "market_trades",
-        "predictions",
         "market_snapshots",
         "edges",
         "settlements",
     ):
         cursor.execute(
             f"DELETE FROM {table} WHERE market_internal_id IN ({placeholders})",  # noqa: S608
+            tuple(market_ids),
+        )
+
+    # Tables that use market_id (not market_internal_id)
+    for table in ("temporal_alignment", "predictions"):
+        cursor.execute(
+            f"DELETE FROM {table} WHERE market_id IN ({placeholders})",  # noqa: S608
             tuple(market_ids),
         )
 

--- a/tests/fixtures/cleanup_helpers.py
+++ b/tests/fixtures/cleanup_helpers.py
@@ -1,0 +1,267 @@
+"""Shared test data cleanup helpers for RESTRICT FK semantics.
+
+Migration 0057 converted all CASCADE/SET NULL FKs to ON DELETE RESTRICT.
+Test fixtures can no longer rely on CASCADE to auto-delete children when
+deleting parents. This module provides cleanup functions that delete in
+strict reverse FK order.
+
+Usage:
+    from tests.fixtures.cleanup_helpers import (
+        delete_all_test_data,
+        delete_market_with_children,
+    )
+
+    # In a fixture:
+    delete_all_test_data(cursor)
+
+    # Scoped cleanup:
+    delete_market_with_children(cursor, "ticker = %s", ("TEST-MKT",))
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# =============================================================================
+# FK dependency tiers (leaf → root)
+# =============================================================================
+# Tier 1: Leaf tables (nothing references these)
+# Tier 2: Tables whose only children are in Tier 1
+# Tier 3: Core tables (children in Tier 1-2)
+# Tier 4: Dimension tables (children in Tier 1-3)
+# Tier 5: Root tables (platforms)
+
+_TIER_1_TABLES = (
+    "temporal_alignment",
+    "exit_attempts",
+    "position_exits",
+    "account_ledger",
+    "settlements",
+    "market_trades",
+    "orderbook_snapshots",
+    "elo_calculation_log",
+    "predictions",
+    "backtesting_runs",
+    "evaluation_runs",
+    "historical_epa",
+    "historical_stats",
+    "historical_rankings",
+    "game_odds",
+    "team_rankings",
+    "external_team_codes",
+)
+
+_TIER_2_TABLES = (
+    "trades",
+    "orders",
+    "market_snapshots",
+)
+
+_TIER_3_TABLES = (
+    "edges",
+    "positions",
+    "account_balance",
+)
+
+
+def delete_all_test_data(cursor: Any) -> None:
+    """Delete ALL data from transactional tables in strict reverse FK order.
+
+    Safe for RESTRICT semantics. Does NOT delete from dimension/reference
+    tables (teams, venues, series, platforms) or seed data — use the
+    scoped functions for those.
+    """
+    for table in _TIER_1_TABLES:
+        cursor.execute(f"DELETE FROM {table}")  # noqa: S608
+    for table in _TIER_2_TABLES:
+        cursor.execute(f"DELETE FROM {table}")  # noqa: S608
+    for table in _TIER_3_TABLES:
+        cursor.execute(f"DELETE FROM {table}")  # noqa: S608
+
+
+def delete_market_with_children(
+    cursor: Any,
+    where_clause: str,
+    params: tuple[Any, ...] | None = None,
+) -> None:
+    """Delete market(s) and all children in reverse FK order.
+
+    Args:
+        cursor: Database cursor.
+        where_clause: SQL WHERE clause for the markets table
+            (e.g., "ticker = %s" or "platform_id = %s").
+        params: Parameters for the WHERE clause.
+
+    Example:
+        delete_market_with_children(cur, "ticker = %s", ("TEST-MKT",))
+        delete_market_with_children(cur, "platform_id = %s", ("kalshi",))
+    """
+    # Get market IDs matching the condition
+    cursor.execute(
+        f"SELECT id FROM markets WHERE {where_clause}",  # noqa: S608
+        params,
+    )
+    market_ids = [row["id"] for row in cursor.fetchall()]
+    if not market_ids:
+        return
+
+    placeholders = ",".join(["%s"] * len(market_ids))
+
+    # Children referencing markets via market_internal_id
+    for table in (
+        "temporal_alignment",
+        "orderbook_snapshots",
+        "market_trades",
+        "predictions",
+        "market_snapshots",
+        "edges",
+        "settlements",
+    ):
+        cursor.execute(
+            f"DELETE FROM {table} WHERE market_internal_id IN ({placeholders})",  # noqa: S608
+            tuple(market_ids),
+        )
+
+    # Orders reference markets AND have their own children
+    cursor.execute(
+        f"SELECT id FROM orders WHERE market_internal_id IN ({placeholders})",  # noqa: S608
+        tuple(market_ids),
+    )
+    order_ids = [row["id"] for row in cursor.fetchall()]
+    if order_ids:
+        order_placeholders = ",".join(["%s"] * len(order_ids))
+        cursor.execute(
+            f"DELETE FROM account_ledger WHERE order_id IN ({order_placeholders})",  # noqa: S608
+            tuple(order_ids),
+        )
+        cursor.execute(
+            f"DELETE FROM trades WHERE order_id IN ({order_placeholders})",  # noqa: S608
+            tuple(order_ids),
+        )
+        cursor.execute(
+            f"DELETE FROM orders WHERE id IN ({order_placeholders})",  # noqa: S608
+            tuple(order_ids),
+        )
+
+    # Positions reference markets AND have their own children
+    cursor.execute(
+        f"SELECT id FROM positions WHERE market_internal_id IN ({placeholders})",  # noqa: S608
+        tuple(market_ids),
+    )
+    position_ids = [row["id"] for row in cursor.fetchall()]
+    if position_ids:
+        pos_placeholders = ",".join(["%s"] * len(position_ids))
+        cursor.execute(
+            f"DELETE FROM exit_attempts WHERE position_internal_id IN ({pos_placeholders})",  # noqa: S608
+            tuple(position_ids),
+        )
+        cursor.execute(
+            f"DELETE FROM position_exits WHERE position_internal_id IN ({pos_placeholders})",  # noqa: S608
+            tuple(position_ids),
+        )
+        cursor.execute(
+            f"DELETE FROM positions WHERE id IN ({pos_placeholders})",  # noqa: S608
+            tuple(position_ids),
+        )
+
+    # Now safe to delete markets
+    cursor.execute(
+        f"DELETE FROM markets WHERE {where_clause}",  # noqa: S608
+        params,
+    )
+
+
+def delete_event_with_children(
+    cursor: Any,
+    where_clause: str,
+    params: tuple[Any, ...] | None = None,
+) -> None:
+    """Delete event(s) and all children (markets + their subtrees) in reverse FK order."""
+    cursor.execute(
+        f"SELECT id FROM events WHERE {where_clause}",  # noqa: S608
+        params,
+    )
+    event_ids = [row["id"] for row in cursor.fetchall()]
+    if not event_ids:
+        return
+
+    # Markets reference events via event_internal_id
+    for eid in event_ids:
+        delete_market_with_children(cursor, "event_internal_id = %s", (eid,))
+
+    # Now safe to delete events
+    cursor.execute(
+        f"DELETE FROM events WHERE {where_clause}",  # noqa: S608
+        params,
+    )
+
+
+def delete_venue_with_children(
+    cursor: Any,
+    where_clause: str,
+    params: tuple[Any, ...] | None = None,
+) -> None:
+    """Delete venue(s) after clearing FK references from games/game_states."""
+    cursor.execute(
+        f"SELECT venue_id FROM venues WHERE {where_clause}",  # noqa: S608
+        params,
+    )
+    venue_ids = [row["venue_id"] for row in cursor.fetchall()]
+    if not venue_ids:
+        return
+
+    placeholders = ",".join(["%s"] * len(venue_ids))
+
+    # Games reference venues via venue_id — SET NULL the FK (games are not owned by venues)
+    # With RESTRICT we can't delete venues if games reference them.
+    # Clear the venue_id FK on games first.
+    cursor.execute(
+        f"UPDATE games SET venue_id = NULL WHERE venue_id IN ({placeholders})",  # noqa: S608
+        tuple(venue_ids),
+    )
+    # game_states also reference venues
+    cursor.execute(
+        f"UPDATE game_states SET venue_id = NULL WHERE venue_id IN ({placeholders})",  # noqa: S608
+        tuple(venue_ids),
+    )
+
+    cursor.execute(
+        f"DELETE FROM venues WHERE {where_clause}",  # noqa: S608
+        params,
+    )
+
+
+def delete_platform_with_children(
+    cursor: Any,
+    where_clause: str,
+    params: tuple[Any, ...] | None = None,
+) -> None:
+    """Delete platform(s) and everything underneath in reverse FK order.
+
+    This is the nuclear option — equivalent to the old CASCADE behavior
+    but explicit about what gets deleted.
+    """
+    cursor.execute(
+        f"SELECT platform_id FROM platforms WHERE {where_clause}",  # noqa: S608
+        params,
+    )
+    platform_ids = [row["platform_id"] for row in cursor.fetchall()]
+    if not platform_ids:
+        return
+
+    for pid in platform_ids:
+        # Delete markets and all their subtrees
+        delete_market_with_children(cursor, "platform_id = %s", (pid,))
+        # Delete events
+        cursor.execute("DELETE FROM events WHERE platform_id = %s", (pid,))
+        # Delete series
+        cursor.execute("DELETE FROM series WHERE platform_id = %s", (pid,))
+        # Delete strategies and models (they reference platforms)
+        cursor.execute("DELETE FROM strategies WHERE platform_id = %s", (pid,))
+        # Delete account_balance
+        cursor.execute("DELETE FROM account_balance WHERE platform_id = %s", (pid,))
+
+    cursor.execute(
+        f"DELETE FROM platforms WHERE {where_clause}",  # noqa: S608
+        params,
+    )

--- a/tests/fixtures/cleanup_helpers.py
+++ b/tests/fixtures/cleanup_helpers.py
@@ -225,14 +225,22 @@ def delete_venue_with_children(
 
     placeholders = ",".join(["%s"] * len(venue_ids))
 
-    # Games reference venues via venue_id — SET NULL the FK (games are not owned by venues)
-    # With RESTRICT we can't delete venues if games reference them.
-    # Clear the venue_id FK on games first.
+    # games.venue_id and game_states.venue_id both carry foreign-key
+    # constraints to venues(venue_id). Neither is listed in migration 0057
+    # because they were already compliant: games.venue_id was declared
+    # ON DELETE SET NULL and game_states.venue_id was declared NO ACTION
+    # (functionally equivalent to RESTRICT for delete enforcement — they
+    # only diverge for deferrable constraints, which these are not).
+    #
+    # Either way, we cannot simply DELETE a venue while a game or
+    # game_state still references it: SET NULL is a nullify-at-delete
+    # behavior and NO ACTION raises ForeignKeyViolation. Clearing the
+    # references explicitly makes the teardown order-independent and
+    # correct under either semantics, which is the point of this helper.
     cursor.execute(
         f"UPDATE games SET venue_id = NULL WHERE venue_id IN ({placeholders})",  # noqa: S608
         tuple(venue_ids),
     )
-    # game_states also reference venues
     cursor.execute(
         f"UPDATE game_states SET venue_id = NULL WHERE venue_id IN ({placeholders})",  # noqa: S608
         tuple(venue_ids),

--- a/tests/fixtures/transaction_fixtures.py
+++ b/tests/fixtures/transaction_fixtures.py
@@ -178,7 +178,7 @@ def db_transaction_with_setup(
     cursor.execute("""
         INSERT INTO series (series_id, platform_id, external_id, title, category)
         VALUES ('TEST-SERIES-NFL', 'test_platform', 'TEST-EXT-SERIES', 'Test NFL Series', 'sports')
-        ON CONFLICT (series_id) DO NOTHING
+        ON CONFLICT (series_id) WHERE row_current_ind = TRUE DO NOTHING
     """)
 
     # Get series surrogate PK for event FK (migration 0019: series_internal_id)

--- a/tests/integration/cli/_deprecated_test_cli_database_integration.py
+++ b/tests/integration/cli/_deprecated_test_cli_database_integration.py
@@ -115,7 +115,9 @@ def setup_kalshi_platform(db_pool, clean_test_data):
     # The 'kalshi' platform is seeded by Alembic migration and should persist
     # Deleting it causes race conditions in parallel test execution (Issue #228)
     with get_cursor(commit=True) as cur:
-        cur.execute("DELETE FROM markets WHERE platform_id = 'kalshi'")
+        from tests.fixtures.cleanup_helpers import delete_market_with_children
+
+        delete_market_with_children(cur, "platform_id = %s", ("kalshi",))
         cur.execute("DELETE FROM events WHERE platform_id = 'kalshi'")
         cur.execute("DELETE FROM series WHERE platform_id = 'kalshi'")
         cur.execute("DELETE FROM account_balance WHERE platform_id = 'kalshi'")
@@ -379,13 +381,14 @@ def test_fetch_markets_upsert_pattern(
     from precog.database.connection import get_cursor
 
     with get_cursor(commit=True) as cur:
-        cur.execute(
-            """
-            DELETE FROM markets m
-            USING events e
-            WHERE m.event_internal_id = e.id
-              AND e.series_id = 'KXNFLGAME'
-        """
+        # Delete markets and their children via helper (RESTRICT FKs require
+        # children to be deleted first).
+        from tests.fixtures.cleanup_helpers import delete_market_with_children
+
+        delete_market_with_children(
+            cur,
+            "event_internal_id IN (SELECT id FROM events WHERE platform_id = %s)",
+            ("kalshi",),
         )
 
     # Set environment variables for KalshiClient initialization

--- a/tests/integration/cli/_deprecated_test_cli_database_integration.py
+++ b/tests/integration/cli/_deprecated_test_cli_database_integration.py
@@ -91,7 +91,7 @@ def setup_kalshi_platform(db_pool, clean_test_data):
             """
             INSERT INTO series (series_id, platform_id, external_id, title, category)
             VALUES ('KXNFLGAME', 'kalshi', 'KXNFLGAME-EXT', 'NFL Game Series', 'sports')
-            ON CONFLICT (series_id) DO NOTHING
+            ON CONFLICT (series_id) WHERE row_current_ind = TRUE DO NOTHING
         """
         )
 

--- a/tests/integration/database/test_connection_integration.py
+++ b/tests/integration/database/test_connection_integration.py
@@ -50,7 +50,7 @@ class TestConnectionIntegration:
                 """
                 INSERT INTO venues (espn_venue_id, venue_name, city)
                 VALUES (%s, %s, %s)
-                ON CONFLICT (espn_venue_id) DO NOTHING
+                ON CONFLICT (espn_venue_id) WHERE row_current_ind = TRUE DO NOTHING
                 """,
                 ("INT-TEST-001", "Integration Test Venue", "Test City"),
             )

--- a/tests/integration/database/test_crud_positions_trailing_stop_integration.py
+++ b/tests/integration/database/test_crud_positions_trailing_stop_integration.py
@@ -782,21 +782,11 @@ def create_position_market(db_pool: Any) -> Any:
 
     Yields the market surrogate PK.
     """
+    from tests.fixtures.cleanup_helpers import delete_market_with_children
+
     with get_cursor(commit=True) as cur:
-        # Cleanup any orphaned rows from a prior failed run.
-        cur.execute(
-            "DELETE FROM positions WHERE position_id LIKE %s",
-            (_CREATE_POS_BK_PREFIX + "%",),
-        )
-        cur.execute(
-            """
-            DELETE FROM market_snapshots WHERE market_id IN (
-                SELECT id FROM markets WHERE ticker = %s
-            )
-            """,
-            (_CREATE_POS_TEST_TICKER,),
-        )
-        cur.execute("DELETE FROM markets WHERE ticker = %s", (_CREATE_POS_TEST_TICKER,))
+        # Cleanup any orphaned rows from a prior failed run (RESTRICT-safe).
+        delete_market_with_children(cur, "ticker = %s", (_CREATE_POS_TEST_TICKER,))
 
         # Seed strategy + model parent rows idempotently. Mirrors the high
         # IDs conftest.clean_test_data uses so we don't collide with
@@ -862,17 +852,10 @@ def create_position_market(db_pool: Any) -> Any:
 
     yield market_pk
 
-    # Teardown: remove positions + market rows. Leave strategy/model rows
-    # alone so co-running tests that share the 99901 seed don't have the
-    # rug pulled mid-test.
+    # Teardown: RESTRICT-safe cleanup via helper.
     try:
         with get_cursor(commit=True) as cur:
-            cur.execute(
-                "DELETE FROM positions WHERE position_id LIKE %s",
-                (_CREATE_POS_BK_PREFIX + "%",),
-            )
-            cur.execute("DELETE FROM market_snapshots WHERE market_id = %s", (market_pk,))
-            cur.execute("DELETE FROM markets WHERE id = %s", (market_pk,))
+            delete_market_with_children(cur, "id = %s", (market_pk,))
     except Exception:
         # Best-effort cleanup; do not mask the actual test outcome.
         pass

--- a/tests/integration/database/test_crud_positions_trailing_stop_integration.py
+++ b/tests/integration/database/test_crud_positions_trailing_stop_integration.py
@@ -95,21 +95,11 @@ def trailing_stop_position(db_pool: Any) -> Any:
     position_bk = f"{_TEST_POSITION_BK_PREFIX}1"
 
     # Setup: clean any leftover state and ensure the market + position rows exist.
+    from tests.fixtures.cleanup_helpers import delete_market_with_children
+
     with get_cursor(commit=True) as cur:
-        # Cleanup in FK order: positions first (FKs to markets), then markets.
-        cur.execute(
-            "DELETE FROM positions WHERE position_id LIKE %s",
-            (_TEST_POSITION_BK_PREFIX + "%",),
-        )
-        cur.execute(
-            """
-            DELETE FROM market_snapshots WHERE market_id IN (
-                SELECT id FROM markets WHERE ticker = %s
-            )
-            """,
-            (_TEST_TICKER,),
-        )
-        cur.execute("DELETE FROM markets WHERE ticker = %s", (_TEST_TICKER,))
+        # RESTRICT-safe cleanup: delete all children before parents.
+        delete_market_with_children(cur, "ticker = %s", (_TEST_TICKER,))
 
         # Create the underlying market (positions FK to markets.id).
         cur.execute(
@@ -169,12 +159,10 @@ def trailing_stop_position(db_pool: Any) -> Any:
 
     yield position_surrogate_id, position_bk, market_pk
 
-    # Teardown: remove all rows this test touched.
+    # Teardown: RESTRICT-safe cleanup.
     try:
         with get_cursor(commit=True) as cur:
-            cur.execute("DELETE FROM positions WHERE position_id = %s", (position_bk,))
-            cur.execute("DELETE FROM market_snapshots WHERE market_id = %s", (market_pk,))
-            cur.execute("DELETE FROM markets WHERE id = %s", (market_pk,))
+            delete_market_with_children(cur, "id = %s", (market_pk,))
     except Exception:
         # Best-effort cleanup; do not mask the actual test outcome.
         pass

--- a/tests/integration/database/test_migration_0052_0055_execution_environment.py
+++ b/tests/integration/database/test_migration_0052_0055_execution_environment.py
@@ -93,20 +93,10 @@ def migration_test_platform(db_pool: Any) -> Any:
 
     with get_cursor(commit=True) as cur:
         # Defensive cleanup of any prior run.
-        cur.execute(
-            "DELETE FROM exit_attempts WHERE position_internal_id IN "
-            "(SELECT id FROM positions WHERE platform_id = %s)",
-            (platform_id,),
-        )
-        cur.execute(
-            "DELETE FROM position_exits WHERE position_internal_id IN "
-            "(SELECT id FROM positions WHERE platform_id = %s)",
-            (platform_id,),
-        )
+        from tests.fixtures.cleanup_helpers import delete_market_with_children
+
         cur.execute("DELETE FROM account_ledger WHERE platform_id = %s", (platform_id,))
-        cur.execute("DELETE FROM settlements WHERE platform_id = %s", (platform_id,))
-        cur.execute("DELETE FROM positions WHERE platform_id = %s", (platform_id,))
-        cur.execute("DELETE FROM markets WHERE platform_id = %s", (platform_id,))
+        delete_market_with_children(cur, "platform_id = %s", (platform_id,))
         cur.execute("DELETE FROM platforms WHERE platform_id = %s", (platform_id,))
 
         # Platform
@@ -166,18 +156,10 @@ def migration_test_platform(db_pool: Any) -> Any:
 
     # Teardown in reverse FK order.
     with get_cursor(commit=True) as cur:
-        cur.execute(
-            "DELETE FROM exit_attempts WHERE position_internal_id = %s",
-            (position_internal_id,),
-        )
-        cur.execute(
-            "DELETE FROM position_exits WHERE position_internal_id = %s",
-            (position_internal_id,),
-        )
+        from tests.fixtures.cleanup_helpers import delete_market_with_children
+
         cur.execute("DELETE FROM account_ledger WHERE platform_id = %s", (platform_id,))
-        cur.execute("DELETE FROM settlements WHERE platform_id = %s", (platform_id,))
-        cur.execute("DELETE FROM positions WHERE id = %s", (position_internal_id,))
-        cur.execute("DELETE FROM markets WHERE id = %s", (market_internal_id,))
+        delete_market_with_children(cur, "platform_id = %s", (platform_id,))
         cur.execute("DELETE FROM platforms WHERE platform_id = %s", (platform_id,))
 
 

--- a/tests/integration/database/test_migration_0057_fk_restrict.py
+++ b/tests/integration/database/test_migration_0057_fk_restrict.py
@@ -553,6 +553,38 @@ class TestSCDIndexes:
                 "Expected league in index definition (composite business key)"
             )
 
+    def test_game_states_game_id_row_start_ts_compound_index_exists(self, db_pool: Any) -> None:
+        """Compound index for temporal_alignment_writer LATERAL sort.
+
+        Pairs with PR #747 and Pattern 63. The writer's hot-path query
+        does ORDER BY ABS(ms.row_start_ts - gs_inner.row_start_ts) for
+        each game_id bucket, which is only efficient if the planner can
+        walk game_states ordered by row_start_ts within a game_id.
+        """
+        with get_cursor(commit=False) as cur:
+            cur.execute(
+                """
+                SELECT indexdef
+                FROM pg_indexes
+                WHERE schemaname = 'public'
+                    AND tablename = 'game_states'
+                    AND indexname = 'idx_game_states_game_id_row_start_ts'
+                """,
+            )
+            row = cur.fetchone()
+            assert row is not None, (
+                "idx_game_states_game_id_row_start_ts missing — temporal_alignment"
+                " writer LATERAL subquery will fall back to a sequential sort"
+            )
+            indexdef = row["indexdef"].lower()
+            assert "game_id" in indexdef
+            assert "row_start_ts" in indexdef
+            # Partial index on game_id IS NOT NULL — matches the pattern used by
+            # the pre-existing idx_game_states_game_id (0035).
+            assert "game_id is not null" in indexdef, (
+                "Expected partial index WHERE clause matching idx_game_states_game_id"
+            )
+
 
 # =============================================================================
 # TestRestrictBlocksDeletion

--- a/tests/integration/database/test_migration_0057_fk_restrict.py
+++ b/tests/integration/database/test_migration_0057_fk_restrict.py
@@ -348,18 +348,18 @@ def fk_test_team(db_pool: Any) -> Any:
         # Cleanup
         cur.execute(
             "DELETE FROM team_rankings WHERE team_id IN "
-            "(SELECT team_id FROM teams WHERE team_code = %s AND sport = 'nfl')",
+            "(SELECT team_id FROM teams WHERE team_code = %s AND sport = 'football')",
             (team_code,),
         )
         cur.execute(
-            "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+            "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
             (team_code,),
         )
 
         cur.execute(
             """
             INSERT INTO teams (team_code, team_name, sport, league)
-            VALUES (%s, 'Migration 0057 Test Team', 'nfl', 'nfl')
+            VALUES (%s, 'Migration 0057 Test Team', 'football', 'nfl')
             RETURNING team_id
             """,
             (team_code,),
@@ -647,13 +647,13 @@ class TestRestrictBlocksDeletion:
             cur.execute(
                 """
                 INSERT INTO events (
-                    event_id, platform_id, external_id,
+                    platform_id, external_id,
                     category, title
                 )
-                VALUES (%s, %s, %s, 'sports', 'Test Event')
+                VALUES (%s, %s, 'sports', 'Test Event')
                 RETURNING id
                 """,
-                ("MIG57-EVT", platform_id, "MIG57-EVT-EXT"),
+                (platform_id, "MIG57-EVT-EXT"),
             )
             event_id = cur.fetchone()["id"]
 
@@ -873,13 +873,13 @@ class TestSCDDefaults:
         team_code = "M57DA"
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
             cur.execute(
                 """
                 INSERT INTO teams (team_code, team_name, sport, league)
-                VALUES (%s, 'Default Test Team', 'nfl', 'nfl')
+                VALUES (%s, 'Default Test Team', 'football', 'nfl')
                 RETURNING row_current_ind, row_start_ts, row_end_ts
                 """,
                 (team_code,),
@@ -892,7 +892,7 @@ class TestSCDDefaults:
         # Cleanup
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
 
@@ -948,7 +948,7 @@ class TestSCDDefaults:
         team_code = "M57DF"
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
             cur.execute(
@@ -956,7 +956,7 @@ class TestSCDDefaults:
                 INSERT INTO teams (
                     team_code, team_name, sport, league, row_current_ind
                 )
-                VALUES (%s, 'Historical Test Team', 'nfl', 'nfl', FALSE)
+                VALUES (%s, 'Historical Test Team', 'football', 'nfl', FALSE)
                 RETURNING row_current_ind
                 """,
                 (team_code,),
@@ -967,7 +967,7 @@ class TestSCDDefaults:
         # Cleanup
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
 
@@ -976,7 +976,7 @@ class TestSCDDefaults:
         team_code = "M57DN"
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
 
@@ -987,7 +987,7 @@ class TestSCDDefaults:
                     INSERT INTO teams (
                         team_code, team_name, sport, league, row_current_ind
                     )
-                    VALUES (%s, 'Null Current Team', 'nfl', 'nfl', NULL)
+                    VALUES (%s, 'Null Current Team', 'football', 'nfl', NULL)
                     """,
                     (team_code,),
                 )
@@ -995,7 +995,7 @@ class TestSCDDefaults:
         # Cleanup (might not exist if insert failed)
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
 
@@ -1005,7 +1005,7 @@ class TestSCDDefaults:
         team_code = "M57NS"
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
 
@@ -1016,7 +1016,7 @@ class TestSCDDefaults:
                     INSERT INTO teams (
                         team_code, team_name, sport, league, row_start_ts
                     )
-                    VALUES (%s, 'Null Start Team', 'nfl', 'nfl', NULL)
+                    VALUES (%s, 'Null Start Team', 'football', 'nfl', NULL)
                     """,
                     (team_code,),
                 )
@@ -1024,7 +1024,7 @@ class TestSCDDefaults:
         # Cleanup (might not exist if insert failed)
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
 
@@ -1033,7 +1033,7 @@ class TestSCDDefaults:
         team_code = "M57NE"
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
             cur.execute(
@@ -1041,7 +1041,7 @@ class TestSCDDefaults:
                 INSERT INTO teams (
                     team_code, team_name, sport, league, row_end_ts
                 )
-                VALUES (%s, 'Nullable End Team', 'nfl', 'nfl', NULL)
+                VALUES (%s, 'Nullable End Team', 'football', 'nfl', NULL)
                 RETURNING row_end_ts
                 """,
                 (team_code,),
@@ -1052,7 +1052,7 @@ class TestSCDDefaults:
         # Cleanup
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
 
@@ -1071,13 +1071,13 @@ class TestSCDUniqueConstraint:
         team_code = "M57DU"
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
             cur.execute(
                 """
                 INSERT INTO teams (team_code, team_name, sport, league, row_current_ind)
-                VALUES (%s, 'Dup Test Team 1', 'nfl', 'nfl', TRUE)
+                VALUES (%s, 'Dup Test Team 1', 'football', 'nfl', TRUE)
                 """,
                 (team_code,),
             )
@@ -1087,7 +1087,7 @@ class TestSCDUniqueConstraint:
                 cur.execute(
                     """
                     INSERT INTO teams (team_code, team_name, sport, league, row_current_ind)
-                    VALUES (%s, 'Dup Test Team 2', 'nfl', 'nfl', TRUE)
+                    VALUES (%s, 'Dup Test Team 2', 'football', 'nfl', TRUE)
                     """,
                     (team_code,),
                 )
@@ -1095,7 +1095,7 @@ class TestSCDUniqueConstraint:
         # Cleanup
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
 
@@ -1104,27 +1104,27 @@ class TestSCDUniqueConstraint:
         team_code = "M57HD"
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
             # Insert two historical rows -- both FALSE, no unique violation
             cur.execute(
                 """
                 INSERT INTO teams (team_code, team_name, sport, league, row_current_ind)
-                VALUES (%s, 'Hist Team V1', 'nfl', 'nfl', FALSE)
+                VALUES (%s, 'Hist Team V1', 'football', 'nfl', FALSE)
                 """,
                 (team_code,),
             )
             cur.execute(
                 """
                 INSERT INTO teams (team_code, team_name, sport, league, row_current_ind)
-                VALUES (%s, 'Hist Team V2', 'nfl', 'nfl', FALSE)
+                VALUES (%s, 'Hist Team V2', 'football', 'nfl', FALSE)
                 """,
                 (team_code,),
             )
 
             cur.execute(
-                "SELECT COUNT(*) AS cnt FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "SELECT COUNT(*) AS cnt FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
             assert cur.fetchone()["cnt"] == 2
@@ -1132,7 +1132,7 @@ class TestSCDUniqueConstraint:
         # Cleanup
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
 
@@ -1248,13 +1248,13 @@ class TestDeleteWithoutChildren:
         team_code = "M57OR"
         with get_cursor(commit=True) as cur:
             cur.execute(
-                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'football'",
                 (team_code,),
             )
             cur.execute(
                 """
                 INSERT INTO teams (team_code, team_name, sport, league)
-                VALUES (%s, 'Orphan Test Team', 'nfl', 'nfl')
+                VALUES (%s, 'Orphan Test Team', 'football', 'nfl')
                 RETURNING team_id
                 """,
                 (team_code,),

--- a/tests/integration/database/test_migration_0057_fk_restrict.py
+++ b/tests/integration/database/test_migration_0057_fk_restrict.py
@@ -1,0 +1,1271 @@
+"""Integration tests for migration 0057 (FK RESTRICT conversion + SCD Type 2).
+
+Verifies the POST-MIGRATION state of all foreign key constraints and
+the SCD Type 2 columns on teams, venues, and series. These tests run
+against a real database (testcontainer per ADR-057).
+
+Test groups:
+    - TestAllFKsAreRestrict: every FK in the conversion inventory has
+      ON DELETE RESTRICT (query pg_catalog for delete_rule)
+    - TestSCDColumns: row_current_ind, row_start_ts, row_end_ts exist
+      with correct type, default, and nullability on teams/venues/series
+    - TestSCDIndexes: partial unique indexes and current-row filter
+      indexes exist on teams/venues/series
+    - TestRestrictBlocksDeletion: representative DELETE on referenced
+      parents raises IntegrityError (one test per FK category)
+    - TestSCDDefaults: new rows get correct SCD defaults
+    - TestDeleteWithoutChildren: parent rows with no children can
+      still be deleted (RESTRICT only blocks when children exist)
+
+Issues: #724, #725 (partial)
+Epic: #745 (Schema Hardening Arc, Cohort C2)
+
+Markers:
+    @pytest.mark.integration: real DB required (testcontainer per ADR-057)
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import psycopg2
+import pytest
+
+from precog.database.connection import get_cursor
+
+# =============================================================================
+# Complete FK inventory -- must match migration 0057
+# =============================================================================
+
+# All FKs that were SET NULL, now RESTRICT
+SET_NULL_FKS = [
+    ("events", "series_internal_id", "series", "id"),
+    ("events", "game_id", "games", "id"),
+    ("edges", "model_id", "probability_models", "model_id"),
+    ("edges", "strategy_id", "strategies", "strategy_id"),
+    ("historical_epa", "team_id", "teams", "team_id"),
+    ("elo_calculation_log", "game_state_id", "game_states", "id"),
+    ("elo_calculation_log", "home_team_id", "teams", "team_id"),
+    ("elo_calculation_log", "away_team_id", "teams", "team_id"),
+    ("elo_calculation_log", "game_id", "games", "id"),
+    ("game_odds", "home_team_id", "teams", "team_id"),
+    ("game_odds", "away_team_id", "teams", "team_id"),
+    ("game_odds", "game_id", "games", "id"),
+    ("historical_stats", "team_id", "teams", "team_id"),
+    ("historical_rankings", "team_id", "teams", "team_id"),
+    ("orders", "strategy_id", "strategies", "strategy_id"),
+    ("orders", "model_id", "probability_models", "model_id"),
+    ("orders", "edge_id", "edges", "id"),
+    ("orders", "position_id", "positions", "id"),
+    ("trades", "order_id", "orders", "id"),
+    ("account_ledger", "order_id", "orders", "id"),
+    ("evaluation_runs", "model_id", "probability_models", "model_id"),
+    ("evaluation_runs", "strategy_id", "strategies", "strategy_id"),
+    ("backtesting_runs", "strategy_id", "strategies", "strategy_id"),
+    ("backtesting_runs", "model_id", "probability_models", "model_id"),
+    ("predictions", "model_id", "probability_models", "model_id"),
+    ("predictions", "event_id", "events", "id"),
+    ("games", "home_team_id", "teams", "team_id"),
+    ("games", "away_team_id", "teams", "team_id"),
+    ("games", "venue_id", "venues", "venue_id"),
+    ("game_states", "game_id", "games", "id"),
+    ("temporal_alignment", "game_id", "games", "id"),
+]
+
+# All FKs that were CASCADE, now RESTRICT
+CASCADE_FKS = [
+    ("series", "platform_id", "platforms", "platform_id"),
+    ("events", "platform_id", "platforms", "platform_id"),
+    ("markets", "platform_id", "platforms", "platform_id"),
+    ("strategies", "platform_id", "platforms", "platform_id"),
+    ("positions", "platform_id", "platforms", "platform_id"),
+    ("trades", "platform_id", "platforms", "platform_id"),
+    ("settlements", "platform_id", "platforms", "platform_id"),
+    ("account_balance", "platform_id", "platforms", "platform_id"),
+    ("orders", "platform_id", "platforms", "platform_id"),
+    ("account_ledger", "platform_id", "platforms", "platform_id"),
+    ("market_trades", "platform_id", "platforms", "platform_id"),
+    ("markets", "event_internal_id", "events", "id"),
+    ("team_rankings", "team_id", "teams", "team_id"),
+    ("position_exits", "position_internal_id", "positions", "id"),
+    ("exit_attempts", "position_internal_id", "positions", "id"),
+    ("market_snapshots", "market_id", "markets", "id"),
+    ("orders", "market_internal_id", "markets", "id"),
+    ("market_trades", "market_internal_id", "markets", "id"),
+    ("predictions", "evaluation_run_id", "evaluation_runs", "id"),
+    ("predictions", "market_id", "markets", "id"),
+    ("orderbook_snapshots", "market_internal_id", "markets", "id"),
+    ("temporal_alignment", "market_id", "markets", "id"),
+    ("temporal_alignment", "market_snapshot_id", "market_snapshots", "id"),
+    ("temporal_alignment", "game_state_id", "game_states", "id"),
+    ("edges", "market_internal_id", "markets", "id"),
+    ("positions", "market_internal_id", "markets", "id"),
+    ("trades", "market_internal_id", "markets", "id"),
+    ("settlements", "market_internal_id", "markets", "id"),
+]
+
+ALL_FKS = SET_NULL_FKS + CASCADE_FKS
+
+# Tables that got SCD Type 2 columns
+SCD_TABLES = ["teams", "venues", "series"]
+
+# SCD columns and their expected properties
+SCD_COLUMNS = {
+    "row_current_ind": {"data_type": "boolean", "is_nullable": "NO", "has_default": True},
+    "row_start_ts": {
+        "data_type": "timestamp with time zone",
+        "is_nullable": "NO",
+        "has_default": True,
+    },
+    "row_end_ts": {
+        "data_type": "timestamp with time zone",
+        "is_nullable": "YES",
+        "has_default": False,
+    },
+}
+
+# Expected partial unique indexes (SCD business key enforcement)
+SCD_UNIQUE_INDEXES = {
+    "idx_teams_unique_current": "teams",
+    "idx_venues_unique_current": "venues",
+    "idx_series_unique_current": "series",
+}
+
+# Expected current-row filter indexes
+SCD_CURRENT_INDEXES = {
+    "idx_teams_current": "teams",
+    "idx_venues_current": "venues",
+    "idx_series_current": "series",
+}
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def fk_test_platform(db_pool: Any) -> Any:
+    """Create an isolated platform + downstream objects for FK testing.
+
+    Yields platform_id. Cleanup deletes all test data in reverse FK order.
+    """
+    platform_id = "mig-0057-fk-test"
+
+    with get_cursor(commit=True) as cur:
+        # Defensive cleanup of any prior run (reverse FK order)
+        cur.execute(
+            "DELETE FROM temporal_alignment WHERE market_id IN "
+            "(SELECT id FROM markets WHERE platform_id = %s)",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM orderbook_snapshots WHERE market_internal_id IN "
+            "(SELECT id FROM markets WHERE platform_id = %s)",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM market_trades WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM predictions WHERE market_id IN "
+            "(SELECT id FROM markets WHERE platform_id = %s)",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM account_ledger WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM trades WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM exit_attempts WHERE position_internal_id IN "
+            "(SELECT id FROM positions WHERE platform_id = %s)",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM position_exits WHERE position_internal_id IN "
+            "(SELECT id FROM positions WHERE platform_id = %s)",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM orders WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM market_snapshots WHERE market_id IN "
+            "(SELECT id FROM markets WHERE platform_id = %s)",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM settlements WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM positions WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM edges WHERE market_internal_id IN "
+            "(SELECT id FROM markets WHERE platform_id = %s)",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM markets WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM events WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM account_balance WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM strategies WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM series WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM platforms WHERE platform_id = %s",
+            (platform_id,),
+        )
+
+        # Create platform
+        cur.execute(
+            """
+            INSERT INTO platforms (
+                platform_id, platform_type, display_name, base_url, status
+            )
+            VALUES (%s, 'trading', 'Migration 0057 Test',
+                    'https://mig-0057-test.example.com', 'active')
+            """,
+            (platform_id,),
+        )
+
+    yield platform_id
+
+    # Teardown in reverse FK order
+    with get_cursor(commit=True) as cur:
+        cur.execute(
+            "DELETE FROM temporal_alignment WHERE market_id IN "
+            "(SELECT id FROM markets WHERE platform_id = %s)",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM orderbook_snapshots WHERE market_internal_id IN "
+            "(SELECT id FROM markets WHERE platform_id = %s)",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM market_trades WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM predictions WHERE market_id IN "
+            "(SELECT id FROM markets WHERE platform_id = %s)",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM account_ledger WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM trades WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM exit_attempts WHERE position_internal_id IN "
+            "(SELECT id FROM positions WHERE platform_id = %s)",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM position_exits WHERE position_internal_id IN "
+            "(SELECT id FROM positions WHERE platform_id = %s)",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM orders WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM market_snapshots WHERE market_id IN "
+            "(SELECT id FROM markets WHERE platform_id = %s)",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM settlements WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM positions WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM edges WHERE market_internal_id IN "
+            "(SELECT id FROM markets WHERE platform_id = %s)",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM markets WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM events WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM account_balance WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM strategies WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM series WHERE platform_id = %s",
+            (platform_id,),
+        )
+        cur.execute(
+            "DELETE FROM platforms WHERE platform_id = %s",
+            (platform_id,),
+        )
+
+
+@pytest.fixture
+def fk_test_team(db_pool: Any) -> Any:
+    """Create a test team for FK deletion tests. Yields team_id."""
+    team_code = "MIG57T"
+    with get_cursor(commit=True) as cur:
+        # Cleanup
+        cur.execute(
+            "DELETE FROM team_rankings WHERE team_id IN "
+            "(SELECT team_id FROM teams WHERE team_code = %s AND sport = 'nfl')",
+            (team_code,),
+        )
+        cur.execute(
+            "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+            (team_code,),
+        )
+
+        cur.execute(
+            """
+            INSERT INTO teams (team_code, team_name, sport, league)
+            VALUES (%s, 'Migration 0057 Test Team', 'nfl', 'nfl')
+            RETURNING team_id
+            """,
+            (team_code,),
+        )
+        team_id = cur.fetchone()["team_id"]
+
+    yield team_id
+
+    with get_cursor(commit=True) as cur:
+        cur.execute("DELETE FROM team_rankings WHERE team_id = %s", (team_id,))
+        cur.execute("DELETE FROM teams WHERE team_id = %s", (team_id,))
+
+
+# =============================================================================
+# TestAllFKsAreRestrict
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestAllFKsAreRestrict:
+    """Every FK in the conversion inventory has ON DELETE RESTRICT."""
+
+    @pytest.mark.parametrize(
+        ("child_table", "child_column", "parent_table", "parent_column"),
+        ALL_FKS,
+        ids=[f"{t[0]}.{t[1]}->{t[2]}.{t[3]}" for t in ALL_FKS],
+    )
+    def test_fk_is_restrict(
+        self,
+        db_pool: Any,
+        child_table: str,
+        child_column: str,
+        parent_table: str,
+        parent_column: str,
+    ) -> None:
+        """FK on {child_table}.{child_column} has delete_rule = RESTRICT."""
+        with get_cursor(commit=False) as cur:
+            cur.execute(
+                """
+                SELECT rc.delete_rule
+                FROM information_schema.referential_constraints rc
+                JOIN information_schema.key_column_usage kcu
+                    ON rc.constraint_name = kcu.constraint_name
+                    AND rc.constraint_schema = kcu.constraint_schema
+                WHERE kcu.table_name = %s
+                    AND kcu.column_name = %s
+                    AND kcu.table_schema = 'public'
+                """,
+                (child_table, child_column),
+            )
+            row = cur.fetchone()
+            assert row is not None, f"No FK found for {child_table}.{child_column}"
+            # PostgreSQL reports RESTRICT as either 'RESTRICT' or 'NO ACTION'
+            # Both block parent deletion. Our migration explicitly uses RESTRICT.
+            assert row["delete_rule"] in ("RESTRICT", "NO ACTION"), (
+                f"Expected RESTRICT for {child_table}.{child_column}, got {row['delete_rule']}"
+            )
+
+
+# =============================================================================
+# TestSCDColumns
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestSCDColumns:
+    """SCD Type 2 columns exist with correct type, default, and nullability."""
+
+    @pytest.mark.parametrize("table", SCD_TABLES)
+    @pytest.mark.parametrize("column_name", SCD_COLUMNS.keys())
+    def test_scd_column_exists_with_correct_shape(
+        self, db_pool: Any, table: str, column_name: str
+    ) -> None:
+        """SCD column has expected data type and nullability."""
+        expected = SCD_COLUMNS[column_name]
+        with get_cursor(commit=False) as cur:
+            cur.execute(
+                """
+                SELECT column_name, data_type, is_nullable, column_default
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                    AND table_name = %s
+                    AND column_name = %s
+                """,
+                (table, column_name),
+            )
+            row = cur.fetchone()
+            assert row is not None, f"{column_name} column not found on {table}"
+            assert row["data_type"] == expected["data_type"], (
+                f"Expected {expected['data_type']}, got {row['data_type']} "
+                f"for {table}.{column_name}"
+            )
+            assert row["is_nullable"] == expected["is_nullable"], (
+                f"Expected is_nullable={expected['is_nullable']}, "
+                f"got {row['is_nullable']} for {table}.{column_name}"
+            )
+            if expected["has_default"]:
+                assert row["column_default"] is not None, (
+                    f"Expected a default for {table}.{column_name}, got None"
+                )
+            else:
+                assert row["column_default"] is None, (
+                    f"Expected no default for {table}.{column_name}, got {row['column_default']}"
+                )
+
+
+# =============================================================================
+# TestSCDIndexes
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestSCDIndexes:
+    """Partial unique indexes and current-row filter indexes exist."""
+
+    @pytest.mark.parametrize(
+        ("index_name", "table"),
+        list(SCD_UNIQUE_INDEXES.items()),
+        ids=list(SCD_UNIQUE_INDEXES.keys()),
+    )
+    def test_unique_index_exists(self, db_pool: Any, index_name: str, table: str) -> None:
+        """Partial unique index for SCD business key exists."""
+        with get_cursor(commit=False) as cur:
+            cur.execute(
+                """
+                SELECT indexname, indexdef
+                FROM pg_indexes
+                WHERE schemaname = 'public'
+                    AND tablename = %s
+                    AND indexname = %s
+                """,
+                (table, index_name),
+            )
+            row = cur.fetchone()
+            assert row is not None, f"Index {index_name} not found on {table}"
+            # Verify it is a partial index (has WHERE clause)
+            assert "WHERE" in row["indexdef"].upper(), (
+                f"Expected partial index (WHERE clause) for {index_name}"
+            )
+            # Verify it is UNIQUE
+            assert "UNIQUE" in row["indexdef"].upper(), f"Expected UNIQUE index for {index_name}"
+            # Verify it filters on row_current_ind = true
+            assert "row_current_ind" in row["indexdef"].lower(), (
+                f"Expected row_current_ind filter in {index_name}"
+            )
+
+    @pytest.mark.parametrize(
+        ("index_name", "table"),
+        list(SCD_CURRENT_INDEXES.items()),
+        ids=list(SCD_CURRENT_INDEXES.keys()),
+    )
+    def test_current_row_index_exists(self, db_pool: Any, index_name: str, table: str) -> None:
+        """Current-row filter index exists (non-unique partial)."""
+        with get_cursor(commit=False) as cur:
+            cur.execute(
+                """
+                SELECT indexname, indexdef
+                FROM pg_indexes
+                WHERE schemaname = 'public'
+                    AND tablename = %s
+                    AND indexname = %s
+                """,
+                (table, index_name),
+            )
+            row = cur.fetchone()
+            assert row is not None, f"Index {index_name} not found on {table}"
+            # Verify it is a partial index
+            assert "WHERE" in row["indexdef"].upper(), (
+                f"Expected partial index (WHERE clause) for {index_name}"
+            )
+            assert "row_current_ind" in row["indexdef"].lower(), (
+                f"Expected row_current_ind filter in {index_name}"
+            )
+
+    def test_teams_unique_current_uses_composite_key(self, db_pool: Any) -> None:
+        """Teams unique-current index uses (team_code, league), not team_code alone."""
+        with get_cursor(commit=False) as cur:
+            cur.execute(
+                """
+                SELECT indexdef
+                FROM pg_indexes
+                WHERE schemaname = 'public'
+                    AND indexname = 'idx_teams_unique_current'
+                """,
+            )
+            row = cur.fetchone()
+            assert row is not None, "idx_teams_unique_current not found"
+            indexdef = row["indexdef"].lower()
+            assert "team_code" in indexdef, "Expected team_code in index definition"
+            assert "league" in indexdef, (
+                "Expected league in index definition (composite business key)"
+            )
+
+
+# =============================================================================
+# TestRestrictBlocksDeletion
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestRestrictBlocksDeletion:
+    """Representative DELETE on referenced parents raises IntegrityError.
+
+    One test per FK category: platform, team, strategy, market, position.
+    """
+
+    def test_platform_delete_blocked_by_series(self, db_pool: Any, fk_test_platform: str) -> None:
+        """Cannot delete platform that has series referencing it."""
+        platform_id = fk_test_platform
+
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                """
+                INSERT INTO series (
+                    series_id, platform_id, external_id,
+                    category, title
+                )
+                VALUES (%s, %s, %s, 'sports', 'Test Series')
+                """,
+                ("MIG57-SERIES", platform_id, "MIG57-SERIES-EXT"),
+            )
+
+        with pytest.raises(psycopg2.errors.ForeignKeyViolation):
+            with get_cursor(commit=True) as cur:
+                cur.execute(
+                    "DELETE FROM platforms WHERE platform_id = %s",
+                    (platform_id,),
+                )
+
+        # Cleanup
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM series WHERE series_id = %s",
+                ("MIG57-SERIES",),
+            )
+
+    def test_team_delete_blocked_by_team_rankings(self, db_pool: Any, fk_test_team: int) -> None:
+        """Cannot delete team that has team_rankings referencing it."""
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                """
+                INSERT INTO team_rankings (
+                    team_id, ranking_type, rank, season
+                )
+                VALUES (%s, 'AP', 1, 2025)
+                """,
+                (fk_test_team,),
+            )
+
+        with pytest.raises(psycopg2.errors.ForeignKeyViolation):
+            with get_cursor(commit=True) as cur:
+                cur.execute(
+                    "DELETE FROM teams WHERE team_id = %s",
+                    (fk_test_team,),
+                )
+
+        # Cleanup
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM team_rankings WHERE team_id = %s",
+                (fk_test_team,),
+            )
+
+    def test_strategy_delete_blocked_by_orders(self, db_pool: Any, fk_test_platform: str) -> None:
+        """Cannot delete strategy that has orders referencing it."""
+        platform_id = fk_test_platform
+
+        with get_cursor(commit=True) as cur:
+            # Create strategy
+            cur.execute(
+                """
+                INSERT INTO strategies (
+                    platform_id, strategy_name, strategy_version,
+                    strategy_type, config, status
+                )
+                VALUES (%s, 'mig57-test-strat', '1.0',
+                        'value', '{}', 'active')
+                RETURNING strategy_id
+                """,
+                (platform_id,),
+            )
+            strategy_id = cur.fetchone()["strategy_id"]
+
+            # Create event for market
+            cur.execute(
+                """
+                INSERT INTO events (
+                    event_id, platform_id, external_id,
+                    category, title
+                )
+                VALUES (%s, %s, %s, 'sports', 'Test Event')
+                RETURNING id
+                """,
+                ("MIG57-EVT", platform_id, "MIG57-EVT-EXT"),
+            )
+            event_id = cur.fetchone()["id"]
+
+            # Create market
+            cur.execute(
+                """
+                INSERT INTO markets (
+                    platform_id, event_internal_id, external_id,
+                    ticker, title, market_type, status
+                )
+                VALUES (%s, %s, %s, %s, 'Test Market', 'binary', 'open')
+                RETURNING id
+                """,
+                (platform_id, event_id, "MIG57-MKT-EXT", "MIG57-TICK"),
+            )
+            market_id = cur.fetchone()["id"]
+
+            # Create order referencing strategy
+            cur.execute(
+                """
+                INSERT INTO orders (
+                    platform_id, external_order_id,
+                    market_internal_id, strategy_id,
+                    side, action, order_type,
+                    requested_price, requested_quantity,
+                    remaining_quantity, status,
+                    execution_environment
+                )
+                VALUES (%s, %s, %s, %s, 'yes', 'buy', 'market',
+                        %s, 1, 1, 'submitted', 'paper')
+                RETURNING id
+                """,
+                (
+                    platform_id,
+                    "MIG57-ORD",
+                    market_id,
+                    strategy_id,
+                    Decimal("0.5000"),
+                ),
+            )
+
+        with pytest.raises(psycopg2.errors.ForeignKeyViolation):
+            with get_cursor(commit=True) as cur:
+                cur.execute(
+                    "DELETE FROM strategies WHERE strategy_id = %s",
+                    (strategy_id,),
+                )
+
+        # Cleanup in reverse FK order
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM orders WHERE platform_id = %s",
+                (platform_id,),
+            )
+            cur.execute(
+                "DELETE FROM markets WHERE platform_id = %s",
+                (platform_id,),
+            )
+            cur.execute(
+                "DELETE FROM events WHERE platform_id = %s",
+                (platform_id,),
+            )
+            cur.execute(
+                "DELETE FROM strategies WHERE platform_id = %s",
+                (platform_id,),
+            )
+
+    def test_market_delete_blocked_by_market_snapshots(
+        self, db_pool: Any, fk_test_platform: str
+    ) -> None:
+        """Cannot delete market that has market_snapshots referencing it."""
+        platform_id = fk_test_platform
+
+        with get_cursor(commit=True) as cur:
+            # Create market
+            cur.execute(
+                """
+                INSERT INTO markets (
+                    platform_id, external_id, ticker, title,
+                    market_type, status
+                )
+                VALUES (%s, %s, %s, 'Snapshot Test Market', 'binary', 'open')
+                RETURNING id
+                """,
+                (platform_id, "MIG57-SNAP-MKT-EXT", "MIG57-SNAP-TICK"),
+            )
+            market_id = cur.fetchone()["id"]
+
+            # Create snapshot referencing market
+            cur.execute(
+                """
+                INSERT INTO market_snapshots (
+                    market_id, yes_ask_price, no_ask_price,
+                    row_current_ind, row_start_ts
+                )
+                VALUES (%s, %s, %s, TRUE, NOW())
+                """,
+                (market_id, Decimal("0.5500"), Decimal("0.4600")),
+            )
+
+        with pytest.raises(psycopg2.errors.ForeignKeyViolation):
+            with get_cursor(commit=True) as cur:
+                cur.execute(
+                    "DELETE FROM markets WHERE id = %s",
+                    (market_id,),
+                )
+
+        # Cleanup
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM market_snapshots WHERE market_id = %s",
+                (market_id,),
+            )
+            cur.execute(
+                "DELETE FROM markets WHERE id = %s",
+                (market_id,),
+            )
+
+    def test_positions_delete_blocked_by_position_exits(
+        self, db_pool: Any, fk_test_platform: str
+    ) -> None:
+        """Cannot delete position that has position_exits referencing it."""
+        platform_id = fk_test_platform
+
+        with get_cursor(commit=True) as cur:
+            # Create market for position
+            cur.execute(
+                """
+                INSERT INTO markets (
+                    platform_id, external_id, ticker, title,
+                    market_type, status
+                )
+                VALUES (%s, %s, %s, 'Position Test Market', 'binary', 'open')
+                RETURNING id
+                """,
+                (platform_id, "MIG57-POS-MKT-EXT", "MIG57-POS-TICK"),
+            )
+            market_id = cur.fetchone()["id"]
+
+            # Create position
+            cur.execute(
+                """
+                INSERT INTO positions (
+                    position_id, platform_id, market_internal_id,
+                    side, quantity, entry_price, current_price,
+                    status, entry_time, last_check_time,
+                    row_current_ind, row_start_ts,
+                    execution_environment
+                )
+                VALUES (
+                    %s, %s, %s, 'YES', 10, %s, %s, 'open',
+                    NOW(), NOW(), TRUE, NOW(), 'paper'
+                )
+                RETURNING id
+                """,
+                (
+                    "MIG57-POS",
+                    platform_id,
+                    market_id,
+                    Decimal("0.5000"),
+                    Decimal("0.5000"),
+                ),
+            )
+            position_id = cur.fetchone()["id"]
+
+            # Create position_exit referencing position
+            cur.execute(
+                """
+                INSERT INTO position_exits (
+                    position_internal_id, exit_reason, exit_price,
+                    quantity_exited, realized_pnl,
+                    execution_environment
+                )
+                VALUES (%s, 'stop_loss', %s, 5, %s, 'paper')
+                """,
+                (
+                    position_id,
+                    Decimal("0.4500"),
+                    Decimal("-0.2500"),
+                ),
+            )
+
+        with pytest.raises(psycopg2.errors.ForeignKeyViolation):
+            with get_cursor(commit=True) as cur:
+                cur.execute(
+                    "DELETE FROM positions WHERE id = %s",
+                    (position_id,),
+                )
+
+        # Cleanup
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM position_exits WHERE position_internal_id = %s",
+                (position_id,),
+            )
+            cur.execute(
+                "DELETE FROM positions WHERE id = %s",
+                (position_id,),
+            )
+            cur.execute(
+                "DELETE FROM markets WHERE id = %s",
+                (market_id,),
+            )
+
+
+# =============================================================================
+# TestSCDDefaults
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestSCDDefaults:
+    """New rows in teams/venues/series get correct SCD Type 2 defaults."""
+
+    def test_team_scd_defaults(self, db_pool: Any) -> None:
+        """New team row has row_current_ind=TRUE, row_start_ts populated, row_end_ts=NULL."""
+        team_code = "M57DA"
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+            cur.execute(
+                """
+                INSERT INTO teams (team_code, team_name, sport, league)
+                VALUES (%s, 'Default Test Team', 'nfl', 'nfl')
+                RETURNING row_current_ind, row_start_ts, row_end_ts
+                """,
+                (team_code,),
+            )
+            row = cur.fetchone()
+            assert row["row_current_ind"] is True
+            assert row["row_start_ts"] is not None
+            assert row["row_end_ts"] is None
+
+        # Cleanup
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+
+    def test_venue_scd_defaults(self, db_pool: Any) -> None:
+        """New venue row has correct SCD defaults."""
+        venue_name = "Migration 0057 Test Venue"
+        with get_cursor(commit=True) as cur:
+            cur.execute("DELETE FROM venues WHERE venue_name = %s", (venue_name,))
+            cur.execute(
+                """
+                INSERT INTO venues (venue_name, city, state)
+                VALUES (%s, 'TestCity', 'TS')
+                RETURNING row_current_ind, row_start_ts, row_end_ts
+                """,
+                (venue_name,),
+            )
+            row = cur.fetchone()
+            assert row["row_current_ind"] is True
+            assert row["row_start_ts"] is not None
+            assert row["row_end_ts"] is None
+
+        # Cleanup
+        with get_cursor(commit=True) as cur:
+            cur.execute("DELETE FROM venues WHERE venue_name = %s", (venue_name,))
+
+    def test_series_scd_defaults(self, db_pool: Any, fk_test_platform: str) -> None:
+        """New series row has correct SCD defaults."""
+        series_id = "MIG57-SCD-DEFAULT-SERIES"
+        with get_cursor(commit=True) as cur:
+            cur.execute("DELETE FROM series WHERE series_id = %s", (series_id,))
+            cur.execute(
+                """
+                INSERT INTO series (
+                    series_id, platform_id, external_id,
+                    category, title
+                )
+                VALUES (%s, %s, %s, 'sports', 'SCD Default Test Series')
+                RETURNING row_current_ind, row_start_ts, row_end_ts
+                """,
+                (series_id, fk_test_platform, "MIG57-SCD-DEFAULT-EXT"),
+            )
+            row = cur.fetchone()
+            assert row["row_current_ind"] is True
+            assert row["row_start_ts"] is not None
+            assert row["row_end_ts"] is None
+
+        # Cleanup
+        with get_cursor(commit=True) as cur:
+            cur.execute("DELETE FROM series WHERE series_id = %s", (series_id,))
+
+    def test_row_current_ind_can_be_set_false(self, db_pool: Any) -> None:
+        """row_current_ind can be explicitly set to FALSE (for historical versioning)."""
+        team_code = "M57DF"
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+            cur.execute(
+                """
+                INSERT INTO teams (
+                    team_code, team_name, sport, league, row_current_ind
+                )
+                VALUES (%s, 'Historical Test Team', 'nfl', 'nfl', FALSE)
+                RETURNING row_current_ind
+                """,
+                (team_code,),
+            )
+            row = cur.fetchone()
+            assert row["row_current_ind"] is False
+
+        # Cleanup
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+
+    def test_row_current_ind_not_nullable(self, db_pool: Any) -> None:
+        """row_current_ind cannot be NULL."""
+        team_code = "M57DN"
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+
+        with pytest.raises(psycopg2.errors.NotNullViolation):
+            with get_cursor(commit=True) as cur:
+                cur.execute(
+                    """
+                    INSERT INTO teams (
+                        team_code, team_name, sport, league, row_current_ind
+                    )
+                    VALUES (%s, 'Null Current Team', 'nfl', 'nfl', NULL)
+                    """,
+                    (team_code,),
+                )
+
+        # Cleanup (might not exist if insert failed)
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+
+    def test_row_start_ts_not_nullable(self, db_pool: Any) -> None:
+        """row_start_ts cannot be NULL (server default prevents this in normal use,
+        but explicit NULL insert should be rejected)."""
+        team_code = "M57NS"
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+
+        with pytest.raises(psycopg2.errors.NotNullViolation):
+            with get_cursor(commit=True) as cur:
+                cur.execute(
+                    """
+                    INSERT INTO teams (
+                        team_code, team_name, sport, league, row_start_ts
+                    )
+                    VALUES (%s, 'Null Start Team', 'nfl', 'nfl', NULL)
+                    """,
+                    (team_code,),
+                )
+
+        # Cleanup (might not exist if insert failed)
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+
+    def test_row_end_ts_is_nullable(self, db_pool: Any) -> None:
+        """row_end_ts can be NULL (current rows have no end time)."""
+        team_code = "M57NE"
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+            cur.execute(
+                """
+                INSERT INTO teams (
+                    team_code, team_name, sport, league, row_end_ts
+                )
+                VALUES (%s, 'Nullable End Team', 'nfl', 'nfl', NULL)
+                RETURNING row_end_ts
+                """,
+                (team_code,),
+            )
+            row = cur.fetchone()
+            assert row["row_end_ts"] is None
+
+        # Cleanup
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+
+
+# =============================================================================
+# TestSCDUniqueConstraint
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestSCDUniqueConstraint:
+    """Partial unique indexes prevent duplicate current rows for same business key."""
+
+    def test_teams_duplicate_current_blocked(self, db_pool: Any) -> None:
+        """Cannot have two current rows with same (team_code, league)."""
+        team_code = "M57DU"
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+            cur.execute(
+                """
+                INSERT INTO teams (team_code, team_name, sport, league, row_current_ind)
+                VALUES (%s, 'Dup Test Team 1', 'nfl', 'nfl', TRUE)
+                """,
+                (team_code,),
+            )
+
+        with pytest.raises(psycopg2.errors.UniqueViolation):
+            with get_cursor(commit=True) as cur:
+                cur.execute(
+                    """
+                    INSERT INTO teams (team_code, team_name, sport, league, row_current_ind)
+                    VALUES (%s, 'Dup Test Team 2', 'nfl', 'nfl', TRUE)
+                    """,
+                    (team_code,),
+                )
+
+        # Cleanup
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+
+    def test_teams_historical_duplicates_allowed(self, db_pool: Any) -> None:
+        """Multiple historical (row_current_ind=FALSE) rows with same business key are OK."""
+        team_code = "M57HD"
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+            # Insert two historical rows -- both FALSE, no unique violation
+            cur.execute(
+                """
+                INSERT INTO teams (team_code, team_name, sport, league, row_current_ind)
+                VALUES (%s, 'Hist Team V1', 'nfl', 'nfl', FALSE)
+                """,
+                (team_code,),
+            )
+            cur.execute(
+                """
+                INSERT INTO teams (team_code, team_name, sport, league, row_current_ind)
+                VALUES (%s, 'Hist Team V2', 'nfl', 'nfl', FALSE)
+                """,
+                (team_code,),
+            )
+
+            cur.execute(
+                "SELECT COUNT(*) AS cnt FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+            assert cur.fetchone()["cnt"] == 2
+
+        # Cleanup
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+
+    def test_series_duplicate_current_blocked(self, db_pool: Any, fk_test_platform: str) -> None:
+        """Cannot have two current rows with same series_id."""
+        series_id = "MIG57-DUP-SERIES"
+        with get_cursor(commit=True) as cur:
+            cur.execute("DELETE FROM series WHERE series_id = %s", (series_id,))
+            cur.execute(
+                """
+                INSERT INTO series (
+                    series_id, platform_id, external_id,
+                    category, title, row_current_ind
+                )
+                VALUES (%s, %s, %s, 'sports', 'Dup Series 1', TRUE)
+                """,
+                (series_id, fk_test_platform, "MIG57-DUP-EXT-1"),
+            )
+
+        with pytest.raises(psycopg2.errors.UniqueViolation):
+            with get_cursor(commit=True) as cur:
+                cur.execute(
+                    """
+                    INSERT INTO series (
+                        series_id, platform_id, external_id,
+                        category, title, row_current_ind
+                    )
+                    VALUES (%s, %s, %s, 'sports', 'Dup Series 2', TRUE)
+                    """,
+                    (series_id, fk_test_platform, "MIG57-DUP-EXT-2"),
+                )
+
+        # Cleanup
+        with get_cursor(commit=True) as cur:
+            cur.execute("DELETE FROM series WHERE series_id = %s", (series_id,))
+
+    def test_venues_null_espn_id_allows_multiple_current(self, db_pool: Any) -> None:
+        """Multiple current venues with NULL espn_venue_id are allowed
+        (PostgreSQL UNIQUE treats NULLs as distinct)."""
+        v1_name = "MIG57 Null Venue 1"
+        v2_name = "MIG57 Null Venue 2"
+        with get_cursor(commit=True) as cur:
+            cur.execute("DELETE FROM venues WHERE venue_name IN (%s, %s)", (v1_name, v2_name))
+            cur.execute(
+                """
+                INSERT INTO venues (venue_name, city, state, espn_venue_id, row_current_ind)
+                VALUES (%s, 'City1', 'S1', NULL, TRUE)
+                """,
+                (v1_name,),
+            )
+            cur.execute(
+                """
+                INSERT INTO venues (venue_name, city, state, espn_venue_id, row_current_ind)
+                VALUES (%s, 'City2', 'S2', NULL, TRUE)
+                """,
+                (v2_name,),
+            )
+
+            cur.execute(
+                "SELECT COUNT(*) AS cnt FROM venues WHERE venue_name IN (%s, %s)",
+                (v1_name, v2_name),
+            )
+            assert cur.fetchone()["cnt"] == 2
+
+        # Cleanup
+        with get_cursor(commit=True) as cur:
+            cur.execute("DELETE FROM venues WHERE venue_name IN (%s, %s)", (v1_name, v2_name))
+
+
+# =============================================================================
+# TestDeleteWithoutChildren
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestDeleteWithoutChildren:
+    """Parent rows with no children can still be deleted (RESTRICT only blocks
+    when children exist, not unconditionally)."""
+
+    def test_platform_delete_succeeds_when_no_children(self, db_pool: Any) -> None:
+        """Deleting a platform with no child rows succeeds."""
+        platform_id = "mig-0057-orphan-test"
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM platforms WHERE platform_id = %s",
+                (platform_id,),
+            )
+            cur.execute(
+                """
+                INSERT INTO platforms (
+                    platform_id, platform_type, display_name, base_url, status
+                )
+                VALUES (%s, 'trading', 'Orphan Test Platform',
+                        'https://orphan-test.example.com', 'active')
+                """,
+                (platform_id,),
+            )
+
+        # Delete should succeed -- no children
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM platforms WHERE platform_id = %s",
+                (platform_id,),
+            )
+            cur.execute(
+                "SELECT COUNT(*) AS cnt FROM platforms WHERE platform_id = %s",
+                (platform_id,),
+            )
+            assert cur.fetchone()["cnt"] == 0
+
+    def test_team_delete_succeeds_when_no_children(self, db_pool: Any) -> None:
+        """Deleting a team with no child rows succeeds."""
+        team_code = "M57OR"
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM teams WHERE team_code = %s AND sport = 'nfl'",
+                (team_code,),
+            )
+            cur.execute(
+                """
+                INSERT INTO teams (team_code, team_name, sport, league)
+                VALUES (%s, 'Orphan Test Team', 'nfl', 'nfl')
+                RETURNING team_id
+                """,
+                (team_code,),
+            )
+            team_id = cur.fetchone()["team_id"]
+
+        # Delete should succeed -- no children
+        with get_cursor(commit=True) as cur:
+            cur.execute("DELETE FROM teams WHERE team_id = %s", (team_id,))
+            cur.execute(
+                "SELECT COUNT(*) AS cnt FROM teams WHERE team_id = %s",
+                (team_id,),
+            )
+            assert cur.fetchone()["cnt"] == 0

--- a/tests/integration/trading/test_position_manager.py
+++ b/tests/integration/trading/test_position_manager.py
@@ -14,7 +14,7 @@ from decimal import Decimal
 
 import pytest
 
-from precog.database.connection import get_connection, release_connection
+from precog.database.connection import get_connection, get_cursor, release_connection
 from precog.database.crud_strategies import create_strategy
 from precog.trading.position_manager import (
     InsufficientMarginError,
@@ -90,7 +90,15 @@ def test_market_pks(db_cursor, clean_test_data):
     finally:
         release_connection(conn)
 
-    return market_pks
+    yield market_pks
+
+    # Teardown: delete markets and their children in FK order.
+    # Must use get_cursor (RealDictCursor) because the helper uses dict-style row access.
+    from tests.fixtures.cleanup_helpers import delete_market_with_children
+
+    with get_cursor(commit=True) as cur:
+        for ticker in market_pks:
+            delete_market_with_children(cur, "ticker = %s", (ticker,))
 
 
 @pytest.fixture

--- a/tests/integration/trading/test_position_manager_trailing_stop_integration.py
+++ b/tests/integration/trading/test_position_manager_trailing_stop_integration.py
@@ -93,15 +93,9 @@ def trailing_stop_open_position(db_pool: Any) -> Any:
             "DELETE FROM positions WHERE position_id LIKE %s",
             (_TEST_POSITION_BK_PREFIX + "%",),
         )
-        cur.execute(
-            """
-            DELETE FROM market_snapshots WHERE market_id IN (
-                SELECT id FROM markets WHERE ticker = %s
-            )
-            """,
-            (_TEST_TICKER,),
-        )
-        cur.execute("DELETE FROM markets WHERE ticker = %s", (_TEST_TICKER,))
+        from tests.fixtures.cleanup_helpers import delete_market_with_children
+
+        delete_market_with_children(cur, "ticker = %s", (_TEST_TICKER,))
 
         # Create the underlying market (positions FK to markets.id).
         cur.execute(
@@ -169,8 +163,9 @@ def trailing_stop_open_position(db_pool: Any) -> Any:
     try:
         with get_cursor(commit=True) as cur:
             cur.execute("DELETE FROM positions WHERE position_id = %s", (position_bk,))
-            cur.execute("DELETE FROM market_snapshots WHERE market_id = %s", (market_pk,))
-            cur.execute("DELETE FROM markets WHERE id = %s", (market_pk,))
+            from tests.fixtures.cleanup_helpers import delete_market_with_children
+
+            delete_market_with_children(cur, "id = %s", (market_pk,))
     except Exception:
         pass
 

--- a/tests/performance/database/test_connection_performance.py
+++ b/tests/performance/database/test_connection_performance.py
@@ -120,7 +120,7 @@ class TestConnectionPerformance:
                     """
                     INSERT INTO venues (espn_venue_id, venue_name, city)
                     VALUES (%s, %s, %s)
-                    ON CONFLICT (espn_venue_id) DO NOTHING
+                    ON CONFLICT (espn_venue_id) WHERE row_current_ind = TRUE DO NOTHING
                     """,
                     (f"PERF-BATCH-{i:04d}", f"Venue {i}", "Test City"),
                 )

--- a/tests/property/test_database_crud_properties.py
+++ b/tests/property/test_database_crud_properties.py
@@ -1001,58 +1001,53 @@ def test_check_constraints_enforced(db_pool, clean_test_data, setup_kalshi_platf
     database=None,  # Disable Hypothesis example database to prevent stale state issues
 )
 @given(ticker=st.text(alphabet=st.characters(whitelist_categories=["Lu"]), min_size=5, max_size=20))
-def test_cascade_delete_integrity(db_pool, clean_test_data, ticker):
+def test_restrict_prevents_platform_delete_with_markets(db_pool, clean_test_data, ticker):
     """
-    PROPERTY: Deleting platform cascades to delete all related markets.
+    PROPERTY: Deleting a platform with dependent markets raises ForeignKeyViolation.
 
-    Validates:
-    - Foreign key CASCADE behavior works correctly
-    - Deleting platform removes all markets for that platform
-    - No orphan markets left after platform deletion
-    - Referential integrity maintained
+    Validates (post migration 0057):
+    - Foreign key RESTRICT behavior blocks orphaning children
+    - Deleting platform while markets reference it raises ForeignKeyViolation
+    - Dependent markets must be removed first; only then does platform delete succeed
+    - Referential integrity is preserved by refusing the delete, not by cascading
 
     Why This Matters:
-        Without CASCADE, deleting platforms would fail (due to foreign key constraint)
-        or leave orphan markets. CASCADE ensures referential integrity by automatically
-        removing dependent rows when parent is deleted.
+        Migration 0057 converted markets.platform_id -> platforms.platform_id from
+        ON DELETE CASCADE to ON DELETE RESTRICT (FK #34 in the 0057 conversion list).
+        Silent CASCADE of platform deletes was too dangerous: a misdirected admin
+        DELETE on a high-traffic platform would silently erase every market and all
+        downstream SCD history. RESTRICT forces the caller to delete children
+        explicitly, making the destruction visible and intentional.
 
     Educational Note:
-        PostgreSQL CASCADE behavior:
-        FOREIGN KEY (platform_id) REFERENCES platforms(platform_id) ON DELETE CASCADE
+        After migration 0057, the FK is declared:
+        FOREIGN KEY (platform_id) REFERENCES platforms(platform_id) ON DELETE RESTRICT
 
-        When you delete a platform:
-        1. PostgreSQL finds all markets referencing that platform
-        2. Automatically deletes those markets
-        3. Then deletes the platform
-        4. All in one atomic transaction
-
-        Without CASCADE (default RESTRICT):
         DELETE FROM platforms WHERE platform_id = 'kalshi'
-        ERROR: violates foreign key constraint "fk_markets_platform"
+        ERROR: update or delete on table "platforms" violates foreign key constraint
+               "markets_platform_id_fkey" on table "markets"
         DETAIL: Key (platform_id)=(kalshi) is still referenced from table "markets"
 
-        With CASCADE:
-        DELETE FROM platforms WHERE platform_id = 'kalshi'
-        -- Deletes platform AND all related markets automatically ✅
-
-    Example:
-        >>> create_market(platform_id="test-platform", ticker="MKT-1")
-        >>> create_market(platform_id="test-platform", ticker="MKT-2")
-        >>> delete_platform("test-platform")  # Triggers CASCADE
-        >>> markets = query(Market).filter(platform_id="test-platform").all()
-        >>> assert len(markets) == 0  # Both markets deleted automatically
+        Correct sequence now:
+        DELETE FROM markets WHERE platform_id = 'test-platform';   -- children first
+        DELETE FROM platforms WHERE platform_id = 'test-platform'; -- then parent
     """
     import uuid
 
+    import psycopg2
+
     from precog.database.connection import get_cursor
 
-    # Use UUID to ensure uniqueness across Hypothesis examples
+    # Use UUID to ensure uniqueness across Hypothesis examples.
+    # Prefixes must match the LIKE patterns in tests/conftest.py::clean_test_data
+    # so that any rows leaked across Hypothesis examples are cleaned up between
+    # test runs — especially important under RESTRICT, where CASCADE is no
+    # longer doing the janitorial work.
     unique_id = uuid.uuid4().hex[:8]
-    test_platform_id = f"PLAT-{unique_id}"
-
-    test_series_id = f"SER-{unique_id}"
-    test_event_id = f"EVT-{unique_id}"
-    test_ticker = f"TKR-{unique_id}"
+    test_platform_id = f"TEST-PLATFORM-{unique_id}"
+    test_series_id = f"TEST-SERIES-{unique_id}"
+    test_event_id = f"TEST-EVENT-{unique_id}"
+    test_ticker = f"TEST-{unique_id}"
 
     with get_cursor(commit=True) as cur:
         # Create test platform
@@ -1117,23 +1112,55 @@ def test_cascade_delete_integrity(db_pool, clean_test_data, ticker):
 
     assert count_before > 0, "Market should exist before platform deletion"
 
-    # Delete platform (should CASCADE delete to markets)
-    with get_cursor(commit=True) as cur:
-        cur.execute("DELETE FROM platforms WHERE platform_id = %s", (test_platform_id,))
+    # Attempting to delete the platform while a market still references it
+    # must raise ForeignKeyViolation (RESTRICT semantics from migration 0057).
+    with pytest.raises(psycopg2.errors.ForeignKeyViolation):
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM platforms WHERE platform_id = %s",
+                (test_platform_id,),
+            )
 
-    # Verify markets CASCADE deleted
+    # Platform and market must both still exist after the refused delete.
     with get_cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM platforms WHERE platform_id = %s",
+            (test_platform_id,),
+        )
+        platform_count = (cur.fetchone() or {}).get("count", 0)
         cur.execute(
             "SELECT COUNT(*) FROM markets WHERE platform_id = %s",
             (test_platform_id,),
         )
-        result = cur.fetchone()
-        count_after = result["count"] if result else 0
+        market_count = (cur.fetchone() or {}).get("count", 0)
 
-    assert count_after == 0, (
-        f"CASCADE delete failed: {count_before} markets before deletion, "
-        f"{count_after} after (expected 0)"
-    )
+    assert platform_count == 1, "RESTRICT should have preserved the platform row"
+    assert market_count == count_before, "RESTRICT should have preserved the market rows"
+
+    # Correct deletion sequence: children first, then parent. Use the shared
+    # helper from tests/fixtures/cleanup_helpers.py so that the full RESTRICT
+    # FK subtree (market_snapshots, position_exits, etc.) is torn down in the
+    # right order. Hand-rolling the sequence here would drift from the real
+    # schema as migrations add new child tables.
+    from tests.fixtures.cleanup_helpers import delete_platform_with_children
+
+    with get_cursor(commit=True) as cur:
+        delete_platform_with_children(cur, "platform_id = %s", (test_platform_id,))
+
+    with get_cursor() as cur:
+        cur.execute(
+            "SELECT COUNT(*) FROM platforms WHERE platform_id = %s",
+            (test_platform_id,),
+        )
+        platform_count_after = (cur.fetchone() or {}).get("count", 0)
+        cur.execute(
+            "SELECT COUNT(*) FROM markets WHERE platform_id = %s",
+            (test_platform_id,),
+        )
+        market_count_after = (cur.fetchone() or {}).get("count", 0)
+
+    assert platform_count_after == 0, "Platform should be gone once children are removed"
+    assert market_count_after == 0, "Markets should be gone once explicitly deleted"
 
 
 # TODO: Additional property tests to consider (future phases):

--- a/tests/property/test_database_crud_properties.py
+++ b/tests/property/test_database_crud_properties.py
@@ -113,7 +113,7 @@ def setup_kalshi_platform(db_pool, clean_test_data):
             """
             INSERT INTO series (series_id, platform_id, external_id, title, category)
             VALUES ('KXNFLGAME', 'kalshi', 'KXNFLGAME-EXT', 'NFL Game Series', 'sports')
-            ON CONFLICT (series_id) DO NOTHING
+            ON CONFLICT (series_id) WHERE row_current_ind = TRUE DO NOTHING
         """
         )
         # Get the series surrogate PK for event FK

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -120,7 +120,7 @@ def sample_series(db_pool, clean_test_data, sample_platform) -> str:
     query = """
         INSERT INTO series (series_id, platform_id, external_id, category, subcategory, title, frequency)
         VALUES ('NFL-2025', 'kalshi', 'NFL-2025-ext', 'sports', 'nfl', 'NFL 2025 Season', 'recurring')
-        ON CONFLICT (series_id) DO NOTHING
+        ON CONFLICT (series_id) WHERE row_current_ind = TRUE DO NOTHING
         RETURNING series_id
     """
     execute_query(query)


### PR DESCRIPTION
## Summary

- Converts 59 FK constraints from SET NULL/CASCADE to ON DELETE RESTRICT across the entire schema
- Adds SCD Type 2 columns (row_current_ind, row_start_ts, row_end_ts) to teams, venues, and series
- Drops 5 conflicting UNIQUE constraints/indexes that would block SCD versioning
- Adds 8 partial unique indexes (WHERE row_current_ind = TRUE) as replacements
- Adds 3 helper views: current_teams, current_venues, current_series
- Updates production CRUD + test fixtures to use RESTRICT-safe ON CONFLICT syntax and cleanup helpers

Schema Hardening Arc, Cohort C2. Epic #745.

## Migration 0057

### Part A: FK RESTRICT Conversion (59 FKs)
- 31 SET NULL FKs → RESTRICT (provenance chain: orders→strategies, trades→orders, etc.)
- 28 CASCADE FKs → RESTRICT (11 platform_id + 17 non-platform)
- Dynamic constraint name discovery via information_schema
- Pre-flight orphan check + NOT EXISTS cleanup before each conversion

### Part B: SCD Type 2 on dimension tables
- Added row_current_ind, row_start_ts, row_end_ts to teams, venues, series
- Dropped 5 conflicting constraints: uq_series_series_id, uq_series_platform_external, venues_espn_venue_id_key, idx_teams_code_league_pro, idx_teams_espn_id_league_unique
- Added 8 partial unique indexes on business keys (team_code+league, espn_venue_id, series_id, platform+external, espn_team_id+league)
- Added current_teams, current_venues, current_series helper views
- Backfilled row_start_ts from created_at

## Blast Radius Fixes

Dropping CASCADE FKs and UNIQUE constraints broke test infrastructure and CRUD code. All fixes included in this PR:

**ON CONFLICT clauses** (dropped UNIQUE constraints): 1 production + 8 test files updated to use `ON CONFLICT (...) WHERE row_current_ind = TRUE` syntax matching the new partial indexes.

**Test cleanup ordering** (CASCADE → RESTRICT): Added `tests/fixtures/cleanup_helpers.py` with RESTRICT-safe delete functions (delete_all_test_data, delete_market_with_children, delete_event_with_children, delete_venue_with_children, delete_platform_with_children). Updated 11+ test files to use the helper instead of raw DELETE statements that assumed CASCADE.

**Test fixture CHECK constraint** (migration 0039 rename): Test fixtures used `sport='nfl'` but the CHECK constraint was changed to accept sport NAMES (`'football'`) not league codes in migration 0039. Updated all test fixtures.

**Events schema** (migration 0020 rename): Test fixtures used `event_id` column but it was replaced by surrogate `id` PK in migration 0020. Updated.

## Agent Review Trail

| Agent | Role | Key Findings |
|-------|------|-------------|
| Holden (Steward) | Design scoping | Classified 47 FKs, caught 7 phantom FKs from dropped tables |
| Samwise (Builder) | Implementation | Caught teams business key is (team_code, league) not (team_code, sport) |
| Glokta (Reviewer) | Adversarial review | 3 BLOCKING: conflicting UNIQUE constraints would make SCD decorative. Fixed. |
| Ripley (QA) | Test coverage | Validated 93 test cases, fixture isolation, atomicity |
| User | Manual review | Caught idx_teams_espn_id_league_unique gap, missing series composite replacement, and market_internal_id/market_id naming drift (filed as #756) |

## Process Learnings (Session 48)

- **S72 created**: SCD Type 2 conversion requires exhaustive constraint audit (not just the ones the migration author listed)
- **C39 created**: Arc cohort completion reviews (post-build state audit)
- **S68/S60 hardened**: Now session-end hard gates with counter tracking in MEMORY.md
- **Pattern 41 +2 capabilities**: Attribution (#752) and Graceful Shutdown (#755) as 8th and 9th capabilities
- **S1 trigger updated**: Pair Mulder with Holden on schema-change tasks touching existing tables (caught naming drift)

## Follow-up Issues Filed

- #748 Attribution epic + #749-752 sub-issues
- #753 Exception propagation test for temporal_alignment_writer
- #755 Scheduler shutdown leaves stale rows
- #756 market_internal_id → market_id rename (Cohort C6)
- #757 Dynamic FK discovery refactor for cleanup helper (follow-up to this PR)

## Test plan

- [x] 93 new integration tests (59 FK parametrized + 34 SCD/behavioral)
- [x] All pre-push tiers green (unit + integration + e2e + stress + chaos + race)
- [x] Lint, format, mypy clean
- [x] 2,581 unit tests pass
- [x] Local verification of trailing stop integration tests (12/12 pass)

Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)