### PR TITLE
docs: Add External API Test Mocking pattern to CLAUDE.md Critical Patterns (#764)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,31 @@ ASCII output for console (Windows cp1252). Explicit UTF-8 for file I/O.
 ### 6. Immutable Versioning
 Strategies and models are immutable once created. Create new version, don't modify existing.
 
+### 7. External API Test Mocking — VCR OR live, NEVER hand-written
+
+Tests that exercise code calling **Kalshi, ESPN, or any HTTP client** use one of two approaches — **never** hand-written `MagicMock` response dicts:
+
+```python
+# CORRECT — Pattern 22 VCR cassette (reproducible, catches shape regressions)
+@pytest.mark.vcr  # Records to tests/cassettes/ on first run, replays after
+def test_kalshi_market_fetch():
+    markets = kalshi_client.get_markets(series="NFL")
+    assert markets[0]["ticker"].startswith("KXNFLGAME-")
+
+# CORRECT — Live contract test (catches API format drift)
+@pytest.mark.live_api  # Runs only in nightly contract workflow, never in normal CI
+def test_kalshi_api_responds_to_markets_endpoint():
+    markets = kalshi_client.get_markets()
+    assert "markets" in markets and all("ticker" in m for m in markets["markets"])
+
+# WRONG — Hand-written mock (rots silently, cannot catch drift)
+mock_kalshi.poll_once.return_value = {"items_fetched": 10, "items_updated": 8}
+```
+
+**Why:** Hand-written mocks freeze a guessed shape that diverges from the real API over time. VCR cassettes (`tests/cassettes/`) record real responses once and replay them — they catch regressions in our code AND surface format drift when the cassette is re-recorded. Live contract tests catch drift in real-time but are gated to nightly runs. See `tests/integration/api_connectors/test_kalshi_client_vcr.py` for the canonical Pattern 22 reference implementation.
+
+**Umbrella issue #764** tracks the retrofit of 8 files that historically violated this rule and had been reporting fictional green CI for months. **Trigger S73** enforces this rule on new PRs; **Pattern 22** in `docs/guides/DEVELOPMENT_PATTERNS_V1.31.md` is the authoritative reference.
+
 ---
 
 ## Repository Structure


### PR DESCRIPTION
## Summary

Fills the enforcement-surface gap identified in the session 49 compliance audit (`memory/feedback_test_pattern_compliance.md`): CLAUDE.md previously had zero mention of VCR, Pattern 22, or `tests/cassettes/`. Fresh sessions had no signal that the external-API test mocking pattern existed unless they manually grepped `DEVELOPMENT_PATTERNS_V1.31.md`.

This is **the highest-leverage fix** from the compliance audit because CLAUDE.md is always loaded into agent context at session start, while pattern-library files are only read on demand. The lack of a pointer was one of the root enablers for #764 (agents wrote tests against external APIs without knowing Pattern 22 existed).

## Change

Adds **Critical Pattern #7: External API Test Mocking — VCR OR live, NEVER hand-written** to `CLAUDE.md`. 25 lines total:

- CORRECT code examples (Pattern 22 VCR via `@pytest.mark.vcr`, live contract via `@pytest.mark.live_api`)
- WRONG code example (hand-written `MagicMock.return_value` dict)
- Why rationale (frozen mocks diverge from real API, cassettes catch regressions AND drift)
- Cross-references to the canonical VCR reference implementation, trigger S73 (new this session), Pattern 22 in `DEVELOPMENT_PATTERNS_V1.31.md`, and umbrella issue #764

## Why a separate PR from the retrofit (#771)

The retrofit PR (#771) is test-infrastructure code. This PR is project-level documentation that agents read on every session start. Splitting them lets docs-only CI (the #616 fast path) apply here while the retrofit goes through the full test tier.

## Related

- **#764** — umbrella (this CLAUDE.md gap was a root enabler)
- **#771** — retrofit PR (the code fix for the same problem)
- **#766** — zero live drift-detection (complementary gap)
- **#768** — T41 Test Infrastructure Health audit (new sibling to P41 from this session)
- **#769** — S75 CLI flag existence pre-commit linter
- **Memory:** `feedback_test_pattern_compliance.md` gap 1 ("CLAUDE.md has no mention of VCR") — this PR closes that gap

## Test plan

- [x] Local `git commit` pre-commit checks pass
- [x] Docs-only push (fast path)
- [ ] CI Summary on this PR