### PR TITLE
test: S55 chip-away — tighten 3 loose exit-code assertions (#799)

### DIFF
--- a/tests/unit/cli/test_cli_system.py
+++ b/tests/unit/cli/test_cli_system.py
@@ -137,7 +137,7 @@ class TestSystemVersion:
         """Test version command shows version information."""
         result = cli_runner.invoke(app, ["version"])
 
-        assert result.exit_code in [0, 1]
+        assert result.exit_code == 0
         # Should show some version-related info
         output_lower = strip_ansi(result.stdout).lower()
         assert "version" in output_lower or "precog" in output_lower or "0." in output_lower
@@ -157,7 +157,7 @@ class TestSystemInfo:
         """Test info command shows system diagnostics."""
         result = cli_runner.invoke(app, ["info"])
 
-        assert result.exit_code in [0, 1]
+        assert result.exit_code == 0
         output_lower = strip_ansi(result.stdout).lower()
         # Should show some system info
         assert "python" in output_lower or "system" in output_lower or "info" in output_lower
@@ -166,7 +166,7 @@ class TestSystemInfo:
         """Test info shows Python version."""
         result = cli_runner.invoke(app, ["info"])
 
-        assert result.exit_code in [0, 1]
+        assert result.exit_code == 0
         # Python info should be present
         output_lower = strip_ansi(result.stdout).lower()
         assert "python" in output_lower or "3." in output_lower


### PR DESCRIPTION
## Summary

Session 55 standing-task chip-away against #799 loose-assertion ratchet. 3 tightenings in `tests/unit/cli/test_cli_system.py` where the target CLI command (version/info) has no DB dependencies and clearly returns exit 0 on success.

## What changed

- `test_version_shows_info` — `[0, 1]` → `== 0`
- `test_info_shows_diagnostics` — `[0, 1]` → `== 0`
- `test_info_shows_python_version` — `[0, 1]` → `== 0`

## What was left loose (intentionally)

Attempted to tighten `test_health_database_check` and `test_health_verbose` — failed. The `system health` command returns exit 1 even with `get_cursor` mocked, revealing an actual test-intent gap that needs per-test analysis, not mechanical tightening.

**Filed as #816** — separate follow-up for CLI health test mock-fidelity audit. This is exactly the decay pattern Pattern 66 (strict exit codes) is designed to surface.

## Baseline impact

Current ratchet baseline: 133 (post #808 S54). Target after this PR: 130.
Net session chip-away: -3 (below the ~10 target, but the hidden gap surfaced in #816 is worth more than rushing to 10).

## Test plan

- [x] `pytest tests/unit/cli/test_cli_system.py::TestSystemVersion tests/unit/cli/test_cli_system.py::TestSystemInfo` — 4 passed (3 tightened + 1 adjacent)
- [ ] CI Summary passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)