### PR TITLE
feat: Tier 1 Hook PR 1 — block staged .env/.envrc files (Phase A' exit #1, part 1/4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ env/
 .env.development.local
 .env.staging.local
 .env.production.local
+.envrc
 
 # API Keys and Cryptographic Keys
 _keys/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,33 @@ repos:
         pass_filenames: false
         description: "Scans for hardcoded passwords, API keys, tokens, and secrets (excludes tests and placeholders)"
 
+      # Security: Block staged .env files (CLAUDE.md Security Essentials)
+      - id: env-file-staged
+        name: Block Staged .env Files
+        entry: bash
+        args:
+          - -c
+          - |
+            # Match .env, .env.local, .env.dev, .envrc, src/.env, etc.
+            # Does NOT match environment.py or example.env.txt (anchored on path segment).
+            # Case-insensitive (-i) to catch .ENV / .Env on Windows/macOS filesystems.
+            # Includes .envrc (direnv) which commonly holds exported secrets.
+            staged_env_files=$(git diff --cached --name-only --diff-filter=ACM | grep -iE '(^|/)\.env(rc)?($|\.)' || true)
+            if [ -n "$staged_env_files" ]; then
+              echo ""
+              echo "ERROR: Attempting to commit .env file(s):"
+              echo "$staged_env_files" | sed 's/^/  - /'
+              echo ""
+              echo "Environment files contain secrets and must not be committed."
+              echo "Unstage: git restore --staged <file>"
+              echo "Add to .gitignore if missing: echo '.env' >> .gitignore"
+              exit 1
+            fi
+            echo "No .env files staged"
+        language: system
+        pass_filenames: false
+        description: "Prevents committing .env files (which contain secrets)"
+
       # DEF-005: No print() in production code (use logger instead)
       - id: no-print-in-production
         name: No print() in Production Code


### PR DESCRIPTION
## Summary

First of four Tier 1 pre-commit hooks planned for Phase A' exit criterion #1. Adds a pre-commit hook that blocks commits containing staged environment files (`.env`, `.env.local`, `.envrc`, etc.) — the common secret-leakage vector that until now was only caught by the manual "before every commit" bash recipe in CLAUDE.md.

## Scope correction worth noting

The original Tier 1 PR 1 framing from `hook_inventory_proposal.md` was "consolidate 3 existing security checks (1.1 credential scan, 1.2 .env check, 1.3 Decimal lint) into explicit pre-commit entries." On scoping during session 51, hooks 1.1 and 1.3 turned out to already be implemented as `security-credentials` and `decimal-precision-check` in the current `.pre-commit-config.yaml`. **Only hook 1.2 (.env staged check) was missing.** Actual diff: +28/-0 across 2 files instead of the expected larger consolidation. Hook inventory doc will be updated in S52 to reflect the real state.

## What the new hook catches

- `.env`, `.env.local`, `.env.dev`, `.env.production` (the standard set)
- `service/.env`, `src/.env.dev` (subdirectory variants)
- **`.envrc`** (direnv — common secrets vector, explicitly requested by both Spock and Ripley as a **convergent finding** during review)
- **Case-insensitive** via `grep -iE` so `.ENV` / `.Env` get caught on Windows and case-insensitive macOS filesystems (CLAUDE.md rule 5 cross-platform requirement)

## What it correctly REJECTS (12-case false-positive sweep)

| Input | Behavior | Reason |
|---|---|---|
| `environment.py` | REJECT | no leading `/` or start before `.env` |
| `config/environment.yaml` | REJECT | `e` before `.env`, not `/` |
| `example.env.txt` | REJECT | `le` before `.env`, not `/` |
| `.environ` | REJECT | `i` after `.env`, not `$` or `.` |
| `my.env` | REJECT | `y` before `.env`, not `/` |
| `.env~` (editor backup) | REJECT | `~` after `.env` (deferred, see below) |

Verified by a 12-case regex sweep before commit.

## Defense-in-depth: .gitignore update

Added `.envrc` to `.gitignore` section \"Environment variables (contains passwords, API keys)\". This prevents `git add` from staging the file in the first place. The hook is the last-line defense if gitignore is bypassed with `git add -f`.

## Review cycle

- **Samwise (Builder, pattern-compliance frame):** Initial hook addition matching the existing security-class hook structure. Ran full pre-commit suite clean, tested blocking behavior with a seeded fake file, verified the false-positive rejection set.
- **Spock (Reviewer, pragmatic correctness):** APPROVE WITH COMMENTS. Flagged the `.envrc` gap (direnv secrets vector) as the only real issue; accepted regex anchoring, error message quality, and hook placement.
- **Ripley (Sentinel, highest-risk-first):** CLEAR WITH OBSERVATIONS. **Independently** flagged `.envrc` (convergent with Spock — the exact signal pattern Joe Chip's standing checklist in `roster_agents.md` was designed to surface), plus `.env~` editor backup files (deferred) and case-insensitive filesystem bypass (fixed).
- **PM (Tier 1 Momentum override):** Applied the `.envrc` regex fix (added `(rc)?` group), added `-i` flag for case-insensitivity, added `.envrc` to `.gitignore`. Re-ran the 12-case regex sweep and full pre-commit suite clean.

The convergent `.envrc` finding is exactly what happens when two independent reviewers land on the same issue without shared context — it's real, and it's why we run diff-scoped review even when the PR is small.

## Deferred to follow-up

- **`.env~` editor backup files** (Ripley F2) — low likelihood, rarely staged, defer to a later regex tightening
- **Server-side enforcement via branch protection** — Tier 1 is client-side only per `hook_inventory_proposal.md`; Tier 2 reminder injection hooks come in sessions 56-58

## Phase A' exit criterion #1 progress

| # | Hook | Status |
|---|---|---|
| 1.2 | `.env` / `.envrc` staged check | **THIS PR** |
| 1.4 | S75 CLI flag existence linter (#769) | S52 (PR 2) |
| 1.5 | Loose assertion ratchet with baseline | S53 (PR 3) |
| 1.6 | Mock target path verification with allowlist | S54 (PR 4) |

After this PR: **1/4 Tier 1 hooks live.** Phase A' exit criterion #1 is on track for S54 gate.

## Test plan

- [x] Unit tests: 2617 passed in 45.94s (pre-push)
- [x] Integration + E2E: 1197 passed, 20 skipped in 346.69s (pre-push)
- [x] Stress + Chaos + Race: 1063 passed in 193.30s (pre-push)
- [x] `pre-commit run --all-files`: 17 hooks pass (1 symlink check skipped, no files)
- [x] 12-case regex sweep: 6 matches correct, 6 rejections correct
- [ ] CI on PR open
- [ ] Claude Review — S68 audit in S52

## Related

- **#770** — Harness hook deployment 3-tier plan (this PR is Tier 1 PR 1 of 4)
- **#769** — S75 CLI flag existence linter (next Tier 1 hook, S52)
- **#781** — S50+S51 audit follow-up bundle (parallel Phase A' work, still in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)