### PR TITLE
test+docs: S50+S51 audit follow-up bundle (#773, #774, #775)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,14 +110,17 @@ def test_kalshi_market_fetch():
 def test_kalshi_api_responds_to_markets_endpoint():
     markets = kalshi_client.get_markets()
     assert "markets" in markets and all("ticker" in m for m in markets["markets"])
+    # Shape assertion must mirror the actual client return type (dict vs list)
 
 # WRONG — Hand-written mock (rots silently, cannot catch drift)
-mock_kalshi.poll_once.return_value = {"items_fetched": 10, "items_updated": 8}
+mock_client.get_markets.return_value = {
+    "markets": [{"ticker": "FAKE-001", "yes_price": 50}]
+}
 ```
 
-**Why:** Hand-written mocks freeze a guessed shape that diverges from the real API over time. VCR cassettes (`tests/cassettes/`) record real responses once and replay them — they catch regressions in our code AND surface format drift when the cassette is re-recorded. Live contract tests catch drift in real-time but are gated to nightly runs. See `tests/integration/api_connectors/test_kalshi_client_vcr.py` for the canonical Pattern 22 reference implementation.
+**Why:** Hand-written mocks freeze a guessed shape that diverges from the real API over time. VCR cassettes (`tests/cassettes/`) record real responses once and replay them — they catch regressions in our code AND surface format drift when the cassette is re-recorded. Live contract tests catch drift in real-time but are gated to nightly runs. See `tests/integration/api_connectors/test_kalshi_client_vcr.py` for the canonical Pattern 22 reference implementation. VCR cassettes live in `tests/cassettes/` (configured per-test via `@pytest.fixture(scope="module")` in each VCR test file, not in a shared conftest).
 
-**Umbrella issue #764** tracks the retrofit of 8 files that historically violated this rule and had been reporting fictional green CI for months. **Trigger S73** enforces this rule on new PRs; **Pattern 22** in `docs/guides/DEVELOPMENT_PATTERNS_V1.31.md` is the authoritative reference.
+**Umbrella issue #764** tracks the retrofit of 8 files that historically violated this rule and had been reporting fictional green CI for months. **Trigger S73** (a PM-side agent review that fires Joe Chip on PRs touching external API tests to catch hand-written mocks) enforces this rule on new PRs; **Pattern 22** in `docs/guides/DEVELOPMENT_PATTERNS_V1.31.md` is the authoritative reference.
 
 ---
 

--- a/tests/fixtures/cleanup_helpers.py
+++ b/tests/fixtures/cleanup_helpers.py
@@ -177,7 +177,16 @@ def _delete_cascade(
 
     for child_table, child_column, delete_rule in children:
         if delete_rule == "SET NULL":
-            # Clear the reference instead of deleting the row.
+            # Clear the reference instead of deleting the child row.
+            #
+            # Non-transitive by design: we UPDATE the FK to NULL and stop.
+            # If the SET NULL child has its own RESTRICT children
+            # (grandchildren of the parent being deleted), those
+            # grandchildren are NOT cleaned up here -- the child row still
+            # exists, so the grandchildren's FKs are still valid. For
+            # full-subtree cleanup use delete_all_test_data; for scoped
+            # cleanup of a specific subtree, call this helper with the
+            # grandchild's parent directly.
             placeholders = ",".join(["%s"] * len(ids))
             cursor.execute(
                 f"UPDATE {child_table} SET {child_column} = NULL "  # noqa: S608
@@ -201,8 +210,21 @@ def _delete_cascade(
 
         # Discover the child's own children (grandchildren of the root)
         # by looking up the child's PK and recursing.
+        #
+        # _visited handles termination when child_pk == child_column; the
+        # guard is unnecessary. The previous ``child_pk != child_column``
+        # check was overly broad and skipped legitimate recursion into
+        # tables where the FK happens to BE the PK, leaving their own
+        # children uncleaned. The _visited set (line ~174) terminates
+        # any same-(table, column) re-entry on the first recursive call.
+        #
+        # Known limitation: self-referential FKs (e.g., ``foo.parent_id ->
+        # foo.id``) terminate on first re-entry via _visited and may leave
+        # uncleaned grandchildren under the same table. No such FK exists
+        # in the current schema (verified via grep across all migrations);
+        # revisit this helper if one is added.
         child_pk = _discover_primary_key(cursor, child_table)
-        if child_pk is not None and child_pk != child_column:
+        if child_pk is not None:
             # Fetch the child row IDs that match our parent ids, then
             # recursively cascade into the child's subtree before deleting.
             placeholders = ",".join(["%s"] * len(ids))
@@ -356,13 +378,17 @@ def delete_venue_with_children(
 ) -> None:
     """Delete venue(s) via dynamic FK discovery.
 
-    In the current schema, ``games.venue_id`` is ``ON DELETE SET NULL``
-    and ``game_states.venue_id`` is ``ON DELETE NO ACTION``. Neither is
-    listed in migration 0057 because both were already RESTRICT-compliant.
-    ``_delete_cascade`` handles both rules automatically: SET NULL becomes
-    an UPDATE to clear the reference, NO ACTION triggers recursive delete
-    of the child rows -- but since tests rarely populate ``game_states``
-    through this path, the NO ACTION branch is usually a no-op.
+    In the current schema (post-migration 0057), both ``games.venue_id``
+    and ``game_states.venue_id`` prevent venue deletion when referenced:
+
+    - ``games.venue_id`` was ``SET NULL`` in migration 0035; migration 0057
+      converted it to ``RESTRICT``.
+    - ``game_states.venue_id`` has been ``NO ACTION`` since the 0001
+      baseline (implicit default). ``NO ACTION`` behaves identically to
+      ``RESTRICT`` for cleanup purposes.
+
+    ``_delete_cascade`` handles both via dynamic FK discovery -- no
+    hardcoded child list needed.
     """
     cursor.execute(
         f"SELECT venue_id FROM venues WHERE {where_clause}",  # noqa: S608

--- a/tests/integration/api_connectors/test_espn_client_vcr.py
+++ b/tests/integration/api_connectors/test_espn_client_vcr.py
@@ -1,5 +1,5 @@
 """
-Integration tests for ESPN API client using VCR cassettes (Pattern 13).
+Integration tests for ESPN API client using VCR cassettes (Pattern 22).
 
 Tests the full ESPNClient integration using REAL recorded API responses.
 These tests use the VCR (Video Cassette Recorder) pattern:
@@ -19,18 +19,18 @@ Cassettes recorded: tests/cassettes/espn/*.yaml
 - espn_nfl_live_games.yaml (8 live NFL games with situation data)
 - espn_nba_scoreboard.yaml (7 NBA games)
 
-Pattern 13 Exception: External API mock
+Pattern 22 (External API Test Mocking): VCR OR live, never hand-written mocks.
 These tests use VCR to replay REAL API responses. They test API client behavior
 without touching the database, so database fixtures (db_pool, db_cursor, clean_test_data)
-are not applicable. Pattern 13 lesson learned was about DATABASE connection pool mocking,
-not HTTP interaction recording.
+are not applicable. The historical Pattern 13 lesson was about DATABASE connection
+pool mocking, not HTTP interaction recording; the external-API rule is now Pattern 22.
 
 Related Requirements:
     - REQ-DATA-001: Game State Data Collection
-    - REQ-TEST-002: Integration tests use real API fixtures (Pattern 13)
+    - REQ-TEST-002: Integration tests use real API fixtures (Pattern 22)
 
 Reference:
-    - Pattern 13 (CLAUDE.md): Real Fixtures, Not Mocks
+    - Pattern 22 (CLAUDE.md Critical Pattern #7 + DEVELOPMENT_PATTERNS_V1.31.md)
     - GitHub Issue #180: ESPN E2E test edge cases (down: -1)
     - scripts/record_espn_cassettes.py: Cassette recording script
 """
@@ -63,8 +63,8 @@ class TestESPNClientWithVCR:
     - Edge cases like down: -1 during non-play situations
 
     Educational Note:
-        Pattern 13: Real Fixtures, Not Mocks
-        -----------------------------------
+        Pattern 22: External API Test Mocking — VCR OR live
+        ----------------------------------------------------
         Problem: Mocks create false positives (tests pass but code broken)
         - Mock returns simplified structure but real API has nested events
         - Test passes with mock, fails in production

--- a/tests/integration/api_connectors/test_kalshi_client_vcr.py
+++ b/tests/integration/api_connectors/test_kalshi_client_vcr.py
@@ -1,5 +1,5 @@
 """
-Integration tests for Kalshi API client using VCR cassettes (Pattern 13).
+Integration tests for Kalshi API client using VCR cassettes (Pattern 22).
 
 Tests the full KalshiClient integration using REAL recorded API responses.
 These tests use the VCR (Video Cassette Recorder) pattern:
@@ -20,20 +20,20 @@ Cassettes recorded: tests/cassettes/kalshi_*.yaml
 - kalshi_get_fills.yaml (1 historical fill)
 - kalshi_get_settlements.yaml (0 settlements)
 
-Pattern 13 Exception: External API mock
+Pattern 22 (External API Test Mocking): VCR OR live, never hand-written mocks.
 These tests use VCR to replay REAL API responses. They test API client behavior
 without touching the database, so database fixtures (db_pool, db_cursor, clean_test_data)
-are not applicable. Pattern 13 lesson learned was about DATABASE connection pool mocking,
-not HTTP interaction recording.
+are not applicable. The historical Pattern 13 lesson was about DATABASE connection
+pool mocking, not HTTP interaction recording; the external-API rule is now Pattern 22.
 
 Related Requirements:
     - REQ-API-001: Kalshi API Integration
     - REQ-API-002: RSA-PSS Authentication
     - REQ-SYS-003: Decimal Precision for Prices
-    - REQ-TEST-002: Integration tests use real API fixtures (Pattern 13)
+    - REQ-TEST-002: Integration tests use real API fixtures (Pattern 22)
 
 Reference:
-    - Pattern 13 (CLAUDE.md): Real Fixtures, Not Mocks
+    - Pattern 22 (CLAUDE.md Critical Pattern #7 + DEVELOPMENT_PATTERNS_V1.31.md)
     - GitHub Issue #124: Fix integration test mocks
     - Phase 1.5 Test Audit: 77% false positive rate from mocks
 """
@@ -69,8 +69,8 @@ class TestKalshiClientWithVCR:
     - No mocks needed - uses actual recorded HTTP interactions
 
     Educational Note:
-        Pattern 13: Real Fixtures, Not Mocks
-        -----------------------------------
+        Pattern 22: External API Test Mocking — VCR OR live
+        ----------------------------------------------------
         Problem: Mocks create false positives (tests pass but code broken)
         - Mock returns {"balance": "1234.5678"} but real API returns {"balance": 123456} (cents!)
         - Test passes with mock, fails in production

--- a/tests/performance/cli/test_cli_scheduler_performance.py
+++ b/tests/performance/cli/test_cli_scheduler_performance.py
@@ -50,7 +50,10 @@ class TestSchedulerPerformance:
         p95 = sorted(times)[int(iterations * 0.95)]
         p99 = sorted(times)[int(iterations * 0.99)]
 
-        # Help should be very fast
+        # Help should be very fast.
+        # These bounds measure CLI framework overhead alone (Typer + click +
+        # imports). There is no DB or network I/O on the --help path, so
+        # these are pure dispatch benchmarks.
         assert p50 < 200, f"p50={p50}ms exceeds 200ms"
         assert p95 < 500, f"p95={p95}ms exceeds 500ms"
         assert p99 < 1000, f"p99={p99}ms exceeds 1000ms"
@@ -69,7 +72,12 @@ class TestSchedulerPerformance:
         p50 = statistics.median(times)
         p95 = sorted(times)[int(iterations * 0.95)]
 
-        # Status should be reasonably fast
+        # Status should be reasonably fast.
+        # 500ms is the upper bound for CLI framework overhead alone (Typer +
+        # click + imports). There is no live supervisor or DB connection at
+        # this point -- the autouse cleanup fixture nulls ``_supervisor``
+        # between tests, so the status command falls through to its
+        # no-supervisor branch. This measures dispatch overhead only.
         assert p50 < 500, f"p50={p50}ms exceeds 500ms"
         assert p95 < 1000, f"p95={p95}ms exceeds 1000ms"
 

--- a/tests/property/cli/test_cli_scheduler_properties.py
+++ b/tests/property/cli/test_cli_scheduler_properties.py
@@ -261,7 +261,7 @@ class TestSchedulerStateTransitions:
 
     @given(st.integers(min_value=0, max_value=100))
     @settings(max_examples=20, deadline=None)
-    def test_status_with_varying_db_results(self, found_in_db: int):
+    def test_status_with_varying_db_results(self, parity_seed: int):
         """Status should handle the database-backed path returning
         either success or fall-through for any iteration count.
 
@@ -278,8 +278,11 @@ class TestSchedulerStateTransitions:
         original_supervisor = scheduler_module._supervisor
         scheduler_module._supervisor = None
         try:
-            # Even N: DB path "found", odd N: fallback path
-            db_returns = found_in_db % 2 == 0
+            # parity_seed is just a source of True/False variation --
+            # hypothesis gives us a range of integers and we use parity to
+            # toggle the mock's return value. See #778 for a related
+            # latent-assumption issue flagged on a sibling chaos test.
+            db_returns = parity_seed % 2 == 0
             with patch(
                 "precog.cli.scheduler._show_db_backed_status",
                 return_value=db_returns,


### PR DESCRIPTION
## Summary

Bundles S50 post-merge Claude Review dispositions with trivial fixes from the S51 S68 audit on PRs #771 and #772.

- **#774** — `_delete_cascade` recursion fix in `cleanup_helpers.py`: removed overly broad `child_pk != child_column` guard; `_visited` set terminates all cases. Safety verified by grep across all 57 alembic migrations + ORM definitions — zero FK-equals-PK schemas exist today. SET NULL branch gets an expanded comment documenting non-transitive semantics (behavior unchanged). New latent-limitation comment about self-referential FKs per Joe Chip P3.
- **#773 fix 2** — Rewrote `delete_venue_with_children` docstring to reflect post-0057 FK reality (`games.venue_id` is now RESTRICT via migration 0057 conversion; `game_states.venue_id` has always been implicit `NO ACTION` from the 0001 baseline). Old docstring was factually stale.
- **#775** — CLAUDE.md Pattern #7 improvements: WRONG example broadened from poller-internals to HTTP-client-level mock; live_api shape-assertion note added; `cassette_library_dir` pointer corrected (per-test module fixtures, not a shared conftest); Trigger S73 reference expanded with one-sentence description. Pattern 13 → Pattern 22 docstring sweep in VCR external-API test files (`test_kalshi_client_vcr.py`, `test_espn_client_vcr.py`).
- **#771 claude-review trivial fixes** — `test_cli_scheduler_performance.py` comment rewritten to accurately describe the supervisor-is-None fallback path (was misleadingly claiming `service_registry` mocking). `test_cli_scheduler_properties.py` parameter renamed from `found_in_db` to `parity_seed` with clarifying comment referencing #778.

## Review cycle

- **Samwise (Builder, pattern compliance frame):** Initial implementation. 6 files, +66/-33, 34+94 tests green, ruff clean. Report noted the FK-is-PK safety grep and flagged 2 sibling-#764 violators as out-of-scope.
- **Joe Chip (Reviewer, decay frame, S74 author):** APPROVE WITH COMMENTS. Three findings, all applied in follow-up edit under Tier 1 Momentum override with explicit line-numbered spec:
  - P1 — `cassette_library_dir` claim was factually wrong (no matches in `tests/conftest.py`). Fixed to describe per-test-file configuration.
  - P1 — Pattern 13 → 22 sweep was inconsistent within the PR (2 sibling external-API test files in the same directory left untouched). Filed as follow-up #780 rather than extending the sweep in this PR (see "Why the sweep stops here" below).
  - P2 — Performance test comment claimed `service_registry` mocking but the test actually hits the supervisor-is-None fallback via the autouse fixture. Misleading comment rewritten.
- **Ripley (Sentinel, highest-risk-first frame):** CLEAR WITH OBSERVATIONS. Two latent concerns filed as follow-ups:
  - **#779** — Missing unit tests for `_delete_cascade` against synthetic pathological schemas. The guard removal is "correct by tautology" — safe today because nothing in the current schema trips it, not because edge cases are tested. Natural fit for T41 audit of `src/precog/database/` scheduled for S52.
  - **#780** — `test_kalshi_client_integration.py` and `test_kalshi_series_integration.py` are sibling-#764 violators (hand-written response dicts from `api_responses.py`). Leaving their "Pattern 13 Exception" docstrings in place creates a misleading breadcrumb now that CLAUDE.md § Pattern #7 is merged. Full Pattern 22 retrofit tracked separately.

## Why the sweep stops here (#780 context)

Samwise intentionally scoped the Pattern 13 → Pattern 22 docstring sweep to VCR-based tests only. The 2 Kalshi integration files are NOT VCR-based — they are hand-written-mock based. Renaming their docstrings to "Pattern 22" would be a lie (they violate Pattern 22, they don't implement it). The correct action is a full retrofit (record VCR cassettes, delete hand-written response dicts, update assertions), which is ~1-2 hours per file and out of scope for this docs-surface follow-up PR. Tracked as #780 with a clear acceptance-criteria checklist.

## Out of scope (tracked separately)

- **#773 fix 1** was already resolved before the bundle started — migration 0057 docstring already said `team_code, league` (the issue was filed against stale state that had been fixed)
- **#776, #777, #778** — other findings from the S51 S68 audit on PR #771 (separate future PRs)
- **#779, #780** — Ripley's latent concerns from this PR (filed today, separate future PRs)

## Test plan

- [x] Unit tests: 2617 passed in 51s (pre-push)
- [x] Integration + E2E: 1197 passed, 20 skipped in 356s (pre-push)
- [x] Stress + Chaos + Race: 1063 passed in 207s (pre-push)
- [x] Ruff format + check: clean on all 5 modified Python files
- [x] Targeted test subset (cleanup_helpers consumers, perf test, property test, both VCR test files): 10 passed in 11s after Joe Chip fixes applied
- [ ] CI (runs on PR open): property, security, performance, documentation validation, CI Summary
- [ ] Claude Review (CI workflow) — S68 audit will run post-merge in S52

## Closes

Closes #773
Closes #774
Closes #775

🤖 Generated with [Claude Code](https://claude.com/claude-code)