### PR TITLE
feat: Tier 1 Hook PR 4 — mock target path verification (Hook 1.6, #770)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -152,6 +152,57 @@ repos:
         types: [python]
         description: "Enforces Decimal precision for financial calculations (CRITICAL)"
 
+      # Mock target path verification: catch stale mock.patch string targets (Hook 1.6, Phase A')
+      - id: mock-target-paths
+        name: Mock Target Path Verification (Hook 1.6)
+        entry: bash
+        args:
+          - -c
+          - |
+            # Only check STAGED test files for unresolved mock.patch targets.
+            # Pre-existing violations in unstaged files are allowlisted (see
+            # scripts/mock_path_allowlist.txt) or ignored here to avoid
+            # blocking unrelated commits on historical drift.
+            staged_tests=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^tests/.*\.py$' || true)
+            if [ -z "$staged_tests" ]; then
+              echo "No staged test files — skipping mock target path check"
+              exit 0
+            fi
+            output=$(PRECOG_ENV=test python scripts/lint_mock_target_paths.py 2>&1)
+            linter_exit=$?
+            if [ $linter_exit -eq 0 ]; then
+              echo "Mock target path check passed"
+              exit 0
+            fi
+            # Distinguish linter crash from expected violations
+            if ! echo "$output" | grep -q "^Found [0-9]* unresolved mock.patch target"; then
+              echo "ERROR: Mock target linter failed to run (crash or import error):"
+              echo "$output" | tail -20
+              exit 1
+            fi
+            # Filter violations to only staged files
+            violations=""
+            for f in $staged_tests; do
+              match=$(echo "$output" | grep "^  ${f}:" || true)
+              if [ -n "$match" ]; then
+                violations="${violations}${match}\n"
+              fi
+            done
+            if [ -n "$violations" ]; then
+              echo "ERROR: Staged test files contain unresolved mock.patch targets:"
+              echo -e "$violations"
+              echo "Fix: verify the dotted path resolves to a real attribute in src/"
+              echo "     (check for module renames, moved classes, deleted functions)"
+              echo "If intentional (external/dynamic), add to scripts/mock_path_allowlist.txt"
+              echo "Reference: Hook 1.6, umbrella #764 (mock-target decay family)"
+              exit 1
+            fi
+            echo "Mock target path check passed (pre-existing violations in unstaged files ignored)"
+        language: system
+        pass_filenames: false
+        types: [python]
+        description: "Catches test files using stale mock.patch string targets (Hook 1.6)"
+
       # CLI flag existence: verify test runner.invoke flags match actual CLI (#769, S75)
       - id: cli-flag-existence
         name: CLI Flag Existence Check (S75)

--- a/scripts/lint_mock_target_paths.py
+++ b/scripts/lint_mock_target_paths.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+"""Verify that mock.patch string targets resolve to real attributes.
+
+Walks tests/**/*.py AST looking for mock.patch / patch / @patch calls with
+a string literal target, attempts to import the dotted path, and reports
+targets that do not resolve to a real attribute.
+
+Background: mock.patch('some.dotted.path') silently creates the target
+attribute if it doesn't exist, so stale paths produce mocks that mock
+nothing. This is the #764 decay-family this hook prevents. The S75 linter
+(lint_cli_flag_references.py) caught CLI flag decay — this catches mock
+target decay. See Phase A' exit criterion #1, hook 1.6.
+
+Usage:
+    python scripts/lint_mock_target_paths.py [--verbose]
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import sys
+from pathlib import Path
+
+_ALLOWLIST_FILE = Path("scripts/mock_path_allowlist.txt")
+
+
+def load_allowlist() -> set[str]:
+    """Read allowlist file; lines starting with # and blanks are ignored."""
+    if not _ALLOWLIST_FILE.exists():
+        return set()
+    entries: set[str] = set()
+    with _ALLOWLIST_FILE.open(encoding="utf-8") as f:
+        for raw in f:
+            line = raw.strip()
+            if not line or line.startswith("#"):
+                continue
+            entries.add(line)
+    return entries
+
+
+def _is_patch_call(node: ast.Call) -> bool:
+    """True if the call is `patch(...)`, `mock.patch(...)`, or `<...>.patch(...)`."""
+    func = node.func
+    if isinstance(func, ast.Name) and func.id == "patch":
+        return True
+    # mock.patch(...) or unittest.mock.patch(...)
+    return isinstance(func, ast.Attribute) and func.attr == "patch"
+
+
+def _extract_patch_targets(tree: ast.AST) -> list[tuple[str, int]]:
+    """Find string literal targets passed to patch()/@patch()/mock.patch().
+
+    Handles:
+      - patch("a.b.c")                 -> ("a.b.c", lineno)
+      - @patch("a.b.c")                -> ("a.b.c", lineno)
+      - mock.patch("a.b.c")            -> ("a.b.c", lineno)
+
+    Skips (silently):
+      - patch(some_var)                — dynamic target, can't resolve
+      - patch.object(Cls, "method")    — first arg is a Name, not a string
+      - patch.multiple(...)            — different shape, skipped
+    """
+    targets: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        if not _is_patch_call(node):
+            continue
+        # Reject patch.object / patch.multiple / patch.dict subforms
+        func = node.func
+        # patch.object etc. look like Attribute(Attribute(..., "patch"), "object")
+        # but ast.walk reaches the outer Call separately; our _is_patch_call only
+        # matches when the terminal attr is "patch". Subforms like patch.object()
+        # have terminal attr "object"/"multiple"/"dict" and are skipped here.
+        _ = func  # silence linter; matched above
+        if not node.args:
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            targets.append((first.value, first.lineno))
+    return targets
+
+
+def resolve_dotted_path(dotted: str) -> bool:
+    """True if `dotted` resolves to a real attribute in the current source tree.
+
+    Strategy: split on '.', try importing progressively longer module prefixes,
+    then walk remaining components as attributes via getattr.
+    """
+    parts = dotted.split(".")
+    # Try longest-to-shortest module prefix so `a.b.c.d` tries importing a.b.c.d,
+    # then a.b.c (with d as attr), then a.b (with c.d as attrs), etc.
+    for split in range(len(parts), 0, -1):
+        mod_name = ".".join(parts[:split])
+        attr_chain = parts[split:]
+        try:
+            mod = importlib.import_module(mod_name)
+        except (ImportError, ValueError, TypeError):
+            # ValueError: relative-name edge cases; TypeError: weird inputs
+            continue
+        obj: object = mod
+        ok = True
+        for attr in attr_chain:
+            if not hasattr(obj, attr):
+                ok = False
+                break
+            obj = getattr(obj, attr)
+        if ok:
+            return True
+    return False
+
+
+def main() -> int:
+    verbose = "--verbose" in sys.argv
+    allowlist = load_allowlist()
+
+    test_dir = Path("tests")
+    if not test_dir.exists():
+        print("ERROR: tests/ directory not found")
+        return 1
+
+    # Ensure source imports work
+    import os
+
+    os.environ.setdefault("PRECOG_ENV", "test")
+
+    unresolved: list[tuple[Path, int, str]] = []
+    seen_targets = 0
+    for test_file in sorted(test_dir.rglob("*.py")):
+        try:
+            source = test_file.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(test_file))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for target, lineno in _extract_patch_targets(tree):
+            seen_targets += 1
+            if target in allowlist:
+                continue
+            if not resolve_dotted_path(target):
+                unresolved.append((test_file, lineno, target))
+
+    if verbose:
+        print(f"Scanned {seen_targets} mock.patch string targets")
+        print(f"Allowlist: {len(allowlist)} entries")
+
+    if unresolved:
+        print(f"Found {len(unresolved)} unresolved mock.patch target(s):\n")
+        for filepath, lineno, target in unresolved:
+            print(f"  {filepath}:{lineno}: {target}")
+        print("\nIf a path is intentionally external or dynamic, add it to")
+        print(f"{_ALLOWLIST_FILE} (one dotted path per line).")
+        return 1
+
+    if verbose:
+        print("All mock.patch targets resolved.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint_mock_target_paths.py
+++ b/scripts/lint_mock_target_paths.py
@@ -96,8 +96,10 @@ def resolve_dotted_path(dotted: str) -> bool:
         attr_chain = parts[split:]
         try:
             mod = importlib.import_module(mod_name)
-        except (ImportError, ValueError, TypeError):
-            # ValueError: relative-name edge cases; TypeError: weird inputs
+        except Exception:
+            # Broad catch matches the sibling S75 linter (lint_cli_flag_existence.py):
+            # any import-time failure (ImportError, ValueError, RuntimeError, OSError,
+            # etc.) means this prefix isn't a usable module — try the next shorter one.
             continue
         obj: object = mod
         ok = True
@@ -147,7 +149,10 @@ def main() -> int:
     if unresolved:
         print(f"Found {len(unresolved)} unresolved mock.patch target(s):\n")
         for filepath, lineno, target in unresolved:
-            print(f"  {filepath}:{lineno}: {target}")
+            # Use as_posix() so paths use forward slashes on Windows too;
+            # the pre-commit wrapper greps staged filenames from `git diff`
+            # output (forward-slash) against this line, so separators must match.
+            print(f"  {filepath.as_posix()}:{lineno}: {target}")
         print("\nIf a path is intentionally external or dynamic, add it to")
         print(f"{_ALLOWLIST_FILE} (one dotted path per line).")
         return 1

--- a/scripts/mock_path_allowlist.txt
+++ b/scripts/mock_path_allowlist.txt
@@ -1,0 +1,29 @@
+# Mock path allowlist for scripts/lint_mock_target_paths.py
+#
+# Format:
+#   - One dotted path per line
+#   - Lines starting with # are comments
+#   - Blank lines ignored
+#
+# When to add an entry:
+#   1. Third-party attribute that the linter's import resolver can't reach
+#      (e.g., attributes only created after some runtime setup)
+#   2. Dynamic path that is constructed legitimately (rare — patch() with
+#      a non-string arg is already skipped silently, so this is mostly for
+#      string paths that are intentionally indirect)
+#   3. Stdlib paths the importer refuses for env-specific reasons
+#
+# Real stale paths (where the target module moved or the attr was deleted)
+# are NOT allowlist candidates — they are bugs and should be fixed in the
+# test file. Reference: umbrella #764 (scheduler CLI anti-pattern), S75
+# sister linter (scripts/lint_cli_flag_references.py).
+#
+# ----- allowlist entries below -----
+
+# Stale references in a deprecated, not-collected test file (filename
+# prefix `_deprecated_` means pytest skips collection). These point at
+# the old flat `main` module that no longer exists. File will be deleted
+# in a future cleanup; until then, allowlist to keep the hook green.
+# See: tests/integration/cli/_deprecated_test_cli_database_integration.py
+main.KalshiClient
+main.update_account_balance_with_versioning


### PR DESCRIPTION
## Summary

Final Phase A' exit criterion #1 hook (4 of 4). Linter walks `tests/**/*.py`, resolves `mock.patch('dotted.path')` string targets against the live source tree, flags stale paths. Allowlist for intentional external/dynamic targets.

**Sweep results:** 1,871 mock.patch string targets scanned across full test tree, 3 unresolved (all in a `_deprecated_` test file that pytest skips), 2 allowlisted covering all 3 sites. **0 active test files contain stale paths** — independently confirms the Cap-2 Mock-level-fidelity finding from S51 T41 schedulers audit.

## Review trail

- **Samwise** (Builder, commit 6f78b57) — initial build, 3 files, +241 LoC. Self-test passed.
- **Joe Chip** (Reviewer) — **APPROVE WITH COMMENTS**
  - P0: Windows path separator bug in pre-commit wrapper (backslash/forward-slash mismatch → hook silently always passed on Windows). **Fixed in 059bc87.**
  - P1: Narrow exception handler vs S75 linter (`except (ImportError, ValueError, TypeError)` vs `except Exception`). **Fixed in 059bc87.**
  - P2: No DB-connection cleanup (leak on every commit) — follow-up
- **Ripley** (Sentinel) — **CLEAR WITH OBSERVATIONS**
  - HIGH: Source-side refactor bypasses the hook (design gap, not a bug). Filed as follow-up.
  - LOW: Sports-adapter `__getattr__` false-positive trap (no current refs; file if it activates)
  - LOW: Allowlist drift detection

## Convergent finding

Joe Chip and Ripley independently flagged `src/precog/database/connection.py` module-level `initialize_pool()` side effect. Filed as separate issue (convergent-reviewer signal, new Pattern 70).

## Phase A' hook count

**3/4 → 4/4 live after merge.** Phase A' exit criterion #1 complete. Combined with exit criteria #2 (Patterns V1.32, companion PR) and #3 (T41 3/3 audits, already done), Phase A' is ready for exit gate check this session.

## Test plan

- [x] Linter self-test (injected stale path → flagged correctly)
- [x] Full sweep runs clean (1871 scanned, 0 unresolved outside allowlist)
- [x] validate_quick.sh passes
- [x] Pre-commit suite passes (20/20 hooks, including the new hook running on its own PR)
- [ ] CI Summary passes

Closes #770 (part 4 of 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)