### PR TITLE
test: Retrofit 7 scheduler CLI test files onto factory-mock pattern (#764)

### DIFF
--- a/tests/chaos/cli/test_cli_chaos.py
+++ b/tests/chaos/cli/test_cli_chaos.py
@@ -26,60 +26,122 @@ def setup_commands():
 
 
 class TestSchedulerChaos:
-    """Chaos tests for scheduler CLI."""
+    """Chaos tests for scheduler CLI.
+
+    Mock Level Notes (#764):
+        ``status`` does not call ``create_supervisor``; it queries
+        the database via ``list_scheduler_services``. Chaos for
+        status must be injected into that database call.
+
+        ``poll-once`` does not call ``create_supervisor``; it
+        directly instantiates ``ESPNGamePoller`` and
+        ``KalshiMarketPoller`` from ``precog.schedulers``. Chaos for
+        poll-once must be injected into the poller's ``poll_once``
+        method.
+
+        The previous versions of these tests patched
+        ``ServiceSupervisor`` (a class the CLI never instantiates
+        on these code paths), so the chaos was never actually
+        injected -- the tests reported success on every call,
+        regardless of the random failure rate, because the CLI
+        ran its real (or fallback) path uninfluenced by the mock.
+    """
 
     def test_supervisor_random_failures(self, cli_runner) -> None:
-        """Test scheduler handles random supervisor failures.
+        """Test scheduler status handles random database-IPC failures.
 
-        Chaos: Random failures during 20 invocations.
+        Chaos: 30% random failure rate on the database-backed
+        status query across 20 invocations. Failures are caught
+        inside ``_show_db_backed_status`` (it has a try/except that
+        returns False on error and falls back to the in-process
+        path), so the CLI must complete with exit 0 on every call.
         """
+        from precog.cli import scheduler as scheduler_module
+
         call_count = [0]
 
         def random_failure(*args, **kwargs):
             call_count[0] += 1
             if random.random() < 0.3:  # 30% failure rate
-                raise Exception("Random supervisor failure")
-            return {"running": False, "pollers": []}
+                raise Exception("Random database failure")
+            return []  # No services in DB -> fall back to in-process
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.get_status.side_effect = random_failure
-            mock_supervisor.return_value = mock_instance
+        original_supervisor = scheduler_module._supervisor
+        scheduler_module._supervisor = None
+        try:
+            with patch(
+                "precog.database.crud_schedulers.list_scheduler_services",
+                side_effect=random_failure,
+            ):
+                successes = 0
+                for _ in range(20):
+                    result = cli_runner.invoke(app, ["scheduler", "status"])
+                    if result.exit_code == 0:
+                        successes += 1
 
-            successes = 0
-            for _ in range(20):
-                result = cli_runner.invoke(app, ["scheduler", "status"])
-                if result.exit_code in [0, 1, 2]:
-                    successes += 1
-
-            # Should handle failures gracefully
-            assert successes >= 10, f"Only {successes} successes out of 20"
+                # The CLI catches DB failures internally and falls
+                # back, so every call should exit cleanly.
+                assert successes == 20, (
+                    f"Only {successes}/20 status calls succeeded; expected 20. "
+                    f"Chaos was actually injected (call_count={call_count[0]})."
+                )
+                # Verify the chaos hook was actually exercised -- if
+                # the patch silently missed (the #764 anti-pattern),
+                # call_count would be zero.
+                assert call_count[0] == 20, (
+                    f"chaos hook was only called {call_count[0]} times; "
+                    "expected 20 (one per status invocation)"
+                )
+        finally:
+            scheduler_module._supervisor = original_supervisor
 
     def test_poll_with_intermittent_failures(self, cli_runner) -> None:
-        """Test poll-once with intermittent failures.
+        """Test poll-once with intermittent ESPN poller failures.
 
-        Chaos: Alternating success/failure pattern.
+        Chaos: Every 3rd ESPN poll raises. The CLI catches the
+        exception inside the ``try/except`` around ``poller.poll_once()``
+        and continues to the Kalshi poller, so the command always
+        exits cleanly. Verifies the CLI's per-poller error isolation.
         """
         call_count = [0]
 
         def alternating_result(*args, **kwargs):
             call_count[0] += 1
             if call_count[0] % 3 == 0:  # Every 3rd call fails
-                raise Exception("Intermittent failure")
-            return {"games": 5, "updated": 3}
+                raise Exception("Intermittent ESPN failure")
+            return {"items_fetched": 5, "items_updated": 3}
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.poll_once.side_effect = alternating_result
-            mock_supervisor.return_value = mock_instance
+        with (
+            patch("precog.schedulers.ESPNGamePoller") as mock_espn_cls,
+            patch("precog.schedulers.KalshiMarketPoller") as mock_kalshi_cls,
+        ):
+            mock_espn = MagicMock()
+            mock_espn.poll_once.side_effect = alternating_result
+            mock_espn_cls.return_value = mock_espn
+
+            mock_kalshi = MagicMock()
+            mock_kalshi.poll_once.return_value = {
+                "items_fetched": 1,
+                "items_updated": 1,
+                "items_created": 0,
+            }
+            mock_kalshi.kalshi_client = MagicMock()
+            mock_kalshi_cls.return_value = mock_kalshi
 
             results = []
             for _ in range(15):
-                result = cli_runner.invoke(app, ["scheduler", "poll-once", "--league", "nfl"])
+                result = cli_runner.invoke(app, ["scheduler", "poll-once", "--leagues", "nfl"])
                 results.append(result.exit_code)
 
-            # All should complete (success or graceful failure)
+            # All should complete cleanly -- the CLI catches
+            # per-poller exceptions and continues.
             assert len(results) == 15
+            assert all(code == 0 for code in results), f"unexpected non-zero exit codes: {results}"
+            # Verify the chaos hook actually fired.
+            assert call_count[0] == 15, (
+                f"chaos hook was only called {call_count[0]} times; "
+                "expected 15 (one per poll-once invocation)"
+            )
 
 
 class TestDbChaos:
@@ -267,16 +329,35 @@ class TestResourceExhaustion:
     def test_handles_memory_pressure(self, cli_runner) -> None:
         """Test CLI handles memory pressure scenarios.
 
-        Chaos: Large response data.
-        """
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            # Large status response
-            mock_instance.get_status.return_value = {
-                "running": True,
-                "pollers": [{"name": f"poller_{i}", "data": "x" * 1000} for i in range(100)],
-            }
-            mock_supervisor.return_value = mock_instance
+        Chaos: 100 fake services in the database-backed status
+        response. The CLI must render the table and exit cleanly.
 
+        See class docstring for why we patch
+        ``list_scheduler_services`` and not ``ServiceSupervisor``.
+        """
+        from datetime import UTC, datetime
+
+        large_service_list = [
+            {
+                "service_name": f"poller_{i}",
+                "host_id": "test-host",
+                "pid": 1000 + i,
+                "status": "running",
+                "started_at": datetime.now(UTC),
+                "last_heartbeat": datetime.now(UTC),
+                "error_message": None,
+                "stats": {"large_field": "x" * 1000},
+            }
+            for i in range(100)
+        ]
+
+        with patch(
+            "precog.database.crud_schedulers.list_scheduler_services",
+            return_value=large_service_list,
+        ) as mock_list:
             result = cli_runner.invoke(app, ["scheduler", "status"])
-            assert result.exit_code in [0, 1, 2]
+            assert result.exit_code == 0, (
+                f"status under memory pressure should exit 0; "
+                f"got {result.exit_code}: {result.output}"
+            )
+            mock_list.assert_called_once()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -935,6 +935,44 @@ def _cleanup_apscheduler_threads():
         )
 
 
+# =============================================================================
+# SCHEDULER CLI MODULE-GLOBAL CLEANUP (#764)
+# =============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_scheduler_cli_module_globals():
+    """
+    Reset precog.cli.scheduler module globals between tests.
+
+    The CLI's scheduler commands (start, stop, status, poll-once) store their
+    state in module-level globals: _supervisor, _espn_updater, _kalshi_poller.
+    A test that calls `scheduler start` and doesn't follow with `scheduler stop`
+    leaves the mocked supervisor/poller attached to the module, which then
+    leaks into the next test under the same process.
+
+    This fixture saves the pre-test state and restores it after. The retrofit
+    in #764 made the leak deterministic where it was previously probabilistic
+    (factory mocks reliably populate the global every time), so without this
+    fixture a `start`-only test would pollute every subsequent test that reads
+    those globals.
+
+    Scope: function (autouse) - runs after every test.
+    """
+    from precog.cli import scheduler as _scheduler_module
+
+    saved = {
+        "_supervisor": getattr(_scheduler_module, "_supervisor", None),
+        "_espn_updater": getattr(_scheduler_module, "_espn_updater", None),
+        "_kalshi_poller": getattr(_scheduler_module, "_kalshi_poller", None),
+    }
+
+    yield
+
+    for name, value in saved.items():
+        setattr(_scheduler_module, name, value)
+
+
 def pytest_configure(config):
     """
     Register custom markers and enforce test environment.

--- a/tests/integration/cli/test_cli_scheduler_integration.py
+++ b/tests/integration/cli/test_cli_scheduler_integration.py
@@ -6,6 +6,30 @@ using mocks only for external dependencies.
 References:
     - REQ-TEST-003: Integration testing with testcontainers
     - TESTING_STRATEGY V3.2: 8 test types required
+    - Issue #764: scheduler CLI factory-vs-class mock anti-pattern
+
+Mock Level Notes (#764):
+    The CLI's ``scheduler start`` supervised path calls the
+    ``create_supervisor`` factory function, not the
+    ``ServiceSupervisor`` class directly. The factory itself
+    constructs real Kalshi and ESPN pollers, rate limiters, and
+    circuit breakers before instantiating the supervisor. Patching
+    ``ServiceSupervisor`` the class is the wrong level of indirection
+    -- it leaves all of the real poller setup intact, which means
+    real network calls fire on every test. The factory is the
+    correct mock target.
+
+    For ``status``, the CLI does NOT call create_supervisor at all;
+    it calls ``_show_db_backed_status`` which queries the
+    ``scheduler_status`` table via
+    ``precog.database.crud_schedulers.list_scheduler_services``. To
+    keep ``status`` tests hermetic we patch
+    ``_show_db_backed_status`` directly.
+
+    For ``poll-once``, the CLI imports ``ESPNGamePoller`` and
+    ``KalshiMarketPoller`` from ``precog.schedulers`` at function-call
+    time and instantiates them directly -- it does not go through
+    ``create_supervisor``. We patch the package-level re-exports.
 
 Parallel Execution Note:
     These tests must create fresh app instances to avoid test pollution during
@@ -37,240 +61,397 @@ def isolated_app():
     return fresh_app
 
 
+def _make_supervised_mock_supervisor() -> MagicMock:
+    """Build a supervisor mock that behaves correctly in non-foreground mode."""
+    mock_supervisor = MagicMock()
+    mock_supervisor.is_running = True
+    mock_supervisor.start_all.return_value = None
+    mock_supervisor.stop_all.return_value = None
+    mock_supervisor.get_aggregate_metrics.return_value = {
+        "uptime_seconds": 0,
+        "services_healthy": 1,
+        "services_total": 1,
+        "total_restarts": 0,
+        "total_errors": 0,
+        "per_service": {},
+    }
+    return mock_supervisor
+
+
 class TestSchedulerStartIntegration:
-    """Integration tests for scheduler start command."""
+    """Integration tests for scheduler start command (supervised path)."""
 
     def test_start_scheduler_with_valid_config(self, isolated_app) -> None:
-        """Test starting scheduler with valid configuration.
-
-        Integration: Tests scheduler initialization with real config loading.
-        """
+        """Test starting scheduler with valid configuration via supervised path."""
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.start.return_value = True
-            mock_supervisor.return_value = mock_instance
-
-            result = runner.invoke(isolated_app, ["scheduler", "start", "--poller", "espn"])
-
-            # Integration: Verify CLI handles start command gracefully
-            assert result.exit_code in [0, 1, 2]
-
-    def test_start_scheduler_with_custom_interval(self, isolated_app) -> None:
-        """Test starting scheduler with custom poll interval.
-
-        Integration: Tests interval parameter propagation.
-        """
-        runner = CliRunner()
-
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.start.return_value = True
-            mock_supervisor.return_value = mock_instance
-
-            result = runner.invoke(isolated_app, ["scheduler", "start", "--interval", "30"])
-
-            assert result.exit_code in [0, 1, 2]
-
-    def test_start_multiple_pollers(self, isolated_app) -> None:
-        """Test starting scheduler with multiple pollers.
-
-        Integration: Tests multi-poller configuration.
-        """
-        runner = CliRunner()
-
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.start.return_value = True
-            mock_supervisor.return_value = mock_instance
+        with (
+            patch(
+                "precog.schedulers.service_supervisor.create_supervisor"
+            ) as mock_create_supervisor,
+            patch("precog.cli.scheduler._validate_startup", return_value=True),
+            patch("precog.cli.scheduler._prevent_system_sleep_for_supervised"),
+        ):
+            mock_create_supervisor.return_value = _make_supervised_mock_supervisor()
 
             result = runner.invoke(
-                isolated_app, ["scheduler", "start", "--poller", "espn", "--poller", "kalshi"]
+                isolated_app,
+                ["scheduler", "start", "--supervised", "--no-espn"],
             )
 
-            assert result.exit_code in [0, 1, 2]
+            assert result.exit_code == 0, (
+                f"start should exit 0; got {result.exit_code}: {result.output}"
+            )
+            mock_create_supervisor.assert_called_once()
+
+    def test_start_scheduler_with_custom_interval(self, isolated_app) -> None:
+        """Test starting scheduler with custom poll interval via supervised path.
+
+        Verifies the ``--kalshi-interval`` value propagates to the
+        ``create_supervisor`` factory as ``kalshi_poll_interval``.
+        """
+        runner = CliRunner()
+
+        with (
+            patch(
+                "precog.schedulers.service_supervisor.create_supervisor"
+            ) as mock_create_supervisor,
+            patch("precog.cli.scheduler._validate_startup", return_value=True),
+            patch("precog.cli.scheduler._prevent_system_sleep_for_supervised"),
+        ):
+            mock_create_supervisor.return_value = _make_supervised_mock_supervisor()
+
+            result = runner.invoke(
+                isolated_app,
+                [
+                    "scheduler",
+                    "start",
+                    "--supervised",
+                    "--no-espn",
+                    "--kalshi-interval",
+                    "30",
+                ],
+            )
+
+            assert result.exit_code == 0, (
+                f"start should exit 0; got {result.exit_code}: {result.output}"
+            )
+            mock_create_supervisor.assert_called_once()
+            call_kwargs = mock_create_supervisor.call_args.kwargs
+            assert call_kwargs.get("kalshi_poll_interval") == 30
+
+    def test_start_multiple_pollers(self, isolated_app) -> None:
+        """Test starting scheduler with multiple pollers (ESPN + Kalshi)."""
+        runner = CliRunner()
+
+        with (
+            patch(
+                "precog.schedulers.service_supervisor.create_supervisor"
+            ) as mock_create_supervisor,
+            patch("precog.cli.scheduler._validate_startup", return_value=True),
+            patch("precog.cli.scheduler._prevent_system_sleep_for_supervised"),
+        ):
+            mock_create_supervisor.return_value = _make_supervised_mock_supervisor()
+
+            result = runner.invoke(
+                isolated_app,
+                ["scheduler", "start", "--supervised"],
+            )
+
+            assert result.exit_code == 0, (
+                f"start should exit 0; got {result.exit_code}: {result.output}"
+            )
+            mock_create_supervisor.assert_called_once()
+            call_kwargs = mock_create_supervisor.call_args.kwargs
+            assert call_kwargs.get("enabled_services") == {"espn", "kalshi_rest"}
 
 
 class TestSchedulerStopIntegration:
-    """Integration tests for scheduler stop command."""
+    """Integration tests for scheduler stop command.
+
+    Note: ``scheduler stop`` accesses module-global references in
+    ``precog.cli.scheduler`` (``_supervisor``, ``_espn_updater``,
+    ``_kalshi_poller``). With no prior start, those are None and stop
+    is a no-op -- no real I/O. We don't need supervisor mocks here;
+    we test the no-op happy path behavior.
+    """
 
     def test_stop_running_scheduler(self, isolated_app) -> None:
-        """Test stopping a running scheduler.
+        """Test stopping a scheduler that has a supervisor in module state.
 
-        Integration: Tests scheduler shutdown sequence.
+        Pre-populates the module-global ``_supervisor`` so stop has
+        something to stop. Asserts the supervisor's ``stop_all`` was
+        called -- the actual contract of the stop command in
+        supervised mode.
         """
-        runner = CliRunner()
+        from precog.cli import scheduler as scheduler_module
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.stop.return_value = True
-            mock_instance.is_running.return_value = True
-            mock_supervisor.return_value = mock_instance
+        mock_supervisor = MagicMock()
+        mock_supervisor.is_running = True
+        mock_supervisor.stop_all.return_value = None
+        mock_supervisor.get_aggregate_metrics.return_value = {
+            "uptime_seconds": 5,
+            "total_restarts": 0,
+            "total_errors": 0,
+        }
 
+        original_supervisor = scheduler_module._supervisor
+        scheduler_module._supervisor = mock_supervisor
+        try:
+            runner = CliRunner()
             result = runner.invoke(isolated_app, ["scheduler", "stop"])
 
-            assert result.exit_code in [0, 1, 2]
+            assert result.exit_code == 0, (
+                f"stop should exit 0; got {result.exit_code}: {result.output}"
+            )
+            mock_supervisor.stop_all.assert_called_once()
+        finally:
+            scheduler_module._supervisor = original_supervisor
 
     def test_stop_not_running_scheduler(self, isolated_app) -> None:
         """Test stopping when scheduler is not running.
 
-        Integration: Tests graceful handling of stop on idle scheduler.
+        With all module globals None, stop is a no-op and prints
+        "No schedulers were running". Asserts exit code 0 and the
+        no-op message.
         """
-        runner = CliRunner()
+        from precog.cli import scheduler as scheduler_module
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.is_running.return_value = False
-            mock_supervisor.return_value = mock_instance
-
+        # Force all globals to None to ensure clean no-op state.
+        original_supervisor = scheduler_module._supervisor
+        original_espn = scheduler_module._espn_updater
+        original_kalshi = scheduler_module._kalshi_poller
+        scheduler_module._supervisor = None
+        scheduler_module._espn_updater = None
+        scheduler_module._kalshi_poller = None
+        try:
+            runner = CliRunner()
             result = runner.invoke(isolated_app, ["scheduler", "stop"])
 
-            assert result.exit_code in [0, 1, 2]
+            assert result.exit_code == 0, (
+                f"stop should exit 0; got {result.exit_code}: {result.output}"
+            )
+            assert "No schedulers were running" in result.output
+        finally:
+            scheduler_module._supervisor = original_supervisor
+            scheduler_module._espn_updater = original_espn
+            scheduler_module._kalshi_poller = original_kalshi
 
 
 class TestSchedulerStatusIntegration:
-    """Integration tests for scheduler status command."""
+    """Integration tests for scheduler status command.
+
+    The ``status`` command does NOT call ``create_supervisor``. It
+    calls ``_show_db_backed_status`` which queries
+    ``list_scheduler_services``. We patch
+    ``_show_db_backed_status`` directly so the test is hermetic.
+    """
 
     def test_status_with_running_scheduler(self, isolated_app) -> None:
-        """Test status when scheduler is running.
-
-        Integration: Tests status retrieval with active pollers.
-        """
+        """Test status when database reports a running scheduler service."""
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.is_running.return_value = True
-            mock_instance.get_status.return_value = {
-                "running": True,
-                "pollers": [{"name": "espn", "status": "running", "interval": 15}],
-            }
-            mock_supervisor.return_value = mock_instance
-
+        with patch("precog.cli.scheduler._show_db_backed_status", return_value=True) as mock_status:
             result = runner.invoke(isolated_app, ["scheduler", "status"])
 
-            # Integration: Verify status command completes
-            assert result.exit_code in [0, 1, 2]
+            assert result.exit_code == 0, (
+                f"status should exit 0; got {result.exit_code}: {result.output}"
+            )
+            mock_status.assert_called_once()
 
-    def test_status_output_formats(self, isolated_app) -> None:
-        """Test status output in different formats.
+    def test_status_falls_back_to_in_process(self, isolated_app) -> None:
+        """Test status falls back to in-process check when DB has no entries.
 
-        Integration: Tests format rendering.
+        Replaces the original ``test_status_output_formats`` test, which
+        was passing ``--format`` -- a flag the status command does not
+        accept. The original test exercised only the Typer parser
+        rejecting an unknown option, with mocks that never ran.
         """
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.get_status.return_value = {"running": False, "pollers": []}
-            mock_supervisor.return_value = mock_instance
+        with patch(
+            "precog.cli.scheduler._show_db_backed_status", return_value=False
+        ) as mock_status:
+            result = runner.invoke(isolated_app, ["scheduler", "status"])
 
-            for fmt in ["json", "table"]:
-                result = runner.invoke(isolated_app, ["scheduler", "status", "--format", fmt])
-                assert result.exit_code in [0, 1, 2]
+            assert result.exit_code == 0, (
+                f"status should exit 0; got {result.exit_code}: {result.output}"
+            )
+            mock_status.assert_called_once()
 
 
 class TestSchedulerPollOnceIntegration:
-    """Integration tests for scheduler poll-once command."""
+    """Integration tests for scheduler poll-once command.
+
+    poll-once instantiates ``ESPNGamePoller`` and
+    ``KalshiMarketPoller`` directly -- it does not use the supervisor
+    factory. Patch them at the package re-export path so the
+    function-scoped imports inside ``poll_once`` pick up the mocks.
+    """
 
     def test_poll_once_nfl(self, isolated_app) -> None:
-        """Test single poll for NFL games.
-
-        Integration: Tests one-shot poll execution.
-        """
+        """Test single poll for NFL games."""
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.poll_once.return_value = {"games": 5, "updated": 3}
-            mock_supervisor.return_value = mock_instance
+        with (
+            patch("precog.schedulers.ESPNGamePoller") as mock_espn_cls,
+            patch("precog.schedulers.KalshiMarketPoller") as mock_kalshi_cls,
+        ):
+            mock_espn = MagicMock()
+            mock_espn.poll_once.return_value = {
+                "items_fetched": 5,
+                "items_updated": 3,
+            }
+            mock_espn_cls.return_value = mock_espn
 
-            result = runner.invoke(isolated_app, ["scheduler", "poll-once", "--league", "nfl"])
-
-            assert result.exit_code in [0, 1, 2]
-
-    def test_poll_once_with_save(self, isolated_app) -> None:
-        """Test poll-once with database save.
-
-        Integration: Tests database persistence flag.
-        """
-        runner = CliRunner()
-
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.poll_once.return_value = {"games": 3, "saved": 3}
-            mock_supervisor.return_value = mock_instance
+            mock_kalshi = MagicMock()
+            mock_kalshi.poll_once.return_value = {
+                "items_fetched": 10,
+                "items_updated": 8,
+                "items_created": 2,
+            }
+            mock_kalshi.kalshi_client = MagicMock()
+            mock_kalshi_cls.return_value = mock_kalshi
 
             result = runner.invoke(
-                isolated_app, ["scheduler", "poll-once", "--league", "nfl", "--save"]
+                isolated_app,
+                ["scheduler", "poll-once", "--leagues", "nfl"],
             )
 
-            assert result.exit_code in [0, 1, 2]
+            assert result.exit_code == 0, (
+                f"poll-once should exit 0; got {result.exit_code}: {result.output}"
+            )
+            mock_espn.poll_once.assert_called_once()
+            mock_kalshi.poll_once.assert_called_once()
+
+    def test_poll_once_espn_only(self, isolated_app) -> None:
+        """Test single poll for ESPN only (no Kalshi).
+
+        Replaces the original ``test_poll_once_with_save`` test, which
+        passed a ``--save`` flag the command does not accept.
+        """
+        runner = CliRunner()
+
+        with (
+            patch("precog.schedulers.ESPNGamePoller") as mock_espn_cls,
+            patch("precog.schedulers.KalshiMarketPoller") as mock_kalshi_cls,
+        ):
+            mock_espn = MagicMock()
+            mock_espn.poll_once.return_value = {
+                "items_fetched": 3,
+                "items_updated": 3,
+            }
+            mock_espn_cls.return_value = mock_espn
+
+            result = runner.invoke(
+                isolated_app,
+                ["scheduler", "poll-once", "--leagues", "nfl", "--no-kalshi"],
+            )
+
+            assert result.exit_code == 0, (
+                f"poll-once should exit 0; got {result.exit_code}: {result.output}"
+            )
+            mock_espn.poll_once.assert_called_once()
+            mock_kalshi_cls.assert_not_called()
 
     def test_poll_once_multiple_leagues(self, isolated_app) -> None:
-        """Test poll-once for multiple leagues.
-
-        Integration: Tests multi-league poll execution.
-        """
+        """Test poll-once for multiple leagues (single comma-separated arg)."""
         runner = CliRunner()
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.poll_once.return_value = {"games": 10, "updated": 8}
-            mock_supervisor.return_value = mock_instance
+        with (
+            patch("precog.schedulers.ESPNGamePoller") as mock_espn_cls,
+            patch("precog.schedulers.KalshiMarketPoller") as mock_kalshi_cls,
+        ):
+            mock_espn = MagicMock()
+            mock_espn.poll_once.return_value = {
+                "items_fetched": 10,
+                "items_updated": 8,
+            }
+            mock_espn_cls.return_value = mock_espn
+
+            mock_kalshi = MagicMock()
+            mock_kalshi.poll_once.return_value = {
+                "items_fetched": 20,
+                "items_updated": 12,
+                "items_created": 3,
+            }
+            mock_kalshi.kalshi_client = MagicMock()
+            mock_kalshi_cls.return_value = mock_kalshi
 
             result = runner.invoke(
-                isolated_app, ["scheduler", "poll-once", "--league", "nfl", "--league", "nba"]
+                isolated_app,
+                ["scheduler", "poll-once", "--leagues", "nfl,nba"],
             )
 
-            assert result.exit_code in [0, 1, 2]
+            assert result.exit_code == 0, (
+                f"poll-once should exit 0; got {result.exit_code}: {result.output}"
+            )
+            # ESPNGamePoller should be constructed with both leagues
+            call_kwargs = mock_espn_cls.call_args.kwargs
+            assert call_kwargs.get("leagues") == ["nfl", "nba"]
 
 
 class TestSchedulerConfigIntegration:
     """Integration tests for scheduler configuration handling."""
 
-    def test_scheduler_respects_config_file(self, isolated_app) -> None:
-        """Test scheduler uses configuration file settings.
+    def test_scheduler_respects_supervised_path(self, isolated_app) -> None:
+        """Test the supervised path runs end-to-end via the factory.
 
-        Integration: Tests config loader integration.
-        Uses --supervised so the mocked ServiceSupervisor is actually used
-        (non-supervised mode creates real pollers that make API calls).
+        Replaces the original ``test_scheduler_respects_config_file``,
+        which patched ``ServiceSupervisor`` (wrong level) AND
+        ``ConfigLoader`` at a path that the CLI never imports. The
+        original test was exercising only the Typer parser; the
+        mocks were never reached.
         """
         runner = CliRunner()
 
         with (
-            patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor,
-            patch("precog.config.config_loader.ConfigLoader") as mock_config,
+            patch(
+                "precog.schedulers.service_supervisor.create_supervisor"
+            ) as mock_create_supervisor,
+            patch("precog.cli.scheduler._validate_startup", return_value=True),
+            patch("precog.cli.scheduler._prevent_system_sleep_for_supervised"),
         ):
-            mock_config_instance = MagicMock()
-            mock_config_instance.get.return_value = {"poll_interval": 30}
-            mock_config.return_value = mock_config_instance
-
-            mock_instance = MagicMock()
-            mock_supervisor.return_value = mock_instance
+            mock_create_supervisor.return_value = _make_supervised_mock_supervisor()
 
             result = runner.invoke(
-                isolated_app, ["scheduler", "start", "--supervised", "--no-foreground"]
+                isolated_app,
+                ["scheduler", "start", "--supervised"],
             )
 
-            assert result.exit_code in [0, 1, 2]
+            assert result.exit_code == 0, (
+                f"start should exit 0; got {result.exit_code}: {result.output}"
+            )
+            mock_create_supervisor.assert_called_once()
 
     def test_scheduler_environment_override(self, isolated_app) -> None:
         """Test scheduler with environment variable overrides.
 
-        Integration: Tests env var precedence.
+        Sets ``PRECOG_POLL_INTERVAL=45`` and verifies the supervised
+        start still completes cleanly. The CLI does not currently
+        consume this env var (it would have to thread through Typer
+        defaults), but we keep the test as a regression guard for
+        any future env-var integration that should not break the
+        supervised path.
         """
         runner = CliRunner()
 
         with (
-            patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor,
+            patch(
+                "precog.schedulers.service_supervisor.create_supervisor"
+            ) as mock_create_supervisor,
+            patch("precog.cli.scheduler._validate_startup", return_value=True),
+            patch("precog.cli.scheduler._prevent_system_sleep_for_supervised"),
             patch.dict("os.environ", {"PRECOG_POLL_INTERVAL": "45"}),
         ):
-            mock_instance = MagicMock()
-            mock_supervisor.return_value = mock_instance
+            mock_create_supervisor.return_value = _make_supervised_mock_supervisor()
 
             result = runner.invoke(
-                isolated_app, ["scheduler", "start", "--supervised", "--no-foreground"]
+                isolated_app,
+                ["scheduler", "start", "--supervised"],
             )
 
-            assert result.exit_code in [0, 1, 2]
+            assert result.exit_code == 0, (
+                f"start should exit 0; got {result.exit_code}: {result.output}"
+            )
+            mock_create_supervisor.assert_called_once()

--- a/tests/performance/cli/test_cli_performance.py
+++ b/tests/performance/cli/test_cli_performance.py
@@ -37,48 +37,90 @@ def isolated_app():
 
 
 class TestSchedulerPerformance:
-    """Performance tests for scheduler CLI."""
+    """Performance tests for scheduler CLI.
+
+    Mock Level Notes (#764):
+        These tests measure CLI dispatch + status/poll-once orchestration
+        latency, not real network or database latency. The mocks
+        return immediately so latency reflects only CLI framework
+        overhead and the precog code paths above the mocked layer.
+
+        ``status`` patches ``_show_db_backed_status`` (the actual
+        path the CLI uses), and ``poll-once`` patches the
+        ``ESPNGamePoller``/``KalshiMarketPoller`` package re-exports
+        (the actual classes the CLI instantiates). The previous
+        version patched ``ServiceSupervisor`` -- a class neither
+        command instantiates -- which meant the mocks were no-ops
+        and the latency numbers were measuring real database
+        access on the ``status`` test.
+    """
 
     def test_status_latency(self, cli_runner, isolated_app) -> None:
-        """Test scheduler status command latency.
+        """Test scheduler status command CLI dispatch latency.
 
-        Performance: p95 should be < 100ms.
+        Performance: p95 should be < 500ms with the database-backed
+        status path mocked. This measures CLI framework overhead +
+        the precog code in ``_show_db_backed_status``'s caller, not
+        real database latency.
         """
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.get_status.return_value = {"running": False, "pollers": []}
-            mock_supervisor.return_value = mock_instance
-
+        with patch("precog.cli.scheduler._show_db_backed_status", return_value=True) as mock_status:
             latencies = []
             for _ in range(20):
                 start = time.perf_counter()
                 result = cli_runner.invoke(isolated_app, ["scheduler", "status"])
                 elapsed = (time.perf_counter() - start) * 1000  # ms
                 latencies.append(elapsed)
-                assert result.exit_code in [0, 1, 2]
+                assert result.exit_code == 0, (
+                    f"status should exit 0; got {result.exit_code}: {result.output}"
+                )
 
+            assert mock_status.call_count == 20, (
+                f"_show_db_backed_status called {mock_status.call_count} times; expected 20"
+            )
             p95 = sorted(latencies)[int(len(latencies) * 0.95)]
             # CLI operations should be fast
             assert p95 < 500, f"p95 latency {p95}ms exceeds threshold"
 
     def test_poll_once_throughput(self, cli_runner, isolated_app) -> None:
-        """Test poll-once command throughput.
+        """Test poll-once command throughput with poller calls mocked.
 
-        Performance: Should handle 10 calls in < 5 seconds.
+        Performance: Should handle 10 calls in < 5 seconds. Measures
+        CLI dispatch + poll_once orchestration overhead, not real
+        API latency.
         """
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.poll_once.return_value = {"games": 5, "updated": 3}
-            mock_supervisor.return_value = mock_instance
+        with (
+            patch("precog.schedulers.ESPNGamePoller") as mock_espn_cls,
+            patch("precog.schedulers.KalshiMarketPoller") as mock_kalshi_cls,
+        ):
+            mock_espn = MagicMock()
+            mock_espn.poll_once.return_value = {
+                "items_fetched": 5,
+                "items_updated": 3,
+            }
+            mock_espn_cls.return_value = mock_espn
+
+            mock_kalshi = MagicMock()
+            mock_kalshi.poll_once.return_value = {
+                "items_fetched": 5,
+                "items_updated": 3,
+                "items_created": 1,
+            }
+            mock_kalshi.kalshi_client = MagicMock()
+            mock_kalshi_cls.return_value = mock_kalshi
 
             start = time.perf_counter()
             for _ in range(10):
                 result = cli_runner.invoke(
-                    isolated_app, ["scheduler", "poll-once", "--league", "nfl"]
+                    isolated_app, ["scheduler", "poll-once", "--leagues", "nfl"]
                 )
-                assert result.exit_code in [0, 1, 2]
+                assert result.exit_code == 0, (
+                    f"poll-once should exit 0; got {result.exit_code}: {result.output}"
+                )
             elapsed = time.perf_counter() - start
 
+            assert mock_espn.poll_once.call_count == 10, (
+                f"ESPN poll_once called {mock_espn.poll_once.call_count} times; expected 10"
+            )
             assert elapsed < 5.0, f"10 poll-once calls took {elapsed:.2f}s"
 
 
@@ -222,13 +264,17 @@ class TestCommandThroughput:
 
         Performance: Should handle 50 mixed commands in < 10 seconds.
 
-        Note: The status command calls both test_connection() AND get_cursor(),
-        so both must be mocked to prevent real database access during tests.
+        Note: The DB status command calls both test_connection() AND
+        get_cursor(); the scheduler status command calls
+        ``_show_db_backed_status``. Both must be mocked at the
+        actual call site to prevent real network/database access.
         """
         with (
             patch("precog.database.connection.test_connection") as mock_test,
             patch("precog.database.connection.get_cursor") as mock_cursor_ctx,
-            patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor,
+            patch(
+                "precog.cli.scheduler._show_db_backed_status", return_value=True
+            ) as mock_sched_status,
         ):
             mock_test.return_value = True
             mock_cur = MagicMock()
@@ -243,9 +289,6 @@ class TestCommandThroughput:
             mock_cur.fetchall.return_value = []
             mock_cursor_ctx.return_value.__enter__ = MagicMock(return_value=mock_cur)
             mock_cursor_ctx.return_value.__exit__ = MagicMock(return_value=False)
-            mock_instance = MagicMock()
-            mock_instance.get_status.return_value = {"running": False, "pollers": []}
-            mock_supervisor.return_value = mock_instance
 
             commands = [
                 ["system", "version"],
@@ -254,13 +297,27 @@ class TestCommandThroughput:
                 ["scheduler", "status"],
             ]
 
+            # Scheduler is the #764 in-scope command and is held to
+            # strict exit 0. Other commands have their own
+            # "missing critical tables -> exit 1" behavior under
+            # partial mocks; out of scope for this retrofit.
             start = time.perf_counter()
             for i in range(50):
                 cmd = commands[i % len(commands)]
                 result = cli_runner.invoke(isolated_app, cmd)
-                assert result.exit_code in [0, 1, 2]
+                if cmd[0] == "scheduler":
+                    assert result.exit_code == 0, (
+                        f"{cmd} should exit 0; got {result.exit_code}: {result.output}"
+                    )
+                else:
+                    assert result.exit_code in [0, 1, 2]
             elapsed = time.perf_counter() - start
 
+            # 50 / 4 commands -> 12-13 scheduler status invocations
+            assert mock_sched_status.call_count >= 12, (
+                f"scheduler status mock was only called "
+                f"{mock_sched_status.call_count} times; expected at least 12"
+            )
             throughput = 50 / elapsed
             # Relaxed threshold for CI/slow systems
             assert throughput > 3, f"Throughput {throughput:.2f} ops/s is too low"

--- a/tests/property/cli/test_cli_scheduler_properties.py
+++ b/tests/property/cli/test_cli_scheduler_properties.py
@@ -3,7 +3,21 @@
 Tests command-line argument parsing invariants and output format consistency
 using Hypothesis to generate edge cases.
 
-Reference: TESTING_STRATEGY V3.2 - Property Tests (2/8)
+Reference:
+    - TESTING_STRATEGY V3.2 - Property Tests (2/8)
+    - Issue #764 - scheduler CLI factory-vs-class mock anti-pattern
+
+Mock Level Notes (#764):
+    Tests that exercise the scheduler ``start`` command MUST patch
+    ``create_supervisor`` (the factory the CLI actually calls) with
+    ``_validate_startup`` also patched, and they MUST pass
+    ``--supervised``. Otherwise the CLI takes the non-supervised
+    path that instantiates real Kalshi/ESPN pollers.
+
+    Tests that exercise ``status`` patch
+    ``_show_db_backed_status`` because the status command does NOT
+    go through ``create_supervisor`` -- it queries the database via
+    ``list_scheduler_services``.
 """
 
 from unittest.mock import MagicMock, patch
@@ -30,59 +44,153 @@ def get_fresh_cli():
     return fresh_app, runner
 
 
+def _make_supervised_mock() -> MagicMock:
+    """Build a supervisor mock for non-foreground supervised start tests."""
+    mock_supervisor = MagicMock()
+    mock_supervisor.is_running = True
+    mock_supervisor.start_all.return_value = None
+    mock_supervisor.stop_all.return_value = None
+    mock_supervisor.get_aggregate_metrics.return_value = {
+        "uptime_seconds": 0,
+        "services_healthy": 1,
+        "services_total": 1,
+        "total_restarts": 0,
+        "total_errors": 0,
+        "per_service": {},
+    }
+    return mock_supervisor
+
+
 class TestSchedulerArgumentInvariants:
     """Property tests for scheduler command argument validation."""
 
-    @given(st.text(min_size=1, max_size=50))
-    @settings(max_examples=50)
-    def test_scheduler_name_handling(self, name: str):
-        """Scheduler commands should handle arbitrary string names gracefully."""
-        # Skip control characters which can break terminal output
-        assume(all(ord(c) >= 32 for c in name))
-        assume(name.strip())  # Skip whitespace-only names
+    @given(st.text(min_size=1, max_size=20, alphabet="abcdefghijklmnopqrstuvwxyz,"))
+    @settings(max_examples=50, deadline=None)
+    def test_leagues_string_handling(self, leagues: str):
+        """The scheduler start --leagues option should accept any
+        comma-separated lowercase ASCII string without crashing the
+        supervised path.
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.get_scheduler_status.return_value = {}
-            mock_supervisor.return_value = mock_instance
+        Replaces the original ``test_scheduler_name_handling`` test,
+        which used ``status --name <text>`` -- ``status`` does not
+        accept ``--name``, so the original test was exercising only
+        the Typer parser's "no such option" rejection. The mocks
+        never ran. We now exercise an option the CLI actually
+        accepts and verify the supervised path completes cleanly.
+        """
+        assume(leagues.strip(","))  # at least one non-comma char
 
-            app, runner = get_fresh_cli()
-            result = runner.invoke(app, ["scheduler", "status", "--name", name])
-            # Command should complete without crashing
-            assert result.exit_code in [0, 1, 2]
-
-    @given(st.integers())
-    @settings(max_examples=50)
-    def test_poll_interval_integer_handling(self, interval: int):
-        """Poll-once should handle any integer interval argument."""
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.poll_once.return_value = {"success": True}
-            mock_supervisor.return_value = mock_instance
+        with (
+            patch(
+                "precog.schedulers.service_supervisor.create_supervisor"
+            ) as mock_create_supervisor,
+            patch("precog.cli.scheduler._validate_startup", return_value=True),
+            patch("precog.cli.scheduler._prevent_system_sleep_for_supervised"),
+        ):
+            mock_create_supervisor.return_value = _make_supervised_mock()
 
             app, runner = get_fresh_cli()
-            # Pass interval as string (CLI receives strings)
             result = runner.invoke(
-                app, ["scheduler", "poll-once", "--poll-interval", str(interval)]
+                app,
+                [
+                    "scheduler",
+                    "start",
+                    "--supervised",
+                    "--no-kalshi",
+                    "--leagues",
+                    leagues,
+                ],
             )
-            # Command should complete (may fail validation but not crash)
-            assert result.exit_code in [0, 1, 2]
+
+            assert result.exit_code == 0, (
+                f"supervised start should exit 0 for leagues={leagues!r}; "
+                f"got {result.exit_code}: {result.output}"
+            )
+            mock_create_supervisor.assert_called_once()
+
+    @given(st.integers(min_value=1, max_value=10000))
+    @settings(max_examples=50, deadline=None)
+    def test_kalshi_interval_integer_handling(self, interval: int):
+        """The scheduler start --kalshi-interval option should accept
+        any positive integer and propagate it to the factory.
+
+        Replaces the original ``test_poll_interval_integer_handling``
+        test, which passed ``poll-once --poll-interval`` -- a flag
+        ``poll-once`` does not accept. The original was a Typer
+        rejection test in disguise.
+        """
+        with (
+            patch(
+                "precog.schedulers.service_supervisor.create_supervisor"
+            ) as mock_create_supervisor,
+            patch("precog.cli.scheduler._validate_startup", return_value=True),
+            patch("precog.cli.scheduler._prevent_system_sleep_for_supervised"),
+        ):
+            mock_create_supervisor.return_value = _make_supervised_mock()
+
+            app, runner = get_fresh_cli()
+            result = runner.invoke(
+                app,
+                [
+                    "scheduler",
+                    "start",
+                    "--supervised",
+                    "--no-espn",
+                    "--kalshi-interval",
+                    str(interval),
+                ],
+            )
+
+            assert result.exit_code == 0, (
+                f"supervised start should exit 0 for interval={interval}; "
+                f"got {result.exit_code}: {result.output}"
+            )
+            mock_create_supervisor.assert_called_once()
+            call_kwargs = mock_create_supervisor.call_args.kwargs
+            assert call_kwargs.get("kalshi_poll_interval") == interval
 
     @given(st.floats(allow_nan=False, allow_infinity=False))
-    @settings(max_examples=50)
-    def test_poll_interval_float_rejection(self, interval: float):
-        """Poll-once should handle float interval arguments."""
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.poll_once.return_value = {"success": True}
-            mock_supervisor.return_value = mock_instance
+    @settings(max_examples=50, deadline=None)
+    def test_kalshi_interval_float_rejection(self, interval: float):
+        """The scheduler start --kalshi-interval option should reject
+        non-integer values with Typer's bad-usage exit code 2.
+
+        Replaces the original ``test_poll_interval_float_rejection``
+        test, which used a non-existent ``--poll-interval`` option.
+        Property tested: invalid integer input -> Typer exit 2 -> the
+        factory is never called.
+        """
+        with patch(
+            "precog.schedulers.service_supervisor.create_supervisor"
+        ) as mock_create_supervisor:
+            mock_create_supervisor.return_value = _make_supervised_mock()
 
             app, runner = get_fresh_cli()
             result = runner.invoke(
-                app, ["scheduler", "poll-once", "--poll-interval", str(interval)]
+                app,
+                [
+                    "scheduler",
+                    "start",
+                    "--supervised",
+                    "--kalshi-interval",
+                    str(interval),
+                ],
             )
-            # Typer may convert or reject floats - either is valid behavior
-            assert result.exit_code in [0, 1, 2]
+
+            # Typer's int parser calls int(value_str) which raises for every
+            # str(float) representation — including "0.0", "1e+300", and plain
+            # integer-valued floats like "1.0". Every finite float should
+            # therefore produce exit code 2 with the factory never called.
+            #
+            # If this assertion ever fires, it means Typer's parser changed or
+            # a new Hypothesis strategy is producing values that bypass the
+            # int() rejection — a legitimate assumption decay the property
+            # test should surface, not silently paper over.
+            assert result.exit_code == 2, (
+                f"expected Typer exit 2 (bad int parse) for interval={interval!r}, "
+                f"got {result.exit_code}: {result.output}"
+            )
+            mock_create_supervisor.assert_not_called()
 
 
 class TestSchedulerOutputInvariants:
@@ -112,34 +220,75 @@ class TestSchedulerOutputInvariants:
 class TestSchedulerStateTransitions:
     """Property tests for scheduler state handling."""
 
-    @given(st.lists(st.sampled_from(["start", "stop"]), min_size=1, max_size=5))
-    @settings(max_examples=20, deadline=None)  # CLI invocations can exceed 200ms deadline
+    @given(st.lists(st.sampled_from(["status", "stop"]), min_size=1, max_size=5))
+    @settings(max_examples=20, deadline=None)
     def test_command_sequence_stability(self, commands: list):
-        """Any sequence of start/stop commands should not crash."""
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.start_scheduler.return_value = True
-            mock_instance.stop_scheduler.return_value = True
-            mock_supervisor.return_value = mock_instance
+        """Any sequence of status/stop commands should not crash.
 
-            app, runner = get_fresh_cli()
-            for cmd in commands:
-                result = runner.invoke(app, ["scheduler", cmd, "--name", "test"])
-                # Each command should complete without crashing
-                assert result.exit_code in [0, 1, 2]
+        Replaces the original ``test_command_sequence_stability``
+        which alternated start/stop with a non-existent ``--name``
+        flag (Typer rejected each call with exit 2). We now sequence
+        status and stop -- both no-op-friendly commands -- and
+        require strict exit 0 with the underlying paths mocked.
+
+        ``start`` is excluded from the sequence because each
+        successful start would mutate module-global state in
+        ``precog.cli.scheduler`` and pollute subsequent calls; that
+        is a real coupling but is not what this property test is
+        meant to exercise.
+        """
+        from precog.cli import scheduler as scheduler_module
+
+        # Snapshot and clear module globals so stop is a clean no-op.
+        original_supervisor = scheduler_module._supervisor
+        original_espn = scheduler_module._espn_updater
+        original_kalshi = scheduler_module._kalshi_poller
+        scheduler_module._supervisor = None
+        scheduler_module._espn_updater = None
+        scheduler_module._kalshi_poller = None
+        try:
+            with patch("precog.cli.scheduler._show_db_backed_status", return_value=False):
+                app, runner = get_fresh_cli()
+                for cmd in commands:
+                    result = runner.invoke(app, ["scheduler", cmd])
+                    assert result.exit_code == 0, (
+                        f"{cmd} should exit 0; got {result.exit_code}: {result.output}"
+                    )
+        finally:
+            scheduler_module._supervisor = original_supervisor
+            scheduler_module._espn_updater = original_espn
+            scheduler_module._kalshi_poller = original_kalshi
 
     @given(st.integers(min_value=0, max_value=100))
-    @settings(max_examples=20)
-    def test_status_with_varying_scheduler_counts(self, count: int):
-        """Status should handle any number of schedulers."""
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            # Generate mock scheduler status
-            mock_instance.get_scheduler_status.return_value = {
-                f"scheduler_{i}": {"running": i % 2 == 0} for i in range(count)
-            }
-            mock_supervisor.return_value = mock_instance
+    @settings(max_examples=20, deadline=None)
+    def test_status_with_varying_db_results(self, found_in_db: int):
+        """Status should handle the database-backed path returning
+        either success or fall-through for any iteration count.
 
-            app, runner = get_fresh_cli()
-            result = runner.invoke(app, ["scheduler", "status"])
-            assert result.exit_code in [0, 1, 2]
+        Replaces the original ``test_status_with_varying_scheduler_counts``
+        which built a mock dictionary of N schedulers but patched
+        ``ServiceSupervisor`` -- which the status command never
+        instantiates. The original test exercised only the empty
+        in-process fallback path, regardless of N. We now use N as
+        an iteration count and verify the patched
+        ``_show_db_backed_status`` invariant holds across calls.
+        """
+        from precog.cli import scheduler as scheduler_module
+
+        original_supervisor = scheduler_module._supervisor
+        scheduler_module._supervisor = None
+        try:
+            # Even N: DB path "found", odd N: fallback path
+            db_returns = found_in_db % 2 == 0
+            with patch(
+                "precog.cli.scheduler._show_db_backed_status",
+                return_value=db_returns,
+            ) as mock_status:
+                app, runner = get_fresh_cli()
+                result = runner.invoke(app, ["scheduler", "status"])
+                assert result.exit_code == 0, (
+                    f"status should exit 0; got {result.exit_code}: {result.output}"
+                )
+                mock_status.assert_called_once()
+        finally:
+            scheduler_module._supervisor = original_supervisor

--- a/tests/race/cli/test_cli_race.py
+++ b/tests/race/cli/test_cli_race.py
@@ -63,16 +63,23 @@ class TestSchedulerRace:
     def test_rapid_sequential_status_checks(self, isolated_app) -> None:
         """Test rapid sequential status check invocations.
 
-        Race: Tests 10 rapid status calls in sequence.
+        Race: Tests 10 rapid status calls in sequence. Verifies the
+        status command's module-global access (``_supervisor``,
+        ``_show_db_backed_status``) does not develop inconsistent
+        state across rapid calls.
+
+        Mock note (#764): patches ``_show_db_backed_status``, the
+        actual code path the status command takes. The previous
+        version patched ``ServiceSupervisor``, which the status
+        command never instantiates -- so the test was either
+        making real DB calls (if ``list_scheduler_services`` worked)
+        or hitting the in-process fallback. Either way, the mock
+        was a no-op.
         """
         runner = CliRunner()
         results = []
 
-        with patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor:
-            mock_instance = MagicMock()
-            mock_instance.get_status.return_value = {"running": False, "pollers": []}
-            mock_supervisor.return_value = mock_instance
-
+        with patch("precog.cli.scheduler._show_db_backed_status", return_value=True) as mock_status:
             start = time.perf_counter()
             for _ in range(10):
                 result = runner.invoke(isolated_app, ["scheduler", "status"])
@@ -80,19 +87,24 @@ class TestSchedulerRace:
             elapsed = time.perf_counter() - start
 
             assert len(results) == 10
-            assert all(code in [0, 1, 2] for code in results)
+            assert all(code == 0 for code in results), f"unexpected exit codes: {results}"
+            assert mock_status.call_count == 10, (
+                f"_show_db_backed_status called {mock_status.call_count} times; expected 10"
+            )
             # All 10 calls should complete in reasonable time
             assert elapsed < 30.0, f"10 calls took {elapsed:.2f}s"
 
     def test_rapid_alternating_start_stop(self, isolated_app) -> None:
         """Test rapid alternating start and stop requests.
 
-        Race: Tests alternating start/stop calls.
+        Race: Tests alternating start/stop calls on the non-supervised code path.
 
-        Note: Must mock create_supervisor (the factory the CLI actually calls),
-        not ServiceSupervisor directly. The CLI calls create_supervisor() which
-        internally creates real pollers — mocking only the class leaves real
-        ESPN/Kalshi clients alive, causing APScheduler thread leaks and timeouts.
+        Note: This test drives the NON-supervised code path (no --supervised flag),
+        where the CLI directly instantiates ESPNGamePoller / KalshiMarketPoller from
+        precog.schedulers. Both must be mocked at the package level to prevent
+        real API client creation. This is distinct from the supervised path which
+        requires patching create_supervisor (see test_cli_scheduler_e2e.py for
+        that pattern).
         """
         runner = CliRunner()
         results = []
@@ -102,8 +114,8 @@ class TestSchedulerRace:
         mock_poller.stop.return_value = None
 
         with (
-            patch("precog.schedulers.ESPNGamePoller", return_value=mock_poller),
-            patch("precog.schedulers.KalshiMarketPoller", return_value=mock_poller),
+            patch("precog.schedulers.ESPNGamePoller", return_value=mock_poller) as mock_espn,
+            patch("precog.schedulers.KalshiMarketPoller", return_value=mock_poller) as mock_kalshi,
         ):
             for i in range(5):
                 result = runner.invoke(isolated_app, ["scheduler", "start"])
@@ -112,8 +124,16 @@ class TestSchedulerRace:
                 results.append(("stop", result.exit_code))
 
             assert len(results) == 10
-            # All should complete without errors
-            assert all(code in [0, 1, 2] for _, code in results)
+            for label, code in results:
+                assert code == 0, f"{label} returned exit {code} (expected 0)"
+
+            assert mock_espn.call_count == 5, (
+                f"ESPNGamePoller constructor called {mock_espn.call_count} times, expected 5 — "
+                "mock is a no-op if count is 0"
+            )
+            assert mock_kalshi.call_count == 5, (
+                f"KalshiMarketPoller constructor called {mock_kalshi.call_count} times, expected 5"
+            )
 
 
 class TestDbRace:
@@ -238,14 +258,28 @@ class TestCrossModuleRace:
         """Test rapid commands across different modules.
 
         Race: Tests rapid commands from scheduler, db, and system.
+        Verifies that interleaved access does not develop
+        inconsistent module-global state.
+
+        Mock note (#764): scheduler status patches
+        ``_show_db_backed_status`` (the real code path) and is
+        held to strict exit 0. The db/system commands are out of
+        scope for #764 -- they have their own "missing critical
+        tables -> exit 1" behavior under partial mocks that is
+        unrelated to the scheduler retrofit. Their assertions
+        remain intentionally loose; tightening them would require
+        a separate audit of db/system CLI mock fidelity.
         """
         runner = CliRunner()
-        results = []
+        scheduler_results = []
+        other_results = []
 
         with (
             patch("precog.database.connection.test_connection") as mock_test,
             patch("precog.database.connection.get_cursor") as mock_ctx,
-            patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor,
+            patch(
+                "precog.cli.scheduler._show_db_backed_status", return_value=True
+            ) as mock_sched_status,
         ):
             mock_test.return_value = True
             mock_cur = MagicMock()
@@ -260,9 +294,6 @@ class TestCrossModuleRace:
             mock_cur.fetchall.return_value = []
             mock_ctx.return_value.__enter__ = MagicMock(return_value=mock_cur)
             mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
-            mock_instance = MagicMock()
-            mock_instance.get_status.return_value = {"running": False, "pollers": []}
-            mock_supervisor.return_value = mock_instance
 
             commands = [
                 (["scheduler", "status"], "scheduler"),
@@ -276,22 +307,43 @@ class TestCrossModuleRace:
             for _ in range(3):
                 for cmd, name in commands:
                     result = runner.invoke(isolated_app, cmd)
-                    results.append((name, result.exit_code))
+                    if name == "scheduler":
+                        scheduler_results.append(result.exit_code)
+                    else:
+                        other_results.append((name, result.exit_code))
 
-            assert len(results) == 15  # 5 commands * 3 rounds
-            assert all(code in [0, 1, 2] for _, code in results)
+            # scheduler status fired 3 times -- verify the mock was hit
+            assert mock_sched_status.call_count == 3, (
+                f"_show_db_backed_status called {mock_sched_status.call_count} times; expected 3"
+            )
+            # Scheduler is the #764 in-scope path: strict exit 0.
+            assert all(code == 0 for code in scheduler_results), (
+                f"scheduler status exit codes: {scheduler_results}; expected all 0"
+            )
+            # db/system are out of scope (#764): just require they
+            # don't crash with an unhandled exception.
+            assert len(other_results) == 12  # 4 non-scheduler commands * 3 rounds
+            assert all(code in [0, 1, 2] for _, code in other_results), (
+                f"unexpected exit codes from db/system: {other_results}"
+            )
 
     def test_state_isolation_between_modules(self, isolated_app) -> None:
         """Test that module state doesn't leak between rapid calls.
 
-        Race: Verifies isolation between different CLI modules.
+        Race: Verifies isolation between different CLI modules. Module-
+        global state in ``precog.cli.scheduler`` is not touched by
+        the ``status`` code path when ``_show_db_backed_status``
+        returns True, so the scheduler module remains in a clean
+        state across calls.
         """
         runner = CliRunner()
 
         with (
             patch("precog.database.connection.test_connection") as mock_test,
             patch("precog.database.connection.get_cursor") as mock_ctx,
-            patch("precog.schedulers.service_supervisor.ServiceSupervisor") as mock_supervisor,
+            patch(
+                "precog.cli.scheduler._show_db_backed_status", return_value=True
+            ) as mock_sched_status,
         ):
             mock_test.return_value = True
             mock_cur = MagicMock()
@@ -306,20 +358,26 @@ class TestCrossModuleRace:
             mock_cur.fetchall.return_value = []
             mock_ctx.return_value.__enter__ = MagicMock(return_value=mock_cur)
             mock_ctx.return_value.__exit__ = MagicMock(return_value=False)
-            mock_instance = MagicMock()
-            mock_instance.get_status.return_value = {"running": False, "pollers": []}
-            mock_supervisor.return_value = mock_instance
 
-            # Rapid interleaved calls
+            # Rapid interleaved calls. Scheduler is the #764 in-scope
+            # path and is held to strict exit 0; db/system have their
+            # own "missing critical tables -> exit 1" behavior under
+            # partial mocks that is out of scope for this retrofit.
             for _ in range(5):
-                # Call scheduler
+                # Call scheduler -- the #764 in-scope path
                 r1 = runner.invoke(isolated_app, ["scheduler", "status"])
-                assert r1.exit_code in [0, 1, 2]
+                assert r1.exit_code == 0, (
+                    f"scheduler status should exit 0; got {r1.exit_code}: {r1.output}"
+                )
 
-                # Immediately call db
+                # Immediately call db (out of scope: just require no crash)
                 r2 = runner.invoke(isolated_app, ["db", "status"])
                 assert r2.exit_code in [0, 1, 2]
 
-                # Immediately call system
+                # Immediately call system (out of scope: just require no crash)
                 r3 = runner.invoke(isolated_app, ["system", "health"])
                 assert r3.exit_code in [0, 1, 2]
+
+            assert mock_sched_status.call_count == 5, (
+                f"_show_db_backed_status called {mock_sched_status.call_count} times; expected 5"
+            )

--- a/tests/stress/cli/test_cli_stress.py
+++ b/tests/stress/cli/test_cli_stress.py
@@ -50,10 +50,19 @@ class TestSchedulerStress:
         """
         runner = CliRunner()
 
-        with patch("precog.cli.scheduler._show_db_backed_status", return_value=False):
+        with patch(
+            "precog.cli.scheduler._show_db_backed_status", return_value=False
+        ) as mock_status:
             for i in range(50):
                 result = runner.invoke(isolated_app, ["scheduler", "status"])
-                assert result.exit_code in [0, 1, 2], f"Failed on iteration {i}"
+                assert result.exit_code == 0, (
+                    f"Failed on iteration {i}: exit={result.exit_code}, output={result.output}"
+                )
+
+            assert mock_status.call_count == 50, (
+                f"_show_db_backed_status called {mock_status.call_count} times, expected 50 — "
+                "mock is a no-op if count is 0"
+            )
 
     def test_rapid_start_stop_cycles(self, isolated_app) -> None:
         """Test rapid start-stop cycles.
@@ -84,9 +93,21 @@ class TestSchedulerStress:
 
             for i in range(20):
                 result = runner.invoke(isolated_app, ["scheduler", "start"])
-                assert result.exit_code in [0, 1, 2], f"Start failed on iteration {i}"
+                assert result.exit_code == 0, (
+                    f"Start failed on iteration {i}: exit={result.exit_code}, output={result.output}"
+                )
                 result = runner.invoke(isolated_app, ["scheduler", "stop"])
-                assert result.exit_code in [0, 1, 2], f"Stop failed on iteration {i}"
+                assert result.exit_code == 0, (
+                    f"Stop failed on iteration {i}: exit={result.exit_code}, output={result.output}"
+                )
+
+            assert mock_espn.call_count == 20, (
+                f"ESPNGamePoller constructor called {mock_espn.call_count} times, expected 20 "
+                "(one per start iteration) — mock is a no-op if count is 0"
+            )
+            assert mock_kalshi.call_count == 20, (
+                f"KalshiMarketPoller constructor called {mock_kalshi.call_count} times, expected 20"
+            )
 
     def test_many_poll_once_invocations(self, isolated_app) -> None:
         """Test many poll-once invocations.
@@ -121,8 +142,23 @@ class TestSchedulerStress:
             mock_kalshi.return_value = mock_kalshi_instance
 
             for i in range(30):
-                result = runner.invoke(isolated_app, ["scheduler", "poll-once", "--league", "nfl"])
-                assert result.exit_code in [0, 1, 2], f"Failed on iteration {i}"
+                # NOTE: poll-once accepts --leagues (plural, comma-separated),
+                # not --league. The previous version of this test passed
+                # --league which Typer rejected with exit 2; the mocks
+                # were never called. (#764)
+                result = runner.invoke(isolated_app, ["scheduler", "poll-once", "--leagues", "nfl"])
+                assert result.exit_code == 0, (
+                    f"Failed on iteration {i}: exit={result.exit_code}, output={result.output}"
+                )
+
+            assert mock_espn_instance.poll_once.call_count == 30, (
+                f"ESPN poll_once called "
+                f"{mock_espn_instance.poll_once.call_count} times; expected 30"
+            )
+            assert mock_kalshi_instance.poll_once.call_count == 30, (
+                f"Kalshi poll_once called "
+                f"{mock_kalshi_instance.poll_once.call_count} times; expected 30"
+            )
 
 
 class TestDbStress:

--- a/tests/unit/cli/test_cli_scheduler.py
+++ b/tests/unit/cli/test_cli_scheduler.py
@@ -71,29 +71,77 @@ class TestSchedulerHelp:
 
 
 class TestSchedulerStart:
-    """Test scheduler start command."""
+    """Test scheduler start command.
 
-    @patch("precog.schedulers.service_supervisor.ServiceSupervisor")
-    def test_start_supervised_mode(self, mock_supervisor_class, runner):
-        """Test start command with supervised mode."""
-        mock_supervisor = MagicMock()
-        mock_supervisor_class.return_value = mock_supervisor
+    See #764 for the rationale on patching ``create_supervisor`` (the
+    factory) rather than ``ServiceSupervisor`` (the class). The CLI's
+    supervised path calls ``create_supervisor(...)`` which itself
+    instantiates real Kalshi and ESPN pollers, rate limiters, and
+    circuit breakers before constructing the supervisor. Patching the
+    class leaves all that real setup intact and the tests start
+    making real network calls. The factory is the correct mock level.
+    """
 
-        result = runner.invoke(app, ["start", "--supervised", "--no-foreground"])
+    def test_start_supervised_mode(self, runner):
+        """Test start command with supervised mode.
 
-        # Exit code 2 is Typer's "missing option/bad usage" code
-        # Should attempt to start (may fail if services not configured)
-        assert result.exit_code in [0, 1, 2]
+        Asserts the supervised code path reaches ``create_supervisor``
+        and runs to clean exit with exit code 0. The
+        ``_validate_startup`` patch is required because without it the
+        CLI short-circuits with exit code 1 and the factory mock is
+        never reached -- which was the silent no-op that hid the bug
+        in #764 for months.
+        """
+        with (
+            patch(
+                "precog.schedulers.service_supervisor.create_supervisor"
+            ) as mock_create_supervisor,
+            patch("precog.cli.scheduler._validate_startup", return_value=True),
+            patch("precog.cli.scheduler._prevent_system_sleep_for_supervised"),
+        ):
+            mock_supervisor = MagicMock()
+            mock_supervisor.is_running = True
+            mock_supervisor.start_all.return_value = None
+            mock_create_supervisor.return_value = mock_supervisor
 
-    @patch("precog.database.connection.get_connection")
-    def test_start_espn_only(self, mock_conn, runner):
-        """Test start with ESPN only (no Kalshi)."""
-        mock_conn.return_value = MagicMock()
+            result = runner.invoke(app, ["start", "--supervised"])
 
-        result = runner.invoke(app, ["start", "--espn", "--no-kalshi", "--no-foreground"])
+            assert result.exit_code == 0, (
+                f"supervised start should exit 0; got {result.exit_code} "
+                f"with output: {result.output}"
+            )
+            mock_create_supervisor.assert_called_once()
 
-        # May succeed, fail, or have usage error depending on env
-        assert result.exit_code in [0, 1, 2]
+    def test_start_espn_only(self, runner):
+        """Test start with ESPN only (no Kalshi) via supervised path.
+
+        Routes through ``--supervised`` so the ``create_supervisor``
+        mock is the actual code path. ``enabled_services={"espn"}`` is
+        verified by inspecting the factory call kwargs.
+        """
+        with (
+            patch(
+                "precog.schedulers.service_supervisor.create_supervisor"
+            ) as mock_create_supervisor,
+            patch("precog.cli.scheduler._validate_startup", return_value=True),
+            patch("precog.cli.scheduler._prevent_system_sleep_for_supervised"),
+        ):
+            mock_supervisor = MagicMock()
+            mock_supervisor.is_running = True
+            mock_supervisor.start_all.return_value = None
+            mock_create_supervisor.return_value = mock_supervisor
+
+            result = runner.invoke(app, ["start", "--supervised", "--espn", "--no-kalshi"])
+
+            assert result.exit_code == 0, (
+                f"espn-only supervised start should exit 0; got {result.exit_code} "
+                f"with output: {result.output}"
+            )
+            mock_create_supervisor.assert_called_once()
+            call_kwargs = mock_create_supervisor.call_args.kwargs
+            assert call_kwargs.get("enabled_services") == {"espn"}, (
+                f"expected enabled_services={{'espn'}}, got {call_kwargs.get('enabled_services')}"
+            )
 
     def test_start_invalid_interval(self, runner):
         """Test start with invalid interval value.
@@ -157,20 +205,21 @@ class TestSchedulerPollOnce:
 
         result = runner.invoke(app, ["poll-once", "--no-kalshi"])
 
-        # Should attempt poll (may fail on missing config)
-        assert result.exit_code in [0, 1]
+        assert result.exit_code == 0, f"exit={result.exit_code}, output={result.output}"
+        mock_poller.poll_once.assert_called_once()
 
     @patch("precog.schedulers.KalshiMarketPoller")
     def test_poll_once_kalshi_only(self, mock_poller_class, runner):
         """Test poll-once with Kalshi only."""
         mock_poller = MagicMock()
         mock_poller.poll_once.return_value = {"markets": 10, "updated": 5}
+        mock_poller.kalshi_client = MagicMock()
         mock_poller_class.return_value = mock_poller
 
         result = runner.invoke(app, ["poll-once", "--no-espn"])
 
-        # Should attempt poll (may fail on missing credentials)
-        assert result.exit_code in [0, 1]
+        assert result.exit_code == 0, f"exit={result.exit_code}, output={result.output}"
+        mock_poller.poll_once.assert_called_once()
 
     def test_poll_once_help(self, runner):
         """Test poll-once --help shows options."""


### PR DESCRIPTION
## Summary

Retrofit of 7 scheduler CLI test files across every test tier to eliminate the systemic factory-vs-class mock anti-pattern documented in umbrella issue #764. Reference implementation: `tests/e2e/cli/test_cli_scheduler_e2e.py` (post-session-49 tactical fix).

**Scope:** 26 category-B tests across 7 files + a new autouse cleanup fixture in `tests/conftest.py`. 79/79 tests pass on the full 8-file target sweep.

## Background — why this matters

Session 49 uncovered that 8 test files across every test tier were patching `ServiceSupervisor` **the class** when the CLI actually calls `create_supervisor` **the factory function**. The factory does substantial setup before instantiating the supervisor — it constructs real `ESPNGamePoller` and `KalshiMarketPoller`, rate limiters, circuit breakers. Patching the class left all the factory-side setup intact, which meant real pollers started and real HTTP calls fired against Kalshi demo and ESPN public APIs. Tests reported green CI **contingent on external API cooperation**, not on code correctness.

Additionally, the integration file's 12 tests were using non-existent Typer flags (`--poller`, `--interval`, `--league` (singular), `--save`, `--format`, `--no-foreground`) — they were exit-2-from-Typer in disguise. The mocks were never reached AND the args under test never existed. The combination with loose `exit_code in [0, 1, 2]` assertions made them appear green in CI for months while providing zero coverage.

## Changes

### Retrofit pattern applied uniformly

Every category-B test in the 7 files now follows the reference template from `test_cli_scheduler_e2e.py`:

1. **Mock level fix.** `patch("precog.schedulers.service_supervisor.ServiceSupervisor")` → `patch("precog.schedulers.service_supervisor.create_supervisor")`. The factory is the real entry point.
2. **Routing fix.** Tests expecting the supervised code path pass `--supervised` to `runner.invoke(app, [...])`. Tests driving the non-supervised path patch `precog.schedulers.ESPNGamePoller` / `KalshiMarketPoller` at the package level.
3. **Strict exit codes.** `assert exit_code in [0, 1, 2]` → `assert exit_code == 0`. Loose assertions were the universal decay concealer — tightening them is the fail-loud invariant that would have caught #764 years ago.
4. **Mock-was-called assertions.** Every test now includes `mock_create_supervisor.assert_called_once()` or `.call_count == N` so silently-dead mocks fail loudly.

### Per-file notes

| File | Tests fixed | Notes |
|---|---|---|
| `tests/unit/cli/test_cli_scheduler.py` | 2 scheduler + 2 poll-once | `test_start_supervised_mode`, `test_start_espn_only`, plus `test_poll_once_espn_only` / `test_poll_once_kalshi_only` tightened per Joe Chip review |
| `tests/integration/cli/test_cli_scheduler_integration.py` | 12 | Wholesale rewrite — original tests used non-existent Typer flags. Replaced with real flags, correct mock levels per command path (`start` → factory, `status` → `_show_db_backed_status`, `stop` → module-global injection, `poll-once` → package-level pollers). Three tests renamed where original names referenced flags that don't exist |
| `tests/property/cli/test_cli_scheduler_properties.py` | 5 | Same dead-flag root cause. Hypothesis property tests now correctly distinguish Typer-reject (exit 2, factory not called) from accepted values (exit 0, factory called once). `test_kalshi_interval_float_rejection` else branch collapsed per Joe Chip P2 finding (was a latent decay trap) |
| `tests/chaos/cli/test_cli_chaos.py` | 3 | Chaos injection moved from the wrong-level-supervisor layer to the layer the CLI actually reaches: `list_scheduler_services` for status chaos, package-level `ESPNGamePoller.poll_once` for poll chaos, 100 fake rows with 1KB stats blobs for memory pressure. Each test asserts `call_count` on the chaos hook |
| `tests/performance/cli/test_cli_performance.py` | 3 | `test_status_latency` patches `_show_db_backed_status`, `test_poll_once_throughput` uses `--leagues` flag, `test_mixed_command_throughput` got the scheduler-side fix. Note: perf budgets now measure CLI dispatch overhead, not real scheduler latency (tracked in #767) |
| `tests/race/cli/test_cli_race.py` | 3 | `test_rapid_sequential_status_checks` patches `_show_db_backed_status` + strict exit 0 + 10 calls. Cross-module tests apply the same fix to scheduler entries, leave db/system entries loose (out of #764 scope — real CLI behavior returns exit 1 on missing tables) |
| `tests/stress/cli/test_cli_stress.py` | 4 | Includes `test_many_poll_once_invocations` which was using `--league` (singular, doesn't exist) — fixed to `--leagues` with `call_count == 30` assertion. `test_repeated_status_checks` + `test_rapid_start_stop_cycles` tightened per Joe Chip P1 findings |

### New autouse fixture in `tests/conftest.py`

Added `_cleanup_scheduler_cli_module_globals` — saves and restores `precog.cli.scheduler._supervisor`, `_espn_updater`, `_kalshi_poller` between tests. The retrofit made the CLI module-global leak deterministic where it was previously probabilistic (factory mocks reliably populate the globals every time), so without this fixture a `start`-only test would pollute every subsequent test. Ripley's fixture completeness check confirmed all three relevant module globals are covered.

## Review cycle

- **Builder (Nagilum):** 26 tests fixed on first pass, 79/79 pass, +880/-303 lines.
- **Code Reviewer (Joe Chip):** APPROVE WITH COMMENTS — 5 P1 findings (residual loose assertions in stress/race/unit-poll-once tests) + 1 P2 finding (latent decay trap in property test float-rejection else branch). **All 6 fixed in this PR.**
- **Sentinel (Ripley):** **CLEAR TO MERGE** — exhaustive pre/post diff against `main` found zero coincidental real coverage lost. Every pre-retrofit passing test was either Typer-reject no-op, wrong-level patch hitting safe fallback, or already correctly patched. Fixture completeness: all 3 module globals covered.

## Test results

```
============================= 79 passed in 41.06s =============================
```

Full target sweep (7 files + e2e reference). All pre-push tiers passed in 374s.

## Related issues

- **Closes-not #764** — umbrella issue, Phase 3 (retrofit) complete per the fix plan. Phases 4-5 (audit coverage claim + DEVELOPMENT_PATTERNS additions) tracked separately.
- **Sibling #766** — zero live drift-detection coverage on scheduler CLI surface (VCR OR live, never hand-written). Session 50 finding: the "preserve drift detection" assumption from session 49 was based on a surface that had zero drift detection to begin with.
- **Follow-up #767** — cosmetic-coverage audit for 7 tests the retrofit left honestly-green but tier-cosmetic (performance tests measuring CLI dispatch only, chaos tests moved to db layer, etc.). Nagilum flagged these transparently; not a retrofit regression.
- **New triggers from this session:** S73 (external API test pattern compliance), S74 (assumption decay audit radar), S75 (CLI flag existence pre-commit linter — tracked as #769).
- **New audit #768** — T41 Test Infrastructure Health, sibling to P41. Would have caught this failure years ago.
- **New deployment plan #770** — 3-tier hook deployment (mechanical pre-commit → reminder injection → post-action audits).

## Test plan

- [x] Full 8-file target sweep: 79/79 pass locally
- [x] Ruff format + check pass on all 8 edited files
- [x] Pre-push hook (unit + integration + e2e tiers in parallel): 374s, all green
- [ ] CI Summary on this PR
- [ ] Claude Review automated check
- [ ] Integration Tests (PostgreSQL) job