### PR TITLE
feat: #725 missing FKs migration 0059 + SCD copy-forward (items 1-7)

### DIFF
--- a/src/precog/database/alembic/versions/0059_missing_fks_provenance_chain.py
+++ b/src/precog/database/alembic/versions/0059_missing_fks_provenance_chain.py
@@ -1,0 +1,207 @@
+"""Add 7 missing foreign keys to complete the provenance chain.
+
+Closes #725 items 1-7. Item 11 (orderbook_snapshots wiring for orders/edges)
+is explicitly deferred to a follow-up migration 0060 per Holden's S57
+split recommendation — it is design-decision-heavy and splitting lets
+items 1-7 land clean. Items 8-10 are deferred to #726 (Cohort C3 analytics
+enrichment) because they overlap with the analytics re-wiring there.
+
+Revision ID: 0059
+Revises: 0058
+Create Date: 2026-04-15
+
+Issues: #725 (items 1-7)
+Epic: #745 (Schema Hardening Arc, residual from C2)
+
+Design review:
+    Holden (S57) — design memo authoritative. Recommended split (0060 items
+    1-7 + 0061 item 11) onto post-0058 main. This migration is numbered
+    0059 per task-brief instruction because 0058 is the latest on disk
+    and there is no other 0059 in the versions tree.
+
+Council attribution:
+    Holden (Principled Steward) — provenance FK gap identified alongside
+    #724/#725 scoping, S44 C1 review.
+
+Columns added (all nullable, all ON DELETE RESTRICT per ADR-116):
+
+    1. positions.edge_id            → edges(id)             [SCD parent]
+    2. settlements.position_id      → positions(id)         [SCD parent]
+    3. settlements.order_id         → orders(id)
+    4. position_exits.order_id      → orders(id)
+    5. exit_attempts.order_id       → orders(id)
+    6. edges.market_snapshot_id     → market_snapshots(id)  [SCD parent]
+    7. edges.prediction_id          → predictions(id)       [append-only]
+
+Why nullable:
+    Forward-only adoption. Every one of the 7 child tables already has
+    rows (production and test). Adding NOT NULL would force a backfill
+    decision per row, which is out of scope for a provenance-FK wiring
+    migration. Nullable + ``NOT VALID``-free instant validation (empty
+    constraint) keeps this as a pure metadata ALTER.
+
+Why RESTRICT:
+    Matches 0057's RESTRICT conversion. RESTRICT blocks parent deletion
+    when children reference the parent; SET NULL would silently orphan
+    provenance; CASCADE would silently destroy downstream records. For a
+    provenance chain, RESTRICT is the only defensible default.
+
+Why partial indexes:
+    Each new column is NULL-dominant at time of creation (all existing
+    rows are NULL). A full index would bloat with NULLs. Partial indexes
+    WHERE ``<col> IS NOT NULL`` keep the index tight while still giving
+    lookup speed for non-NULL rows.
+
+Naming:
+    Constraints follow PostgreSQL's auto-naming convention
+    ``{child_table}_{child_column}_fkey`` to match 0057's ``NAMED_CONSTRAINTS``
+    fallback. information_schema discovery will pick them up without a
+    dict entry.
+
+SCD co-requirement (highest risk, addressed in the SAME PR):
+    Columns 1, 6, 7 target SCD Type 2 tables (positions, edges, edges).
+    Without updating the SCD *supersede* INSERT column lists in
+    ``crud_positions.py``, every position-version update would silently
+    set ``edge_id = NULL`` on the new version — the equivalent of
+    SET NULL cascade, exactly the behavior 0057 was built to eliminate.
+    This PR therefore also ships:
+        - ``crud_positions.py``: 3 supersede INSERTs gain ``edge_id``
+          sourced from ``current["edge_id"]`` (Pattern 49 copy-forward).
+        - ``tests/integration/database/test_scd_copy_forward.py``:
+          regression test asserting the contract.
+    For ``edges``, no SCD supersede path exists today in the codebase
+    (only ``create_edge`` + direct ``UPDATE`` lifecycle transitions
+    filtered by ``row_current_ind = TRUE``). The ``create_edge`` helper
+    was NOT changed because the two new FK columns will default to
+    ``NULL`` on write and can be populated later when callers have
+    provenance context. When a genuine SCD supersede path is later
+    added for edges (e.g. on price drift), the Pattern 49 copy-forward
+    checklist must be applied there too — see design memo §6 and the
+    checklist comment at the top of ``crud_positions.py`` add for the
+    pattern to follow.
+
+Naming collision note:
+    ``positions.edge_id`` (new) is the surrogate FK to ``edges(id)``
+    — the edge row that produced the position. ``positions.edge_at_entry``
+    (existing, DECIMAL) is the numeric edge value captured at entry time.
+    Distinct semantics; a ``COMMENT ON COLUMN`` is added to make the
+    distinction explicit at the DB level.
+
+Write-protection trigger interaction (0056):
+    ``ALTER TABLE ADD COLUMN`` is DDL and bypasses 0056's row-level
+    write-protection triggers, which fire on INSERT/UPDATE/DELETE. No
+    ``session_replication_role`` adjustment is required. Verified by
+    reading 0056 before authoring this migration.
+
+Downgrade semantics:
+    Forward-only backfill is lost on downgrade (any rows that had
+    non-NULL values revert to having never had the column). Documented
+    per Holden memo §5. Safe because on day-of-land every row is NULL;
+    downgrade discipline over time is a separate process concern.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0059"
+down_revision: str = "0058"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# =============================================================================
+# FK addition specification
+# =============================================================================
+# Each tuple: (child_table, child_column, parent_table, parent_column)
+# All constraints use ON DELETE RESTRICT (ADR-116).
+# All columns are nullable INTEGER (forward-only adoption).
+# All columns get a partial index WHERE <col> IS NOT NULL.
+
+MISSING_FKS: list[tuple[str, str, str, str]] = [
+    # Item 1: positions provenance back to the edge that triggered it
+    ("positions", "edge_id", "edges", "id"),
+    # Item 2: settlements back to the originating position
+    ("settlements", "position_id", "positions", "id"),
+    # Item 3: settlements back to the originating order
+    ("settlements", "order_id", "orders", "id"),
+    # Item 4: position_exits back to the exit-order
+    ("position_exits", "order_id", "orders", "id"),
+    # Item 5: exit_attempts back to the exit-order
+    ("exit_attempts", "order_id", "orders", "id"),
+    # Item 6: edges back to the market_snapshot used at edge calculation
+    ("edges", "market_snapshot_id", "market_snapshots", "id"),
+    # Item 7: edges back to the prediction row that produced the probability
+    ("edges", "prediction_id", "predictions", "id"),
+]
+
+
+def _fk_name(child_table: str, child_column: str) -> str:
+    """Return the auto-naming FK constraint name used by PostgreSQL.
+
+    Matches the ``{table}_{column}_fkey`` pattern that 0057's
+    ``_get_constraint_name`` falls back to when no entry exists in
+    ``NAMED_CONSTRAINTS``. Keeps future information_schema discovery
+    simple.
+    """
+    return f"{child_table}_{child_column}_fkey"
+
+
+def _index_name(child_table: str, child_column: str) -> str:
+    """Return the partial-index name for a new FK column."""
+    return f"idx_{child_table}_{child_column}"
+
+
+def upgrade() -> None:
+    """Add 7 nullable FK columns with RESTRICT + partial indexes."""
+    for child_table, child_column, parent_table, parent_column in MISSING_FKS:
+        constraint_name = _fk_name(child_table, child_column)
+        index_name = _index_name(child_table, child_column)
+
+        # Combined column-add + FK constraint. Postgres validates the
+        # constraint instantly because the column is nullable and no
+        # existing rows violate it (all NULL).
+        op.execute(
+            f"""
+            ALTER TABLE {child_table}
+            ADD COLUMN {child_column} INTEGER
+            CONSTRAINT {constraint_name}
+            REFERENCES {parent_table}({parent_column}) ON DELETE RESTRICT
+            """
+        )
+
+        # Partial index to keep the NULL-dominant column's index tight.
+        op.execute(
+            f"""
+            CREATE INDEX {index_name}
+            ON {child_table}({child_column})
+            WHERE {child_column} IS NOT NULL
+            """
+        )
+
+    # Clarifying comment on positions.edge_id — distinguishes the new
+    # FK column from the pre-existing DECIMAL ``edge_at_entry`` column.
+    # Holden's memo §2 flagged this as a naming-collision risk that would
+    # confuse future readers without an explicit DB-level comment.
+    op.execute(
+        """
+        COMMENT ON COLUMN positions.edge_id IS
+        'Provenance FK to edges(id) — the edge row that produced this '
+        'position. Distinct from edge_at_entry which stores the numeric '
+        'edge value (probability - market_price) captured at entry time. '
+        'Added in migration 0059 for #725.'
+        """
+    )
+
+
+def downgrade() -> None:
+    """Drop the 7 FK columns + partial indexes. Forward-only data is lost."""
+    # Drop in reverse order of upgrade so indexes come down before their
+    # backing columns (Postgres tolerates either order today, but the
+    # explicit teardown sequence matches the upgrade narrative).
+    for child_table, child_column, _parent_table, _parent_column in reversed(MISSING_FKS):
+        index_name = _index_name(child_table, child_column)
+        op.execute(f"DROP INDEX IF EXISTS {index_name}")
+        # ``DROP COLUMN`` cascades the FK constraint automatically.
+        op.execute(f"ALTER TABLE {child_table} DROP COLUMN IF EXISTS {child_column}")

--- a/src/precog/database/crud_positions.py
+++ b/src/precog/database/crud_positions.py
@@ -171,6 +171,10 @@ def create_position(
     # ⭐ ATTRIBUTION ARCHITECTURE (Migration 020) - NEW parameters
     calculated_probability: Decimal | None = None,
     market_price_at_entry: Decimal | None = None,
+    # Provenance FK (migration 0059, #725): the edge row that produced
+    # this position. Optional — callers without edge provenance pass
+    # None and the column stays NULL (forward-only adoption).
+    edge_id: int | None = None,
 ) -> int:
     """
     Create new position with status = 'open' and immutable entry-time attribution.
