### PR TITLE
fix: Document temporal_alignment_writer test gap in audit script

### DIFF
--- a/scripts/audit_test_type_coverage.py
+++ b/scripts/audit_test_type_coverage.py
@@ -153,7 +153,7 @@ MODULE_TIERS = {
     # TUI entries removed — TUI deleted in PR #563 (#558)
     # Schedulers
     "schedulers/espn_game_poller": "business",
-    "schedulers/temporal_alignment_writer": "business",
+    "schedulers/temporal_alignment_writer": "business",  # TODO: only unit tests exist — 7 test types missing, needs full suite
     # Priority-based polling (#560) — new module, promote to business when test suite expands
     "schedulers/league_priority": "experimental",
     # Validation


### PR DESCRIPTION
## Summary

- Mark temporal_alignment_writer as business tier with TODO for missing 7 test types in audit script
- Single-line fix to `scripts/audit_test_type_coverage.py`

The writer shipped in PR #747 (session 47) and is production code. The audit correctly flags the gap — the right fix is building the test suite, not hiding the classification.

Note: 11 CRUD modules also fail the audit after #803 removed stub tests. Real tests exist in combined files (`test_crud_operations_*`) but the per-module audit discovery doesn't map them. Pre-existing limitation; this PR does not address it.

## Test plan

- [x] Audit script runs without error
- [ ] CI Summary passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)