### PR TITLE
feat: G1 doc version drift pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -291,6 +291,15 @@ repos:
         types: [python]
         description: "Catches test files using nonexistent CLI flags (S75, #769)"
 
+      # G1: Doc version drift — block versioned-doc renames with stale cross-references
+      - id: doc-version-drift
+        name: Doc Version Drift (G1)
+        entry: python scripts/lint_doc_version_refs.py
+        language: system
+        pass_filenames: false
+        types: [markdown]
+        description: "Blocks versioned-doc renames (_V<N>.<M>.md) when stale references to the old filename exist elsewhere in the repo (G1)"
+
   # Standard pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/scripts/lint_doc_version_refs.py
+++ b/scripts/lint_doc_version_refs.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""Doc version drift linter (G1).
+
+Blocks a commit that renames a versioned documentation file (pattern:
+``_V<major>.<minor>.md``) while leaving references to the old filename
+elsewhere in the repo. The common failure this prevents: promoting
+``DEVELOPMENT_PATTERNS_V1.31.md`` to ``_V1.32.md`` while other guides,
+CLAUDE.md, or cross-references still hardcode the old version suffix.
+
+Exit codes:
+    0 -- no staged renames matching the versioned-doc pattern, or renames
+        present and all old-filename references updated (or absent).
+    1 -- staged rename(s) found with stale references still pointing at
+        the old filename; lists them for the developer.
+    2 -- internal tool error (git unavailable, unexpected git output).
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+VERSION_PATTERN = re.compile(r"_V\d+\.\d+\.md$")
+EXCLUDE_DIR_RE = re.compile(r"(^|/)_archive(/|$)")
+
+
+def get_staged_versioned_renames() -> list[tuple[str, str]]:
+    """Return [(old_path, new_path), ...] for staged renames whose
+    source and destination both match the versioned-doc pattern.
+    """
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-status", "--diff-filter=R"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        print(f"ERROR: git diff failed: {result.stderr}", file=sys.stderr)
+        sys.exit(2)
+
+    renames: list[tuple[str, str]] = []
+    for line in result.stdout.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 3 or not parts[0].startswith("R"):
+            continue
+        _, old, new = parts
+        if VERSION_PATTERN.search(old) and VERSION_PATTERN.search(new):
+            renames.append((old, new))
+    return renames
+
+
+def find_stale_references(old_path: str) -> list[tuple[str, int, str]]:
+    """Return [(file, line_number, line_content), ...] for refs to the old
+    filename in tracked files, excluding the old file itself and _archive/.
+    """
+    result = subprocess.run(
+        ["git", "grep", "-nF", "--", old_path],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode not in (0, 1):
+        print(f"ERROR: git grep failed: {result.stderr}", file=sys.stderr)
+        sys.exit(2)
+
+    hits: list[tuple[str, int, str]] = []
+    for line in result.stdout.splitlines():
+        match = re.match(r"^([^:]+):(\d+):(.*)$", line)
+        if not match:
+            continue
+        fname, lno, content = match.group(1), int(match.group(2)), match.group(3)
+        if fname == old_path:
+            continue
+        if EXCLUDE_DIR_RE.search(fname):
+            continue
+        hits.append((fname, lno, content))
+    return hits
+
+
+def main() -> int:
+    renames = get_staged_versioned_renames()
+    if not renames:
+        print("No versioned-doc renames staged -- skipping doc drift check")
+        return 0
+
+    any_stale = False
+    for old, new in renames:
+        print(f"Checking references to {old} (renamed to {new})...")
+        stale = find_stale_references(old)
+        if stale:
+            any_stale = True
+            print(f"ERROR: {len(stale)} stale reference(s) to {old}:")
+            for fname, lno, content in stale:
+                print(f"  {fname}:{lno}: {content.rstrip()[:120]}")
+
+    if any_stale:
+        print()
+        print("Fix: update the stale references to the new filename,")
+        print("     OR move the old file to _archive/ (its refs are ignored).")
+        print("Reference: G1 doc-drift hook")
+        return 1
+
+    print("Doc drift check passed (no stale refs for renamed versioned docs)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- New pre-commit hook (G1) that blocks commits which rename a versioned documentation file (pattern \`_V<N>.<M>.md\`) while leaving references to the old filename elsewhere in the repo.
- Prevents the recurring drift pattern: promoting e.g. \`DEVELOPMENT_PATTERNS_V1.31.md\` to \`_V1.32.md\` while CLAUDE.md, other guides, or cross-references still hardcode the old version suffix. Patterns V1.32 promotion (PR #815, currently auto-merge queued) is the next likely real-world test.

## Changes
- `scripts/lint_doc_version_refs.py` — ~90 LoC. Uses `git diff --cached --name-status --diff-filter=R` to find staged rename pairs where both sides match `_V\d+\.\d+\.md$`. Runs `git grep -nF` to find references to the old filename in tracked files. Excludes `_archive/` so historical refs don't produce false positives.
- `.pre-commit-config.yaml` — adds hook entry `doc-version-drift` (G1) with `types: [markdown]` so it skips for non-markdown commits.

## Design notes
- **Option B refined** from the S56 G1 design discussion — "warn-only" (Option A) was rejected because reminders are weak signal; "reverse drift" (Option C) was rejected due to governance-map maintenance tax.
- **Why rename-based detection**: Catches the actual failure mode (stale cross-refs after version bumps) without emitting noise on ADR-text edits or docs-only PRs. Rename is the definitive trigger.
- **Why `git grep -nF`**: Fixed-string match (no regex escaping surprises), tracked-files-only (never searches `.git/`, build artifacts, venvs), returns file:line:content format usable without further parsing.

## Test plan
- [x] YAML syntax valid (pre-commit `Validate YAML Syntax` passed)
- [x] Dry-run on current branch with no staged renames → prints skip message, exit 0
- [x] Pre-commit runs hook as `Doc Version Drift (G1)` with correct skip behavior for non-markdown commits
- [ ] First real-world test: when PR #815 (DEVELOPMENT_PATTERNS V1.32) merges, the next versioned-doc promotion should exercise this hook

## Notes
- Follows same no-unit-test precedent as `lint_cli_flag_references.py` (S75) and `lint_mock_target_paths.py` (Hook 1.6) — logic is simple subprocess + regex, validated via pre-commit integration. Follow-up issue could bundle unit tests for all three linter scripts if desired.
- ASCII-only output per CLAUDE.md Pattern 5 (no em-dashes in print statements to avoid cp1252 render garbage on Windows terminals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)