@@ -268,6 +272,12 @@ def create_position(
         edge_at_entry = calculated_probability - market_price_at_entry
 
     # Step 1: INSERT with placeholder position_key (will be updated immediately)
+    #
+    # Migration 0059 (#725): ``edge_id`` carries provenance back to the
+    # ``edges`` row that produced this position. Nullable; callers
+    # without edge context pass None. Must also appear in every SCD
+    # supersede INSERT below so Pattern 49 copy-forward does not silently
+    # NULL it on version transitions. Design memo: #725 Holden S57 §6.
     insert_query = """
         INSERT INTO positions (
             position_key, market_id, strategy_id, model_id, side,
@@ -276,9 +286,15 @@ def create_position(
             trailing_stop_state, position_metadata,
             status, row_current_ind, entry_time,
             calculated_probability, edge_at_entry, market_price_at_entry,
-            execution_environment
+            execution_environment,
+            edge_id
         )
-        VALUES ('TEMP', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'open', TRUE, NOW(), %s, %s, %s, %s)
+        VALUES (
+            'TEMP', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+            'open', TRUE, NOW(),
+            %s, %s, %s, %s,
+            %s
+        )
         RETURNING id
     """
 
@@ -310,6 +326,7 @@ def create_position(
         edge_at_entry,
         market_price_at_entry,
         execution_environment,
+        edge_id,
     )
 
     with get_cursor(commit=True) as cur:
@@ -585,6 +602,12 @@ def update_position_price(
             # as the JSONB string ``"null"`` instead of a SQL NULL, silently
             # breaking ``WHERE trailing_stop_state IS NULL`` queries. Fixes
             # #666 (latent dict-adapter bug on the update path).
+            # Migration 0059 (#725) Pattern 49 copy-forward checklist:
+            #   edge_id must appear in this INSERT's column list AND its
+            #   params tuple, sourced from current["edge_id"]. Omitting
+            #   either silently NULLs the provenance FK on the new SCD
+            #   version — the exact SET NULL behavior 0057 was built to
+            #   prevent. See migration 0059 docstring and Holden memo §6.
             cur.execute(
                 """
                 INSERT INTO positions (
@@ -594,9 +617,18 @@ def update_position_price(
                     target_price, stop_loss_price,
                     trailing_stop_state, position_metadata,
                     status, entry_time, last_check_time, execution_environment,
+                    edge_id,
                     row_start_ts
                 )
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                VALUES (
+                    %s, %s, %s, %s, %s, %s, %s,
+                    %s, %s,
+                    %s, %s,
+                    %s, %s,
+                    %s, %s, %s, %s,
+                    %s,
+                    %s
+                )
                 RETURNING id
                 """,
                 (
@@ -620,6 +652,7 @@ def update_position_price(
                     current["entry_time"],
                     now,  # last_check_time
                     current["execution_environment"],  # Preserve execution environment
+                    current["edge_id"],  # Pattern 49 copy-forward (#725, migration 0059)
                     now,  # row_start_ts
                 ),
             )
@@ -792,6 +825,12 @@ def close_position(
             # ``current["trailing_stop_state"]`` was already decoded from
             # JSONB to a plain ``dict`` by psycopg2's JSONB adapter when the
             # row was re-fetched on line 693 above, so it is safe to rewrap.
+            # Migration 0059 (#725) Pattern 49 copy-forward checklist:
+            #   edge_id must appear in this INSERT's column list AND its
+            #   params tuple, sourced from current["edge_id"]. Omitting
+            #   either silently NULLs the provenance FK on the new SCD
+            #   version — the exact SET NULL behavior 0057 was built to
+            #   prevent. See migration 0059 docstring and Holden memo §6.
             cur.execute(
                 """
                 INSERT INTO positions (
@@ -801,9 +840,18 @@ def close_position(
                     target_price, stop_loss_price,
                     trailing_stop_state, position_metadata,
                     status, entry_time, exit_time, execution_environment,
+                    edge_id,
                     row_start_ts
                 )
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'closed', %s, %s, %s, %s)
+                VALUES (
+                    %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                    %s,
+                    %s, %s,
+                    %s, %s,
+                    'closed', %s, %s, %s,
+                    %s,
+                    %s
+                )
                 RETURNING id
                 """,
                 (
@@ -826,6 +874,7 @@ def close_position(
                     current["entry_time"],
                     now,  # exit_time
                     current["execution_environment"],  # Preserve execution environment
+                    current["edge_id"],  # Pattern 49 copy-forward (#725, migration 0059)
                     now,  # row_start_ts
                 ),
             )
@@ -1096,6 +1145,12 @@ def set_trailing_stop_state(
             # a JSONB column. The sibling ``update_position_price``,
             # ``close_position``, and ``create_position`` functions were
             # updated to adopt the same pattern (#666, #706).
+            # Migration 0059 (#725) Pattern 49 copy-forward checklist:
+            #   edge_id must appear in this INSERT's column list AND its
+            #   params tuple, sourced from current["edge_id"]. Omitting
+            #   either silently NULLs the provenance FK on the new SCD
+            #   version — the exact SET NULL behavior 0057 was built to
+            #   prevent. See migration 0059 docstring and Holden memo §6.
             cur.execute(
                 """
                 INSERT INTO positions (
@@ -1108,6 +1163,7 @@ def set_trailing_stop_state(
                     exit_price, exit_reason, exit_time,
                     calculated_probability, edge_at_entry, market_price_at_entry,
                     execution_environment,
+                    edge_id,
                     row_start_ts, row_current_ind
                 )
                 VALUES (
@@ -1119,6 +1175,7 @@ def set_trailing_stop_state(
                     %s, %s, %s,
                     %s, %s, %s,
                     %s, %s, %s,
+                    %s,
                     %s,
                     %s, TRUE
                 )
@@ -1157,6 +1214,7 @@ def set_trailing_stop_state(
                     current["edge_at_entry"],
                     current["market_price_at_entry"],
                     current["execution_environment"],  # Preserve execution environment
+                    current["edge_id"],  # Pattern 49 copy-forward (#725, migration 0059)
                     now,  # row_start_ts
                 ),
             )

--- a/tests/integration/database/test_scd_copy_forward.py
+++ b/tests/integration/database/test_scd_copy_forward.py
@@ -1,0 +1,355 @@
+"""Integration tests for the SCD Type 2 copy-forward contract on positions.edge_id.
+
+Migration 0059 (#725) added ``positions.edge_id`` as a nullable FK to
+``edges(id)``. The highest risk at land time is that any SCD supersede
+path whose INSERT column list omits ``edge_id`` will silently NULL the
+provenance FK on the new version — the exact SET NULL behavior 0057
+was built to prevent. Design memo: #725 Holden S57 §6 (the "critical
+SCD copy-forward risk" section).
+
+This file asserts the contract against a real PostgreSQL database
+(testcontainer per ADR-057):
+
+    Given an SCD current row with a non-NULL ``edge_id``,
+    When any supersede path fires,
+    Then the NEW current version carries the SAME ``edge_id`` forward.
+
+Three supersede paths are covered — one test per path so a regression
+in any one path is surfaced immediately with a precise failure signal:
+
+    1. ``update_position_price`` (crud_positions.py line ~598)
+    2. ``close_position`` (crud_positions.py line ~810)
+    3. ``set_trailing_stop_state`` (crud_positions.py line ~1113)
+
+Why this test uses a real DB (not mocks):
+    The Mock Fidelity Rule (protocols.md) explicitly prohibits
+    pure-function mocks for SCD code (failure mode A, temporal
+    coupling) — the supersede path's read-then-write transaction
+    semantics are exactly the thing that broke silently in #629.
+    This test fills the same integration gap
+    ``test_crud_positions_trailing_stop_integration.py`` filled for
+    the trailing-stop rewrite, but for the provenance-FK contract.
+
+Non-goals:
+    - Edge-side copy-forward: no SCD supersede path exists for edges
+      today; ``edges.market_snapshot_id`` and ``edges.prediction_id``
+      are written by ``create_edge`` only (NULL by default), and the
+      two live mutators (``update_edge_outcome`` / ``update_edge_status``)
+      are direct UPDATEs filtered by ``row_current_ind = TRUE`` (lifecycle
+      events, not SCD versions). When a true SCD supersede path is later
+      added for edges, the Pattern 49 copy-forward checklist at the top
+      of each ``INSERT INTO positions (...)`` call in crud_positions.py
+      must be applied there too.
+    - ``create_position`` happy-path: covered by every other position
+      integration test. The new ``edge_id`` parameter is exercised
+      indirectly here via the fixture setup.
+
+Issues: #725 (items 1-7, migration 0059)
+Markers:
+    @pytest.mark.integration: real DB required (testcontainer per ADR-057)
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from precog.database.connection import get_cursor
+from precog.database.crud_positions import (
+    close_position,
+    create_position,
+    set_trailing_stop_state,
+    update_position_price,
+)
+
+# Test identifiers reserved for this suite. TEST- prefix so suite-wide
+# ``clean_test_data`` regex picks up any orphaned rows.
+_TEST_TICKER = "TEST-INT-725-SCD-MKT"
+_TEST_POSITION_BK_PREFIX = "TEST-INT-725-POS-"
+
+
+# =============================================================================
+# Fixture
+# =============================================================================
+
+
+@pytest.fixture
+def position_with_edge(db_pool: Any) -> Any:
+    """Seed market, edge, and open position linked via edge_id; teardown after.
+
+    The fixture creates:
+      - a test market,
+      - a test ``edges`` row (minimum-required columns; row_current_ind=TRUE),
+      - an open position created via ``create_position`` with the new
+        ``edge_id`` parameter set to the edge's surrogate id.
+
+    Yields (position_surrogate_id, position_business_key, market_pk, edge_pk)
+    so each test can:
+      - address the position by its surrogate id (the CRUD entry point),
+      - verify state by business key (the SCD chain identifier),
+      - assert ``edge_id`` values against the seeded ``edge_pk``.
+
+    Uses ``get_cursor(commit=True)`` so rows survive to the next supersede
+    transaction (the supersede helpers commit their own writes).
+    """
+    position_bk = f"{_TEST_POSITION_BK_PREFIX}1"
+
+    from tests.fixtures.cleanup_helpers import delete_market_with_children
+
+    # --- Setup ---------------------------------------------------------------
+    with get_cursor(commit=True) as cur:
+        # RESTRICT-safe cleanup of any leftover test state.
+        delete_market_with_children(cur, "ticker = %s", (_TEST_TICKER,))
+
+        # Underlying market (positions and edges both FK to markets.id).
+        cur.execute(
+            """
+            INSERT INTO markets (
+                platform_id, event_id, external_id, ticker, title,
+                market_type, status
+            )
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            RETURNING id
+            """,
+            (
+                "kalshi",
+                None,
+                f"{_TEST_TICKER}-EXT",
+                _TEST_TICKER,
+                "Issue 725 SCD Copy-Forward Market",
+                "binary",
+                "open",
+            ),
+        )
+        market_pk = cur.fetchone()["id"]
+
+        # Seed a minimal edge row. All non-NULL columns on edges are either
+        # business-identity (edge_key), FK (market_id), or metric fields
+        # (expected_value, probabilities, price). Uses a small deterministic
+        # set of values so the test's provenance assertions are stable.
+        # ``row_current_ind`` is explicitly TRUE so partial indexes accept it.
+        cur.execute(
+            """
+            INSERT INTO edges (
+                edge_key, market_id, model_id,
+                expected_value, true_win_probability,
+                market_implied_probability, market_price,
+                execution_environment, edge_status,
+                row_current_ind, row_start_ts
+            )
+            VALUES (
+                'TEMP', %s, %s,
+                %s, %s, %s, %s,
+                %s, 'detected',
+                TRUE, NOW()
+            )
+            RETURNING id
+            """,
+            (
+                market_pk,
+                None,  # model_id nullable
+                Decimal("0.0500"),
+                Decimal("0.6000"),
+                Decimal("0.5500"),
+                Decimal("0.5500"),
+                "paper",
+            ),
+        )
+        edge_pk = cur.fetchone()["id"]
+
+        # Set the proper edge_key now that we know the surrogate.
+        cur.execute(
+            "UPDATE edges SET edge_key = %s WHERE id = %s",
+            (f"EDGE-{edge_pk}", edge_pk),
+        )
+
+    # Create the position via the CRUD entry point (exercises the new
+    # ``edge_id`` parameter end-to-end). ``create_position`` commits.
+    position_surrogate_id = create_position(
+        market_id=market_pk,
+        strategy_id=None,  # nullable FK
+        model_id=None,  # nullable FK
+        side="YES",
+        quantity=10,
+        entry_price=Decimal("0.5000"),
+        execution_environment="paper",
+        stop_loss_price=Decimal("0.4500"),
+        edge_id=edge_pk,
+    )
+
+    # Re-key from the auto-assigned ``POS-{id}`` to our deterministic bk
+    # so the test can address the chain by a stable business key.
+    with get_cursor(commit=True) as cur:
+        cur.execute(
+            "UPDATE positions SET position_key = %s WHERE id = %s",
+            (position_bk, position_surrogate_id),
+        )
+
+    yield position_surrogate_id, position_bk, market_pk, edge_pk
+
+    # --- Teardown ------------------------------------------------------------
+    try:
+        with get_cursor(commit=True) as cur:
+            delete_market_with_children(cur, "id = %s", (market_pk,))
+    except Exception:
+        # Best-effort; do not mask the actual test outcome.
+        pass
+
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+
+@pytest.mark.integration
+class TestPositionsEdgeIdCopyForward:
+    """SCD copy-forward contract for ``positions.edge_id`` (migration 0059, #725).
+
+    Each test exercises one supersede path end-to-end against a real
+    database. The common assertion shape is:
+
+        - after supersede, exactly 2 rows exist for the business key
+          (1 historical, 1 current);
+        - both rows carry the SAME ``edge_id`` as the seeded value.
+
+    Separate tests per path (rather than a single parametrized shared
+    test) so a regression in any single supersede INSERT produces a
+    precise failure pointer at the CRUD function name.
+    """
+
+    def test_update_position_price_preserves_edge_id(
+        self, position_with_edge: tuple[int, str, int, int]
+    ) -> None:
+        """Price-update supersede must carry ``edge_id`` forward."""
+        surrogate_id, position_bk, _market_pk, edge_pk = position_with_edge
+
+        new_id = update_position_price(
+            position_id=surrogate_id,
+            current_price=Decimal("0.5600"),
+        )
+
+        assert new_id != surrogate_id, "must allocate a new surrogate id"
+
+        rows = _fetch_scd_chain(position_bk)
+        assert len(rows) == 2, (
+            f"expected 1 historical + 1 current row after supersede, found {len(rows)}"
+        )
+        historical, current = _partition_scd_rows(rows)
+        _assert_edge_id_copy_forward(historical, current, expected_edge_pk=edge_pk)
+
+    def test_close_position_preserves_edge_id(
+        self, position_with_edge: tuple[int, str, int, int]
+    ) -> None:
+        """close-position supersede must carry ``edge_id`` forward."""
+        surrogate_id, position_bk, _market_pk, edge_pk = position_with_edge
+
+        new_id = close_position(
+            position_id=surrogate_id,
+            exit_price=Decimal("0.6000"),
+            exit_reason="test_target_hit",
+            realized_pnl=Decimal("1.0000"),
+        )
+
+        assert new_id != surrogate_id, "must allocate a new surrogate id"
+
+        rows = _fetch_scd_chain(position_bk)
+        assert len(rows) == 2
+        historical, current = _partition_scd_rows(rows)
+        _assert_edge_id_copy_forward(historical, current, expected_edge_pk=edge_pk)
+        # And close_position must transition status:
+        assert current["status"] == "closed"
+
+    def test_set_trailing_stop_state_preserves_edge_id(
+        self, position_with_edge: tuple[int, str, int, int]
+    ) -> None:
+        """trailing-stop supersede must carry ``edge_id`` forward."""
+        surrogate_id, position_bk, _market_pk, edge_pk = position_with_edge
+
+        new_state = {
+            "config": {
+                "activation_threshold": "0.15",
+                "initial_distance": "0.05",
+                "tightening_rate": "0.10",
+                "floor_distance": "0.02",
+            },
+            "activated": False,
+            "activation_price": None,
+            "current_stop_price": "0.4500",
+            "highest_price": "0.5500",
+        }
+        new_id = set_trailing_stop_state(
+            position_id=surrogate_id,
+            trailing_stop_state=new_state,
+        )
+
+        assert new_id != surrogate_id, "must allocate a new surrogate id"
+
+        rows = _fetch_scd_chain(position_bk)
+        assert len(rows) == 2
+        historical, current = _partition_scd_rows(rows)
+        _assert_edge_id_copy_forward(historical, current, expected_edge_pk=edge_pk)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def _fetch_scd_chain(position_bk: str) -> list[dict[str, Any]]:
+    """Return every positions row for the business key, oldest first."""
+    with get_cursor(commit=False) as cur:
+        cur.execute(
+            """
+            SELECT id, position_key, edge_id, status, row_current_ind,
+                   row_start_ts, row_end_ts
+            FROM positions
+            WHERE position_key = %s
+            ORDER BY row_start_ts ASC
+            """,
+            (position_bk,),
+        )
+        return list(cur.fetchall())
+
+
+def _partition_scd_rows(
+    rows: list[dict[str, Any]],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Split a 2-row SCD chain into (historical, current) and sanity-check shape."""
+    historical_rows = [r for r in rows if not r["row_current_ind"]]
+    current_rows = [r for r in rows if r["row_current_ind"]]
+    assert len(historical_rows) == 1, (
+        f"expected exactly 1 historical row, got {len(historical_rows)}"
+    )
+    assert len(current_rows) == 1, f"expected exactly 1 current row, got {len(current_rows)}"
+    return historical_rows[0], current_rows[0]
+
+
+def _assert_edge_id_copy_forward(
+    historical: dict[str, Any],
+    current: dict[str, Any],
+    *,
+    expected_edge_pk: int,
+) -> None:
+    """Assert both rows carry ``edge_id == expected_edge_pk``.
+
+    Dedicated assertion helper with a rich failure message — a regression
+    here has a precise signature (the supersede INSERT omitted ``edge_id``
+    from its column list or params tuple) and the error message should
+    reproduce that diagnosis automatically.
+    """
+    assert historical["edge_id"] == expected_edge_pk, (
+        f"fixture seed broke: historical row's edge_id={historical['edge_id']!r} "
+        f"differs from expected {expected_edge_pk!r} BEFORE supersede fires. "
+        f"This means create_position did not persist the edge_id parameter."
+    )
+    assert current["edge_id"] == expected_edge_pk, (
+        f"SCD copy-forward contract violation: current row's edge_id="
+        f"{current['edge_id']!r} should equal historical "
+        f"edge_id={historical['edge_id']!r} (={expected_edge_pk}). "
+        f"The supersede INSERT silently NULLed the provenance FK. "
+        f"Fix: ensure edge_id appears in BOTH the INSERT column list AND "
+        f"its params tuple in crud_positions.py, sourced from current['edge_id']. "
+        f"See migration 0059 docstring and design memo #725 Holden S57 §6."
+    )


### PR DESCRIPTION
## Summary

Closes #725 (items 1-7). Item 11 (orderbook_snapshots wiring) is deferred to follow-up migration 0060 per Holden's S57 split recommendation; items 8-10 belong to #726 Cohort C3 analytics enrichment.

Adds 7 missing FK columns to complete the provenance chain, with CRUD copy-forward updates for the positions SCD Type 2 table and a regression test proving the copy-forward contract holds under all three supersede paths.

Implements Holden's S57 design memo verbatim, with one documented deviation (see below).

## Changes

### Migration 0059 (new)
`src/precog/database/alembic/versions/0059_missing_fks_provenance_chain.py`

7 nullable `INTEGER` FK columns with `ON DELETE RESTRICT` + partial indexes `WHERE <col> IS NOT NULL`. Combined column-add + constraint in a single `ALTER`; Postgres validates instantly (empty constraint on nullable column).

| # | Child | Column | -> Parent | Notes |
|---|---|---|---|---|
| 1 | `positions` | `edge_id` | `edges(id)` | SCD parent; copy-forward wired |
| 2 | `settlements` | `position_id` | `positions(id)` | SCD parent |
| 3 | `settlements` | `order_id` | `orders(id)` | |
| 4 | `position_exits` | `order_id` | `orders(id)` | |
| 5 | `exit_attempts` | `order_id` | `orders(id)` | |
| 6 | `edges` | `market_snapshot_id` | `market_snapshots(id)` | SCD parent |
| 7 | `edges` | `prediction_id` | `predictions(id)` | |

Plus `COMMENT ON COLUMN positions.edge_id` clarifying the distinction from the existing `edge_at_entry` (numeric) column. `revises: 0058`. Auto-naming `{child_table}_{child_column}_fkey` matches 0057's `NAMED_CONSTRAINTS` fallback.

### CRUD copy-forward (the highest-risk element, per Holden memo section 6)
`src/precog/database/crud_positions.py`

All 4 `INSERT INTO positions` call sites updated:

| Line | Function | Change |
|------|---------|---|
| 272 | `create_position` | new optional `edge_id: int \| None = None` parameter, passed through to INSERT |
| 590 | `update_position_price` (supersede) | `edge_id` added to column list + `current["edge_id"]` copy-forward |
| 797 | `close_position` (supersede) | `edge_id` added to column list + `current["edge_id"]` copy-forward |
| 1101 | `set_trailing_stop_state` (supersede) | `edge_id` added to column list + `current["edge_id"]` copy-forward |

Every supersede path has a Pattern 49 copy-forward checklist comment at the top explaining why omission produces silent SET NULL.

### Regression test (new)
`tests/integration/database/test_scd_copy_forward.py`

3 integration tests (one per supersede path) assert the contract against a real PostgreSQL testcontainer:

- `test_update_position_price_preserves_edge_id`
- `test_close_position_preserves_edge_id`
- `test_set_trailing_stop_state_preserves_edge_id`

Fixture creates a market, an edge row, and a position via `create_position(edge_id=edge_pk, ...)`, then each test fires one supersede path and verifies both historical and current SCD rows carry the original `edge_pk`. Rich failure messages pinpoint the exact INSERT column list or params-tuple omission that would cause a future regression.

## Deviation from Holden memo

Holden memo section 6 asks for the same copy-forward treatment in `crud_edges.py` for `edges.market_snapshot_id` and `edges.prediction_id`. Investigation found:

- **No `crud_edges.py` file exists** in the codebase; edge CRUD lives in `crud_analytics.py`.
- **No SCD supersede path exists for edges**: only `create_edge` (initial INSERT) and two direct `UPDATE ... WHERE row_current_ind = TRUE` lifecycle events (`update_edge_outcome`, `update_edge_status`) that do not allocate new SCD versions.

So `create_edge` was **not changed**: the two new FK columns default to NULL, and can be populated later when callers have provenance context. The migration docstring notes that when a genuine SCD supersede path is later added to edges (e.g. on price drift), the Pattern 49 copy-forward checklist from `crud_positions.py` must be applied there too. This keeps scope tight and avoids inventing a supersede path ahead of demand.

## Why numbered 0059 (not 0060)

Holden's memo suggested 0060/0061 to allow for clean splitting, but 0058 is the latest migration on disk — so 0059 is the correct next number. The 0060 slot remains available for the item-11 orderbook_snapshot wiring when that ships.

## Other risks verified

- **0056 write-protection triggers**: `ALTER TABLE ADD COLUMN` is DDL; does not fire row-level INSERT/UPDATE/DELETE triggers. No `session_replication_role` adjustment required. Verified by reading 0056.
- **Naming collision**: `positions.edge_id` (new FK) vs `positions.edge_at_entry` (existing DECIMAL). DB-level `COMMENT ON COLUMN` added for future readers.
- **NULL back-compat**: all 7 child tables allow all existing rows to carry NULL in the new column. Metadata-only ALTER TABLE.
- **RESTRICT cascade cycles**: none introduced. Chained RESTRICT deletion of an edge row requires pruning `orders.edge_id` + `positions.edge_id` + their children, matching 0057 pattern.

## Test plan

- [x] Migration 0059 applied successfully to ephemeral testcontainer (via `db_pool` fixture bootstrap)
- [x] 3 new copy-forward tests pass
- [x] All 285 existing `tests/integration/database/` tests pass (zero regressions)
- [x] All 33 `tests/integration/trading/test_position_manager*` tests pass
- [x] All 1050 `tests/unit/database/` + `tests/unit/trading/` tests pass
- [x] Pre-push validation full suite: 2605 unit + 1180 integration/e2e + 1063 stress/chaos/race — all green in 358s
- [x] ruff format + check clean; mypy clean; pre-commit hooks all pass (including S75 CLI flag, Hook 1.5 loose-assertion, Hook 1.6 mock-target)

## Agent Review Trail

- **Holden** (design, S57) — design memo delivered, authoritative on the split-migration plan + the critical SCD copy-forward risk.
- **Samwise** (build, S57) — implemented per memo with one documented deviation on edges (no SCD supersede path exists yet).
- **Joe Chip + Ripley** — to follow.

Closes #725