### PR TITLE
feat: Auto-update BEHIND PR branches workflow (merge-queue fallback)

### DIFF
--- a/.github/workflows/auto-update-pr-branches.yml
+++ b/.github/workflows/auto-update-pr-branches.yml
@@ -1,0 +1,72 @@
+name: Auto-Update PR Branches
+
+# Purpose
+# Closes the "auto-merge enabled but branch stays BEHIND main" failure mode.
+# When a PR has auto-merge queued and passes all CI checks but its branch is
+# BEHIND main, GitHub waits indefinitely for a human to click "Update branch".
+# This workflow runs after every push to main and auto-updates every such PR.
+#
+# Without this workflow, PRs sit queued-but-stuck for days (observed: #815
+# stalled 26 hours, #797 stalled 2 days). Merge Queue would solve this
+# natively but is not available in the current GitHub UI for this repo.
+#
+# The workflow is idempotent: re-running is safe, and a race with a manual
+# "Update branch" click just results in one extra no-op call.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Update BEHIND PRs with auto-merge enabled
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          echo "Listing open PRs with auto-merge enabled and BEHIND status..."
+
+          # Find open PRs where auto-merge is enabled AND the branch is BEHIND main.
+          # Exclude CONFLICTING (manual resolution needed) and DIRTY (conflicts).
+          candidates=$(gh pr list \
+            --state open \
+            --limit 50 \
+            --json number,mergeStateStatus,autoMergeRequest,mergeable \
+            --jq '.[]
+              | select(.autoMergeRequest != null)
+              | select(.mergeStateStatus == "BEHIND")
+              | select(.mergeable != "CONFLICTING")
+              | .number')
+
+          if [ -z "$candidates" ]; then
+            echo "No PRs to update."
+            exit 0
+          fi
+
+          echo "Candidate PRs: $candidates"
+
+          failures=0
+          for pr in $candidates; do
+            echo "--- Updating PR #$pr ---"
+            if gh pr update-branch "$pr"; then
+              echo "OK: #$pr branch updated"
+            else
+              echo "WARN: #$pr update failed (may need manual resolution)"
+              failures=$((failures + 1))
+            fi
+          done
+
+          echo "Done. $failures failure(s)."
+          # Never fail the workflow on a per-PR update failure — failures are
+          # informational, not critical. The PR stays BEHIND and a human can
+          # resolve it the old-fashioned way.
+          exit 0


### PR DESCRIPTION
## Summary

Closes the "auto-merge enabled but branch stays BEHIND main" failure mode observed on **#815 (26h stall)** and **#797 (2-day stall)**. GitHub's auto-merge waits indefinitely for a human to click "Update branch" when branch protection requires up-to-date-with-main.

**Why not Merge Queue:** Merge Queue would solve this natively, but it is not available in this repo's GitHub UI (verified in both Classic Branch Protection and Repository Rulesets configurations). GHA workflow is the platform-independent fallback.

## How it works

- Triggers on every \`push\` to \`main\` + manual \`workflow_dispatch\`
- Lists open PRs where \`autoMergeRequest != null\` AND \`mergeStateStatus == "BEHIND"\`
- Skips PRs where \`mergeable == "CONFLICTING"\` (needs human resolution)
- Calls \`gh pr update-branch\` on each
- Never fails the workflow on per-PR update failures (informational only)
- Idempotent and race-safe with manual "Update branch" clicks

## Test plan

- [ ] Workflow syntax validates (confirmed locally via pre-commit YAML check ✓)
- [ ] After merge, the next push to \`main\` fires the workflow
- [ ] Workflow completes without error on a \`main\` push when no BEHIND PRs exist
- [ ] Next time a PR sits BEHIND with auto-merge enabled, workflow updates it within ~1-2 min

## Permissions used

- \`pull-requests: write\` (for \`gh pr update-branch\`)
- \`contents: write\` (GitHub API transitively requires for update-branch)

**Watch for:** If branch protection rejects \`GITHUB_TOKEN\` updates to protected branches, the workflow may see 403s in logs. Fix: add \`github-actions[bot]\` to the branch-protection bypass list. We'll know from the first real-world run.

Closes task #8 from session 57 plan (Merge Queue enable directive from user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)