### PR TITLE
feat: #738 A1 — sports + leagues lookup tables + nullable FK backfill + dual-write CRUD

### DIFF
--- a/src/precog/analytics/elo_computation_service.py
+++ b/src/precog/analytics/elo_computation_service.py
@@ -44,6 +44,7 @@ from precog.analytics.elo_engine import (
     EloEngine,
     EloUpdateResult,
 )
+from precog.database.crud_lookups import get_league_id_or_none
 from precog.utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -366,14 +367,18 @@ class EloComputationService:
                 home_elo_after,
                 away_elo_after,
                 calculation_source,
-                calculation_version
+                calculation_version,
+                league_id
             ) VALUES (
-                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                %s, %s, %s, %s, %s, %s, %s, %s
             )
         """
 
         # Determine league from game data
         league = game.get("league") or self._current_league
+        # Dual-write (#738 A1): also populate league_id FK.
+        league_id_value = get_league_id_or_none(league)
 
         params = [
             game["id"],
@@ -398,6 +403,7 @@ class EloComputationService:
             result.away_elo_after,
             self.calculation_source,
             self.calculation_version,
+            league_id_value,
         ]
 
         cursor.execute(query, params)

--- a/src/precog/database/alembic/versions/0060_lookup_tables_sports_leagues_a1.py
+++ b/src/precog/database/alembic/versions/0060_lookup_tables_sports_leagues_a1.py
@@ -1,0 +1,320 @@
+"""#738 Migration A1 — sports + leagues lookup tables, nullable FK columns, backfill.
+
+This is the FIRST of three migrations in the #738 lookup-tables arc:
+
+    A1 (THIS MIGRATION): Create lookup tables + nullable FK columns + backfill.
+    A2 (future):         Enforce NOT NULL + drop CHECK constraints + recreate views.
+    B  (future):         Drop deprecated VARCHAR sport/league columns.
+
+Scope of A1:
+  * Create `sports` (6 seeds: football, basketball, hockey, baseball, soccer, mma).
+  * Create `leagues` (11 seeds: nfl, ncaaf, nba, ncaab, ncaaw, wnba, nhl, mlb,
+    mls, soccer, ufc — each linked to parent `sport_id`).
+  * Add NULLABLE `sport_id` / `league_id` FK columns on 10 tables, with partial
+    indexes on non-NULL values (per-table set — see `_FK_COLUMN_SPEC`).
+  * Backfill the new FK columns from existing VARCHAR values.  Supports the
+    mixed-convention case (`game_odds.sport` holds either sport names OR
+    league codes — both cases covered by a two-step UPDATE).
+  * Assert zero NULLs post-backfill; RAISE if any row fails to resolve.
+
+Explicitly OUT OF SCOPE for A1:
+  * NOT NULL enforcement on the new FK columns (A2).
+  * Dropping the 9 CHECK constraints (A2).
+  * View recreation (A2 — existing views still reference the VARCHAR columns).
+  * Dropping VARCHAR sport/league columns (B).
+  * Test fixture updates (A2, once NOT NULL lands).
+  * Seed SQL file updates (A2).
+
+The dual-write pattern in the CRUD layer (every INSERT writes BOTH the VARCHAR
+value AND the resolved FK id) lands in the same PR as this migration.  Reads
+can continue to use either surface during the A1 -> A2 window; once A2 enforces
+NOT NULL, callers flip to FK-primary, and B drops the VARCHAR.
+
+Unblocks:
+  * #795 (UFC readiness) — `ufc` seed row on `mma` sport.
+
+Revision ID: 0060
+Revises: 0058
+Create Date: 2026-04-15
+
+Issues: #738 (partial — A1 of 3)
+Epic: #745 (Schema Hardening Arc)
+Design review: Session 54 (Holden + Galadriel, design_738_lookup_tables.md)
+Parent PR: TBD (opened by Samwise, S57)
+ADR: #116 (ODS Schema Conventions)
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0060"
+down_revision: str = "0058"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# =========================================================================
+# Seed data (pinned in the migration so dev/test/prod all get the same IDs
+# when running fresh, and incremental upgrades don't drift).
+# =========================================================================
+
+# `sports` seed rows.  `id` is allocated by SERIAL in insertion order; we
+# rely on insertion order (1..6) rather than hardcoding IDs, so downstream
+# JOINs use the `sport_key` business key -- not the numeric id.
+_SPORTS_SEED = [
+    ("football", "Football"),
+    ("basketball", "Basketball"),
+    ("hockey", "Hockey"),
+    ("baseball", "Baseball"),
+    ("soccer", "Soccer"),
+    ("mma", "MMA"),
+]
+
+# `leagues` seed rows.  `sport_id` resolved via subquery on `sport_key`.
+_LEAGUES_SEED = [
+    # (league_key, sport_key, display_name)
+    ("nfl", "football", "NFL"),
+    ("ncaaf", "football", "NCAA Football"),
+    ("nba", "basketball", "NBA"),
+    ("ncaab", "basketball", "NCAA Men's Basketball"),
+    ("ncaaw", "basketball", "NCAA Women's Basketball"),
+    ("wnba", "basketball", "WNBA"),
+    ("nhl", "hockey", "NHL"),
+    ("mlb", "baseball", "MLB"),
+    ("mls", "soccer", "MLS"),
+    ("soccer", "soccer", "Soccer (generic)"),
+    ("ufc", "mma", "UFC"),
+]
+
+
+# =========================================================================
+# FK column specification per table.
+#
+# Each tuple: (table, varchar_column, new_fk_column, lookup_kind)
+#   - varchar_column: existing column holding the sport/league string
+#   - new_fk_column: name of the new FK column to add
+#   - lookup_kind: one of:
+#       "sport_direct"        - varchar holds a sport_key, resolve to sports.id
+#       "league_direct"       - varchar holds a league_key, resolve to leagues.id
+#       "league_to_sport"     - varchar holds a league_key, resolve to
+#                               leagues.sport_id (i.e., derive sport via join)
+#       "sport_or_league"     - varchar holds EITHER a sport_key OR a
+#                               league_key; try sport first, fall back to
+#                               leagues.sport_id
+#
+# Partial index name: idx_<table>_<new_fk_column>
+# =========================================================================
+_FK_COLUMN_SPEC = [
+    # (table, varchar_col, new_fk_col, lookup_kind)
+    # --- sport_id additions ------------------------------------------------
+    ("teams", "sport", "sport_id", "sport_direct"),
+    ("games", "sport", "sport_id", "sport_direct"),
+    ("game_odds", "sport", "sport_id", "sport_or_league"),
+    ("historical_stats", "sport", "sport_id", "league_to_sport"),
+    ("historical_rankings", "sport", "sport_id", "league_to_sport"),
+    ("historical_epa", "sport", "sport_id", "league_to_sport"),
+    # --- league_id additions -----------------------------------------------
+    ("teams", "league", "league_id", "league_direct"),
+    ("games", "league", "league_id", "league_direct"),
+    ("game_states", "league", "league_id", "league_direct"),
+    ("elo_calculation_log", "league", "league_id", "league_direct"),
+    ("external_team_codes", "league", "league_id", "league_direct"),
+]
+
+
+def _insert_seeds(conn: sa.engine.Connection) -> None:
+    """Insert the pinned `sports` and `leagues` seed rows."""
+    # sports
+    for sport_key, display_name in _SPORTS_SEED:
+        conn.execute(
+            sa.text(
+                "INSERT INTO sports (sport_key, display_name) VALUES (:sport_key, :display_name)"
+            ),
+            {"sport_key": sport_key, "display_name": display_name},
+        )
+    # leagues (sport_id resolved via subquery on sport_key)
+    for league_key, sport_key, display_name in _LEAGUES_SEED:
+        conn.execute(
+            sa.text(
+                "INSERT INTO leagues (league_key, sport_id, display_name) "
+                "VALUES ("
+                "    :league_key,"
+                "    (SELECT id FROM sports WHERE sport_key = :sport_key),"
+                "    :display_name"
+                ")"
+            ),
+            {
+                "league_key": league_key,
+                "sport_key": sport_key,
+                "display_name": display_name,
+            },
+        )
+
+
+def _backfill_fk_column(
+    conn: sa.engine.Connection,
+    table: str,
+    varchar_col: str,
+    new_fk_col: str,
+    lookup_kind: str,
+) -> None:
+    """Backfill the new FK column for one table, then assert zero NULLs.
+
+    The four lookup strategies handle the distinct value-shape cases in the
+    source data.  See `_FK_COLUMN_SPEC` comments for per-strategy semantics.
+    """
+    # NOTE: table/column names are interpolated from the hardcoded
+    # `_FK_COLUMN_SPEC` module-level constant, not user input.  The S608
+    # suppressions on each UPDATE below reflect that these are safe
+    # dynamic identifiers, not a SQL-injection surface.
+    if lookup_kind == "sport_direct":
+        conn.execute(
+            sa.text(
+                f"UPDATE {table} SET {new_fk_col} = "  # noqa: S608
+                f"  (SELECT s.id FROM sports s WHERE s.sport_key = {table}.{varchar_col}) "
+                f"WHERE {varchar_col} IS NOT NULL"
+            )
+        )
+    elif lookup_kind == "league_direct":
+        conn.execute(
+            sa.text(
+                f"UPDATE {table} SET {new_fk_col} = "  # noqa: S608
+                f"  (SELECT l.id FROM leagues l WHERE l.league_key = {table}.{varchar_col}) "
+                f"WHERE {varchar_col} IS NOT NULL"
+            )
+        )
+    elif lookup_kind == "league_to_sport":
+        # varchar holds a league code, but we want the parent sport_id
+        conn.execute(
+            sa.text(
+                f"UPDATE {table} SET {new_fk_col} = "  # noqa: S608
+                f"  (SELECT l.sport_id FROM leagues l WHERE l.league_key = {table}.{varchar_col}) "
+                f"WHERE {varchar_col} IS NOT NULL"
+            )
+        )
+    elif lookup_kind == "sport_or_league":
+        # Step 1: try direct sport_key match
+        conn.execute(
+            sa.text(
+                f"UPDATE {table} SET {new_fk_col} = "  # noqa: S608
+                f"  (SELECT s.id FROM sports s WHERE s.sport_key = {table}.{varchar_col}) "
+                f"WHERE {varchar_col} IS NOT NULL "
+                f"  AND {new_fk_col} IS NULL "
+                f"  AND {table}.{varchar_col} IN (SELECT sport_key FROM sports)"
+            )
+        )
+        # Step 2: for remaining nulls, try league_key -> sport_id
+        conn.execute(
+            sa.text(
+                f"UPDATE {table} SET {new_fk_col} = "  # noqa: S608
+                f"  (SELECT l.sport_id FROM leagues l WHERE l.league_key = {table}.{varchar_col}) "
+                f"WHERE {varchar_col} IS NOT NULL "
+                f"  AND {new_fk_col} IS NULL "
+                f"  AND {table}.{varchar_col} IN (SELECT league_key FROM leagues)"
+            )
+        )
+    else:
+        raise ValueError(f"Unknown lookup_kind for {table}.{new_fk_col}: {lookup_kind!r}")
+
+    # Zero-NULL assertion: every row with a non-NULL varchar must have
+    # resolved to a FK.  If any row failed to backfill, the migration
+    # raises here rather than silently leaving holes (per PM direction).
+    null_count_row = conn.execute(
+        sa.text(
+            f"SELECT COUNT(*) AS c FROM {table} "  # noqa: S608
+            f"WHERE {varchar_col} IS NOT NULL AND {new_fk_col} IS NULL"
+        )
+    ).fetchone()
+    null_count = int(null_count_row[0]) if null_count_row else 0
+    if null_count > 0:
+        # Surface the unmatched distinct values so ops has actionable info.
+        sample = conn.execute(
+            sa.text(
+                f"SELECT DISTINCT {varchar_col} FROM {table} "  # noqa: S608
+                f"WHERE {varchar_col} IS NOT NULL AND {new_fk_col} IS NULL "
+                f"LIMIT 20"
+            )
+        ).fetchall()
+        sample_vals = [row[0] for row in sample]
+        raise RuntimeError(
+            f"[0060] Backfill failure on {table}.{new_fk_col}: "
+            f"{null_count} row(s) with non-NULL {varchar_col} did not resolve "
+            f"to a lookup id (lookup_kind={lookup_kind!r}). "
+            f"Unmatched values: {sample_vals!r}. "
+            f"Add missing rows to the sports/leagues seeds or UPDATE the "
+            f"offending rows to a known value before retrying."
+        )
+
+
+def upgrade() -> None:
+    """Create lookup tables + seed + add nullable FK columns + backfill."""
+    conn = op.get_bind()
+
+    # ------------------------------------------------------------------
+    # Step 1: Create lookup tables
+    # ------------------------------------------------------------------
+    op.execute(
+        """
+        CREATE TABLE sports (
+            id SERIAL PRIMARY KEY,
+            sport_key VARCHAR(20) NOT NULL UNIQUE,
+            display_name VARCHAR(100) NOT NULL,
+            is_active BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE leagues (
+            id SERIAL PRIMARY KEY,
+            league_key VARCHAR(20) NOT NULL UNIQUE,
+            sport_id INTEGER NOT NULL REFERENCES sports(id) ON DELETE RESTRICT,
+            display_name VARCHAR(100) NOT NULL,
+            is_active BOOLEAN NOT NULL DEFAULT TRUE,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+
+    # ------------------------------------------------------------------
+    # Step 2: Seed 6 sports + 11 leagues
+    # ------------------------------------------------------------------
+    _insert_seeds(conn)
+
+    # ------------------------------------------------------------------
+    # Step 3: Add nullable FK columns + partial indexes
+    # ------------------------------------------------------------------
+    for table, _varchar_col, new_fk_col, _lookup_kind in _FK_COLUMN_SPEC:
+        parent_table = "sports" if new_fk_col == "sport_id" else "leagues"
+        op.execute(
+            f"ALTER TABLE {table} "
+            f"ADD COLUMN {new_fk_col} INTEGER "
+            f"REFERENCES {parent_table}(id) ON DELETE RESTRICT"
+        )
+        index_name = f"idx_{table}_{new_fk_col}"
+        op.execute(
+            f"CREATE INDEX {index_name} ON {table}({new_fk_col}) WHERE {new_fk_col} IS NOT NULL"
+        )
+
+    # ------------------------------------------------------------------
+    # Step 4: Backfill (with zero-NULL assertion per column)
+    # ------------------------------------------------------------------
+    for table, varchar_col, new_fk_col, lookup_kind in _FK_COLUMN_SPEC:
+        _backfill_fk_column(conn, table, varchar_col, new_fk_col, lookup_kind)
+
+
+def downgrade() -> None:
+    """Reverse the A1 migration: drop FK columns, drop seeds, drop lookup tables."""
+    # Step 1: Drop the FK columns + partial indexes (indexes drop with columns)
+    for table, _varchar_col, new_fk_col, _lookup_kind in _FK_COLUMN_SPEC:
+        op.execute(f"DROP INDEX IF EXISTS idx_{table}_{new_fk_col}")
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS {new_fk_col}")
+
+    # Step 2: Drop lookup tables (RESTRICT auto-enforced; child FK columns
+    # already gone, so DROP is safe).
+    op.execute("DROP TABLE IF EXISTS leagues")
+    op.execute("DROP TABLE IF EXISTS sports")

--- a/src/precog/database/alembic/versions/0060_lookup_tables_sports_leagues_a1.py
+++ b/src/precog/database/alembic/versions/0060_lookup_tables_sports_leagues_a1.py
@@ -52,7 +52,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "0060"
-down_revision: str = "0058"
+down_revision: str = "0059"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/src/precog/database/alembic/versions/0060_lookup_tables_sports_leagues_a1.py
+++ b/src/precog/database/alembic/versions/0060_lookup_tables_sports_leagues_a1.py
@@ -10,7 +10,8 @@ Scope of A1:
   * Create `sports` (6 seeds: football, basketball, hockey, baseball, soccer, mma).
   * Create `leagues` (11 seeds: nfl, ncaaf, nba, ncaab, ncaaw, wnba, nhl, mlb,
     mls, soccer, ufc — each linked to parent `sport_id`).
-  * Add NULLABLE `sport_id` / `league_id` FK columns on 10 tables, with partial
+  * Add NULLABLE `sport_id` / `league_id` FK columns on 10 tables (12 columns
+    total — `game_odds` gets both `sport_id` AND `league_id`), with partial
     indexes on non-NULL values (per-table set — see `_FK_COLUMN_SPEC`).
   * Backfill the new FK columns from existing VARCHAR values.  Supports the
     mixed-convention case (`game_odds.sport` holds either sport names OR
@@ -104,6 +105,15 @@ _LEAGUES_SEED = [
 #       "sport_or_league"     - varchar holds EITHER a sport_key OR a
 #                               league_key; try sport first, fall back to
 #                               leagues.sport_id
+#       "join_via_game"       - the table has no sport/league varchar of its
+#                               own; resolve league_id by joining through
+#                               game_id -> games.league -> leagues.id.
+#                               Used for `game_odds.league_id`: schema
+#                               symmetry with other multi-sport tables, but
+#                               game_odds has no `league` varchar column.
+#                               Allows NULL when game_id IS NULL (unmatched
+#                               imports), since those rows have no game row
+#                               to join through.
 #
 # Partial index name: idx_<table>_<new_fk_column>
 # =========================================================================
@@ -122,6 +132,14 @@ _FK_COLUMN_SPEC = [
     ("game_states", "league", "league_id", "league_direct"),
     ("elo_calculation_log", "league", "league_id", "league_direct"),
     ("external_team_codes", "league", "league_id", "league_direct"),
+    # game_odds.league_id: no native VARCHAR `league` column on this table,
+    # so resolve via JOIN through game_id -> games.league -> leagues.id.
+    # Rows with NULL game_id are permitted to remain NULL in league_id (the
+    # zero-NULL assertion explicitly filters those out).  Listed AFTER
+    # games.league_id so the games row is guaranteed populated when this
+    # backfill runs (although the backfill SQL joins via games.league
+    # VARCHAR, which is independent of games.league_id).
+    ("game_odds", None, "league_id", "join_via_game"),
 ]
 
 
@@ -157,7 +175,7 @@ def _insert_seeds(conn: sa.engine.Connection) -> None:
 def _backfill_fk_column(
     conn: sa.engine.Connection,
     table: str,
-    varchar_col: str,
+    varchar_col: str | None,
     new_fk_col: str,
     lookup_kind: str,
 ) -> None:
@@ -216,32 +234,61 @@ def _backfill_fk_column(
                 f"  AND {table}.{varchar_col} IN (SELECT league_key FROM leagues)"
             )
         )
+    elif lookup_kind == "join_via_game":
+        # No native VARCHAR column — resolve league_id by joining through
+        # game_id -> games.league -> leagues.league_key.  Works regardless
+        # of whether games.league_id has been backfilled yet (joins to the
+        # VARCHAR games.league value directly).
+        # Rows with NULL game_id are left NULL (no game to join through).
+        conn.execute(
+            sa.text(
+                f"UPDATE {table} SET {new_fk_col} = "  # noqa: S608
+                f"  (SELECT l.id FROM leagues l "
+                f"   JOIN games g ON g.league = l.league_key "
+                f"   WHERE g.id = {table}.game_id) "
+                f"WHERE {table}.game_id IS NOT NULL"
+            )
+        )
     else:
         raise ValueError(f"Unknown lookup_kind for {table}.{new_fk_col}: {lookup_kind!r}")
 
-    # Zero-NULL assertion: every row with a non-NULL varchar must have
+    # Zero-NULL assertion: every row with a non-NULL source column must have
     # resolved to a FK.  If any row failed to backfill, the migration
     # raises here rather than silently leaving holes (per PM direction).
+    #
+    # For "join_via_game" (varchar_col is None), the source key is game_id:
+    # any row with non-NULL game_id must have resolved; rows with NULL
+    # game_id are allowed to remain NULL in the FK column (no game to join
+    # through).
+    if lookup_kind == "join_via_game":
+        # Filter: only rows with a joinable game_id must have resolved.
+        null_count_filter = f"WHERE game_id IS NOT NULL AND {new_fk_col} IS NULL"
+        null_count_label = "game_id"
+    else:
+        null_count_filter = f"WHERE {varchar_col} IS NOT NULL AND {new_fk_col} IS NULL"
+        null_count_label = str(varchar_col)
+
     null_count_row = conn.execute(
         sa.text(
             f"SELECT COUNT(*) AS c FROM {table} "  # noqa: S608
-            f"WHERE {varchar_col} IS NOT NULL AND {new_fk_col} IS NULL"
+            f"{null_count_filter}"
         )
     ).fetchone()
     null_count = int(null_count_row[0]) if null_count_row else 0
     if null_count > 0:
         # Surface the unmatched distinct values so ops has actionable info.
+        sample_col = "game_id" if lookup_kind == "join_via_game" else str(varchar_col)
         sample = conn.execute(
             sa.text(
-                f"SELECT DISTINCT {varchar_col} FROM {table} "  # noqa: S608
-                f"WHERE {varchar_col} IS NOT NULL AND {new_fk_col} IS NULL "
+                f"SELECT DISTINCT {sample_col} FROM {table} "  # noqa: S608
+                f"{null_count_filter} "
                 f"LIMIT 20"
             )
         ).fetchall()
         sample_vals = [row[0] for row in sample]
         raise RuntimeError(
             f"[0060] Backfill failure on {table}.{new_fk_col}: "
-            f"{null_count} row(s) with non-NULL {varchar_col} did not resolve "
+            f"{null_count} row(s) with non-NULL {null_count_label} did not resolve "
             f"to a lookup id (lookup_kind={lookup_kind!r}). "
             f"Unmatched values: {sample_vals!r}. "
             f"Add missing rows to the sports/leagues seeds or UPDATE the "

--- a/src/precog/database/crud_elo.py
+++ b/src/precog/database/crud_elo.py
@@ -13,6 +13,7 @@ from decimal import Decimal
 from typing import Any, cast
 
 from .connection import fetch_all, fetch_one, get_cursor
+from .crud_lookups import get_league_id_or_none
 
 logger = logging.getLogger(__name__)
 
@@ -322,6 +323,8 @@ def insert_elo_calculation_log(
         - Migration 0013: elo_calculation_log table schema
         - ADR-109: Elo Rating Computation Engine Architecture
     """
+    # Dual-write (#738 A1): populate league_id FK alongside the VARCHAR.
+    league_id_value = get_league_id_or_none(league)
     query = """
         INSERT INTO elo_calculation_log (
             league, game_date, home_team_id, away_team_id,
@@ -335,12 +338,12 @@ def insert_elo_calculation_log(
             home_elo_change, away_elo_change,
             home_elo_after, away_elo_after,
             home_epa_adjustment, away_epa_adjustment,
-            calculation_source, calculation_version
+            calculation_source, calculation_version, league_id
         )
         VALUES (
             %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
             %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-            %s, %s, %s, %s, %s, %s, %s
+            %s, %s, %s, %s, %s, %s, %s, %s
         )
         RETURNING elo_log_id
     """
@@ -372,6 +375,7 @@ def insert_elo_calculation_log(
         away_epa_adjustment,
         calculation_source,
         calculation_version,
+        league_id_value,
     )
     with get_cursor(commit=True) as cur:
         cur.execute(query, params)

--- a/src/precog/database/crud_game_states.py
+++ b/src/precog/database/crud_game_states.py
@@ -15,6 +15,11 @@ from decimal import Decimal
 from typing import Any, cast
 
 from .connection import fetch_all, fetch_one, get_cursor
+from .crud_lookups import (
+    get_league_id_or_none,
+    get_sport_id_or_none,
+    resolve_sport_id_for_mixed_value,
+)
 from .crud_shared import retry_on_scd_unique_conflict
 
 logger = logging.getLogger(__name__)
@@ -146,17 +151,19 @@ def create_game_state(
         - ADR-029: ESPN Data Model with Normalized Schema
         - Pattern 2: Dual Versioning System (SCD Type 2)
     """
+    # Dual-write (#738 A1): populate league_id FK alongside the VARCHAR.
+    league_id_value = get_league_id_or_none(league)
     insert_query = """
         INSERT INTO game_states (
             espn_event_id, home_team_id, away_team_id, venue_id,
             home_score, away_score, period, clock_seconds, clock_display,
             game_status, game_date, broadcast, neutral_site,
             season_type, week_number, league, situation, linescores,
-            data_source, game_id, row_current_ind, row_start_ts
+            data_source, game_id, league_id, row_current_ind, row_start_ts
         )
         VALUES (
             %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-            %s, %s, TRUE, NOW()
+            %s, %s, %s, TRUE, NOW()
         )
         RETURNING id
     """
@@ -184,6 +191,7 @@ def create_game_state(
                 json.dumps(linescores) if linescores else None,
                 data_source,
                 game_id,
+                league_id_value,
             ),
         )
         result = cur.fetchone()
@@ -440,17 +448,19 @@ def upsert_game_state(
           AND row_current_ind = TRUE
     """
 
+    # Dual-write (#738 A1): populate league_id FK alongside the VARCHAR.
+    league_id_value = get_league_id_or_none(league)
     insert_query = """
         INSERT INTO game_states (
             espn_event_id, home_team_id, away_team_id, venue_id,
             home_score, away_score, period, clock_seconds, clock_display,
             game_status, game_date, broadcast, neutral_site,
             season_type, week_number, league, situation, linescores,
-            data_source, game_id, row_current_ind, row_start_ts
+            data_source, game_id, league_id, row_current_ind, row_start_ts
         )
         VALUES (
             %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-            %s, %s, TRUE, %s
+            %s, %s, %s, TRUE, %s
         )
         RETURNING id
     """
@@ -502,6 +512,7 @@ def upsert_game_state(
                     json.dumps(linescores) if linescores else None,
                     data_source,
                     game_id,
+                    league_id_value,
                     now,
                 ),
             )
@@ -758,6 +769,11 @@ def get_or_create_game(
             f"Phase B rename. Pass league explicitly."
         )
 
+    # Dual-write (#738 A1): populate sport_id + league_id FKs alongside the
+    # VARCHARs.  The `sport` column uses sport names ('football'); the
+    # `league` column uses league codes ('nfl').
+    sport_id_value = get_sport_id_or_none(sport)
+    league_id_value = get_league_id_or_none(league)
     query = """
         INSERT INTO games (
             sport, game_date, home_team_code, away_team_code,
@@ -766,12 +782,14 @@ def get_or_create_game(
             neutral_site, is_playoff, game_type,
             game_time, espn_event_id, external_game_id,
             game_status, data_source,
-            home_score, away_score, source_file, attendance
+            home_score, away_score, source_file, attendance,
+            sport_id, league_id
         )
         VALUES (
             %s, %s, %s, %s, %s, %s, %s, %s,
             %s, %s, %s, %s, %s, %s, %s,
-            %s, %s, %s, %s, %s, %s, %s, %s, %s
+            %s, %s, %s, %s, %s, %s, %s, %s, %s,
+            %s, %s
         )
         ON CONFLICT (sport, game_date, home_team_code, away_team_code) DO UPDATE SET
             updated_at = NOW(),
@@ -794,7 +812,9 @@ def get_or_create_game(
             away_score = COALESCE(EXCLUDED.away_score, games.away_score),
             data_source = EXCLUDED.data_source,
             source_file = COALESCE(EXCLUDED.source_file, games.source_file),
-            attendance = COALESCE(EXCLUDED.attendance, games.attendance)
+            attendance = COALESCE(EXCLUDED.attendance, games.attendance),
+            sport_id = COALESCE(EXCLUDED.sport_id, games.sport_id),
+            league_id = COALESCE(EXCLUDED.league_id, games.league_id)
         RETURNING id
     """
     params = (
@@ -822,6 +842,8 @@ def get_or_create_game(
         away_score,
         source_file,
         attendance,
+        sport_id_value,
+        league_id_value,
     )
     with get_cursor(commit=True) as cur:
         cur.execute(query, params)
@@ -1457,6 +1479,10 @@ def upsert_game_odds(
                 )
 
             # Step 4: Insert new version with matching row_start_ts.
+            # Dual-write (#738 A1): `game_odds.sport` holds EITHER sport
+            # names OR league codes (mixed convention, migration 0048);
+            # `resolve_sport_id_for_mixed_value` handles both shapes.
+            sport_id_value = resolve_sport_id_for_mixed_value(sport)
             cur.execute(
                 """
                 INSERT INTO game_odds (
@@ -1474,6 +1500,7 @@ def upsert_game_odds(
                     home_favorite_at_open, away_favorite_at_open,
                     details_text,
                     home_team_id, away_team_id,
+                    sport_id,
                     row_current_ind, row_start_ts, updated_at
                 )
                 VALUES (
@@ -1485,6 +1512,7 @@ def upsert_game_odds(
                     %s, %s, %s, %s,
                     %s,
                     %s, %s,
+                    %s,
                     TRUE, %s, %s
                 )
                 RETURNING id
@@ -1520,6 +1548,7 @@ def upsert_game_odds(
                     details_text,
                     home_team_id,
                     away_team_id,
+                    sport_id_value,
                     now,
                     now,
                 ),

--- a/src/precog/database/crud_game_states.py
+++ b/src/precog/database/crud_game_states.py
@@ -18,6 +18,7 @@ from .connection import fetch_all, fetch_one, get_cursor
 from .crud_lookups import (
     get_league_id_or_none,
     get_sport_id_or_none,
+    resolve_league_id_via_game,
     resolve_sport_id_for_mixed_value,
 )
 from .crud_shared import retry_on_scd_unique_conflict
@@ -1483,6 +1484,9 @@ def upsert_game_odds(
             # names OR league codes (mixed convention, migration 0048);
             # `resolve_sport_id_for_mixed_value` handles both shapes.
             sport_id_value = resolve_sport_id_for_mixed_value(sport)
+            # Dual-write (#738 A1 amendment): resolve league_id via the
+            # linked games row (game_odds has no native `league` VARCHAR).
+            league_id_value = resolve_league_id_via_game(game_id)
             cur.execute(
                 """
                 INSERT INTO game_odds (
@@ -1500,7 +1504,7 @@ def upsert_game_odds(
                     home_favorite_at_open, away_favorite_at_open,
                     details_text,
                     home_team_id, away_team_id,
-                    sport_id,
+                    sport_id, league_id,
                     row_current_ind, row_start_ts, updated_at
                 )
                 VALUES (
@@ -1512,7 +1516,7 @@ def upsert_game_odds(
                     %s, %s, %s, %s,
                     %s,
                     %s, %s,
-                    %s,
+                    %s, %s,
                     TRUE, %s, %s
                 )
                 RETURNING id
@@ -1549,6 +1553,7 @@ def upsert_game_odds(
                     home_team_id,
                     away_team_id,
                     sport_id_value,
+                    league_id_value,
                     now,
                     now,
                 ),

--- a/src/precog/database/crud_historical.py
+++ b/src/precog/database/crud_historical.py
@@ -12,6 +12,7 @@ import logging
 from typing import Any, cast
 
 from .connection import fetch_all, get_cursor
+from .crud_lookups import get_sport_id_from_league_or_none
 
 logger = logging.getLogger(__name__)
 
@@ -88,18 +89,23 @@ def insert_historical_stat(
 
     # Use a composite conflict target for upsert
     # This handles re-imports of the same data gracefully
+    # Dual-write (#738 A1): historical_stats.sport holds league codes
+    # ('nfl', 'ncaaf', ...) despite the column name.  Resolve via leagues
+    # -> sports join.
+    sport_id_value = get_sport_id_from_league_or_none(sport)
     query = """
         INSERT INTO historical_stats (
             sport, season, week, team_code, player_id, player_name,
-            stat_category, stats, source, source_file
+            stat_category, stats, source, source_file, sport_id
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON CONFLICT (sport, season, COALESCE(week, -1), COALESCE(team_code, ''),
                      COALESCE(player_id, ''), stat_category, source)
         DO UPDATE SET
             player_name = EXCLUDED.player_name,
             stats = EXCLUDED.stats,
-            source_file = EXCLUDED.source_file
+            source_file = EXCLUDED.source_file,
+            sport_id = COALESCE(EXCLUDED.sport_id, historical_stats.sport_id)
         RETURNING historical_stat_id
     """
     with get_cursor(commit=True) as cur:
@@ -120,6 +126,7 @@ def insert_historical_stat(
                 stats_json,
                 source,
                 source_file,
+                sport_id_value,
             ),
         )
         result = cur.fetchone()
@@ -171,18 +178,21 @@ def insert_historical_stats_batch(
     if not records:
         return (0, 0)
 
+    # Dual-write (#738 A1): resolve sport_id from the league-code stored in
+    # the `sport` column (historical_stats uses league codes, not sport names).
     query = """
         INSERT INTO historical_stats (
             sport, season, week, team_code, player_id, player_name,
-            stat_category, stats, source, source_file
+            stat_category, stats, source, source_file, sport_id
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON CONFLICT (sport, season, COALESCE(week, -1), COALESCE(team_code, ''),
                      COALESCE(player_id, ''), stat_category, source)
         DO UPDATE SET
             player_name = EXCLUDED.player_name,
             stats = EXCLUDED.stats,
-            source_file = EXCLUDED.source_file
+            source_file = EXCLUDED.source_file,
+            sport_id = COALESCE(EXCLUDED.sport_id, historical_stats.sport_id)
     """
     total_inserted = 0
 
@@ -201,6 +211,7 @@ def insert_historical_stats_batch(
                     json.dumps(r["stats"]),
                     r["source"],
                     r.get("source_file"),
+                    get_sport_id_from_league_or_none(r["sport"]),
                 )
                 for r in batch
             ]
@@ -478,12 +489,15 @@ def insert_historical_ranking(
         - uq_historical_rankings_team_poll_week unique constraint
         - ADR-106: Historical Data Collection Architecture
     """
+    # Dual-write (#738 A1): resolve sport_id from the league-code stored in
+    # `sport` (historical_rankings uses league codes).
+    sport_id_value = get_sport_id_from_league_or_none(sport)
     query = """
         INSERT INTO historical_rankings (
             sport, season, week, team_code, rank, previous_rank,
-            points, first_place_votes, poll_type, source, source_file
+            points, first_place_votes, poll_type, source, source_file, sport_id
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON CONFLICT (sport, season, week, team_code, poll_type)
         DO UPDATE SET
             rank = EXCLUDED.rank,
@@ -491,7 +505,8 @@ def insert_historical_ranking(
             points = EXCLUDED.points,
             first_place_votes = EXCLUDED.first_place_votes,
             source = EXCLUDED.source,
-            source_file = EXCLUDED.source_file
+            source_file = EXCLUDED.source_file,
+            sport_id = COALESCE(EXCLUDED.sport_id, historical_rankings.sport_id)
         RETURNING historical_ranking_id
     """
     with get_cursor(commit=True) as cur:
@@ -509,6 +524,7 @@ def insert_historical_ranking(
                 poll_type,
                 source,
                 source_file,
+                sport_id_value,
             ),
         )
         result = cur.fetchone()
@@ -550,12 +566,14 @@ def insert_historical_rankings_batch(
     if not records:
         return (0, 0)
 
+    # Dual-write (#738 A1): resolve sport_id for each record from its
+    # league-code `sport` value.
     query = """
         INSERT INTO historical_rankings (
             sport, season, week, team_code, rank, previous_rank,
-            points, first_place_votes, poll_type, source, source_file
+            points, first_place_votes, poll_type, source, source_file, sport_id
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         ON CONFLICT (sport, season, week, team_code, poll_type)
         DO UPDATE SET
             rank = EXCLUDED.rank,
@@ -563,7 +581,8 @@ def insert_historical_rankings_batch(
             points = EXCLUDED.points,
             first_place_votes = EXCLUDED.first_place_votes,
             source = EXCLUDED.source,
-            source_file = EXCLUDED.source_file
+            source_file = EXCLUDED.source_file,
+            sport_id = COALESCE(EXCLUDED.sport_id, historical_rankings.sport_id)
     """
     total_inserted = 0
 
@@ -583,6 +602,7 @@ def insert_historical_rankings_batch(
                     r["poll_type"],
                     r["source"],
                     r.get("source_file"),
+                    get_sport_id_from_league_or_none(r["sport"]),
                 )
                 for r in batch
             ]

--- a/src/precog/database/crud_lookups.py
+++ b/src/precog/database/crud_lookups.py
@@ -1,0 +1,258 @@
+"""Cached lookup helpers for the `sports` and `leagues` lookup tables.
+
+These tables are populated by migration 0060 (#738 A1) and hold at most 6 + 11
+rows.  Since the values are effectively immutable during a process lifetime
+(new sports/leagues only land via migration or a deliberate INSERT), we cache
+the full maps at first use and serve subsequent lookups from memory.
+
+Consumers (CRUD dual-write callers) should call:
+
+    sport_id = get_sport_id("football")   # returns int, raises on unknown
+    league_id = get_league_id("nfl")      # returns int, raises on unknown
+
+... or the *`_or_none` variants if the caller wants to tolerate missing keys
+(e.g., when the incoming VARCHAR value predates the lookup seed).
+
+The module is thread-safe for read-after-first-populate: cache population is
+gated by a single lock, and subsequent reads are dict lookups only.
+
+Related:
+  * Migration 0060 (#738 A1) — creates the tables and seeds 6 + 11 rows.
+  * `crud_teams.py`, `crud_game_states.py`, `crud_historical.py`, `crud_elo.py`
+    — primary consumers via dual-write pattern.
+  * Design memo: `memory/design_738_lookup_tables.md`
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+from .connection import fetch_all
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# CACHE STATE
+# =============================================================================
+# Populated lazily on first lookup, then re-used for the process lifetime.
+# Call `invalidate_cache()` from tests to force a refresh between scenarios.
+
+_sport_key_to_id: dict[str, int] | None = None
+_league_key_to_id: dict[str, int] | None = None
+_league_key_to_sport_id: dict[str, int] | None = None
+_cache_lock = threading.Lock()
+
+
+def _populate_cache() -> None:
+    """Load the sports + leagues tables into the module-level caches.
+
+    Safe to call multiple times; re-runs overwrite prior state.  Callers
+    should hold `_cache_lock` or be okay with the race (the worst-case
+    outcome is a double-load, not incorrect data).
+
+    If the lookup tables do not yet exist (e.g., a test DB that has not
+    been upgraded past migration 0060), the cache is populated with empty
+    dicts.  All `*_or_none` helpers then return None and the `_direct`
+    variants raise KeyError — exactly the same surface as if a caller
+    passes an unknown key.  This keeps unit tests that mock `get_cursor`
+    but not `fetch_all` from blowing up on import-time DB access.
+    """
+    global _sport_key_to_id, _league_key_to_id, _league_key_to_sport_id
+    try:
+        sport_rows: list[dict[str, Any]] = fetch_all("SELECT id, sport_key FROM sports")
+        league_rows: list[dict[str, Any]] = fetch_all(
+            "SELECT id, league_key, sport_id FROM leagues"
+        )
+    except Exception as exc:
+        # UndefinedTable (pre-0060 DB), connection errors, etc. — degrade
+        # gracefully to empty cache.  Dual-write callers use the
+        # `*_or_none` variants, which return None on missing keys, so the
+        # INSERT still succeeds with NULL in the new FK column.  A2 will
+        # enforce NOT NULL and surface any lingering gap.
+        logger.debug(
+            "Lookup cache could not be populated (likely pre-0060 schema): %s",
+            exc,
+        )
+        _sport_key_to_id = {}
+        _league_key_to_id = {}
+        _league_key_to_sport_id = {}
+        return
+    _sport_key_to_id = {row["sport_key"]: int(row["id"]) for row in sport_rows}
+    _league_key_to_id = {row["league_key"]: int(row["id"]) for row in league_rows}
+    _league_key_to_sport_id = {row["league_key"]: int(row["sport_id"]) for row in league_rows}
+    logger.debug(
+        "Lookup cache populated: %d sports, %d leagues",
+        len(_sport_key_to_id),
+        len(_league_key_to_id),
+    )
+
+
+def _ensure_cache() -> None:
+    """Populate the cache on first call; no-op thereafter."""
+    if _sport_key_to_id is not None and _league_key_to_id is not None:
+        return
+    with _cache_lock:
+        if _sport_key_to_id is None or _league_key_to_id is None:
+            _populate_cache()
+
+
+def invalidate_cache() -> None:
+    """Force the next lookup to re-fetch from the database.
+
+    Use from test fixtures that mutate lookup-table contents between scenarios.
+    Production code does not need this — the tables are effectively immutable.
+    """
+    global _sport_key_to_id, _league_key_to_id, _league_key_to_sport_id
+    with _cache_lock:
+        _sport_key_to_id = None
+        _league_key_to_id = None
+        _league_key_to_sport_id = None
+
+
+# =============================================================================
+# PUBLIC LOOKUP API
+# =============================================================================
+
+
+def get_sport_id(sport_key: str) -> int:
+    """Resolve a sport_key string to its sports.id FK value.
+
+    Args:
+        sport_key: Sport key string ('football', 'basketball', 'hockey',
+            'baseball', 'soccer', 'mma').
+
+    Returns:
+        The sports.id integer for that key.
+
+    Raises:
+        KeyError: If sport_key is not present in the `sports` table.
+            Callers that want to tolerate unknown keys should use
+            `get_sport_id_or_none()` instead.
+
+    Example:
+        >>> get_sport_id("football")
+        1
+    """
+    _ensure_cache()
+    assert _sport_key_to_id is not None  # _ensure_cache() guarantees this
+    try:
+        return _sport_key_to_id[sport_key]
+    except KeyError:
+        raise KeyError(
+            f"Unknown sport_key: {sport_key!r}. Valid keys: {sorted(_sport_key_to_id.keys())!r}"
+        ) from None
+
+
+def get_sport_id_or_none(sport_key: str | None) -> int | None:
+    """Same as `get_sport_id` but returns None for unknown or None input.
+
+    Useful during the A1 -> A2 window where CRUD callers may legitimately
+    pass `sport=None` (column is still nullable) or pass a league code into
+    the `sport` slot (the dual-write then populates only the VARCHAR column,
+    not the FK).
+    """
+    if sport_key is None:
+        return None
+    _ensure_cache()
+    assert _sport_key_to_id is not None
+    return _sport_key_to_id.get(sport_key)
+
+
+def get_league_id(league_key: str) -> int:
+    """Resolve a league_key string to its leagues.id FK value.
+
+    Args:
+        league_key: League key string ('nfl', 'ncaaf', 'nba', 'ncaab',
+            'ncaaw', 'wnba', 'nhl', 'mlb', 'mls', 'soccer', 'ufc').
+
+    Returns:
+        The leagues.id integer for that key.
+
+    Raises:
+        KeyError: If league_key is not present in the `leagues` table.
+    """
+    _ensure_cache()
+    assert _league_key_to_id is not None
+    try:
+        return _league_key_to_id[league_key]
+    except KeyError:
+        raise KeyError(
+            f"Unknown league_key: {league_key!r}. Valid keys: {sorted(_league_key_to_id.keys())!r}"
+        ) from None
+
+
+def get_league_id_or_none(league_key: str | None) -> int | None:
+    """Same as `get_league_id` but returns None for unknown or None input."""
+    if league_key is None:
+        return None
+    _ensure_cache()
+    assert _league_key_to_id is not None
+    return _league_key_to_id.get(league_key)
+
+
+def get_sport_id_from_league(league_key: str) -> int:
+    """Resolve a league_key to its parent sports.id (via the leagues table).
+
+    Used in the dual-write path for tables like `historical_stats` where the
+    VARCHAR `sport` column actually holds league codes ('nfl', 'ncaaf', ...)
+    but the new FK column we're populating is `sport_id`.
+
+    Args:
+        league_key: League key string.
+
+    Returns:
+        The `sports.id` integer for the league's parent sport.
+
+    Raises:
+        KeyError: If league_key is not present in the `leagues` table.
+    """
+    _ensure_cache()
+    assert _league_key_to_sport_id is not None
+    try:
+        return _league_key_to_sport_id[league_key]
+    except KeyError:
+        raise KeyError(
+            f"Unknown league_key: {league_key!r}. "
+            f"Valid keys: {sorted(_league_key_to_sport_id.keys())!r}"
+        ) from None
+
+
+def get_sport_id_from_league_or_none(league_key: str | None) -> int | None:
+    """Same as `get_sport_id_from_league` but returns None for unknown input."""
+    if league_key is None:
+        return None
+    _ensure_cache()
+    assert _league_key_to_sport_id is not None
+    return _league_key_to_sport_id.get(league_key)
+
+
+def resolve_sport_id_for_mixed_value(value: str | None) -> int | None:
+    """Handle the `game_odds.sport` mixed-convention case.
+
+    The `game_odds.sport` VARCHAR column historically accepts EITHER a sport
+    name ('football', 'basketball') OR a league code ('nfl', 'nba') due to
+    the expanded CHECK constraint in migration 0048.  This helper resolves
+    either shape to a canonical `sports.id`:
+
+      1. First try direct `sport_key` lookup.
+      2. Fall back to `league_key` -> `leagues.sport_id`.
+      3. Return None if the value matches neither.
+
+    Returns None (rather than raising) for unknown values so that dual-write
+    callers don't break on a value that slipped past the backfill.  The
+    backfill itself enforces zero-NULL at migration time, but incremental
+    writes during the A1 -> A2 window should be permissive.
+    """
+    if value is None:
+        return None
+    _ensure_cache()
+    assert _sport_key_to_id is not None
+    assert _league_key_to_sport_id is not None
+    if value in _sport_key_to_id:
+        return _sport_key_to_id[value]
+    if value in _league_key_to_sport_id:
+        return _league_key_to_sport_id[value]
+    return None

--- a/src/precog/database/crud_lookups.py
+++ b/src/precog/database/crud_lookups.py
@@ -229,6 +229,34 @@ def get_sport_id_from_league_or_none(league_key: str | None) -> int | None:
     return _league_key_to_sport_id.get(league_key)
 
 
+def resolve_league_id_via_game(game_id: int | None) -> int | None:
+    """Resolve league_id for game_odds by looking up the games row.
+
+    game_odds has no native `league` VARCHAR column — the league context
+    comes from the linked `games.league` value.  This helper fetches the
+    games row's league key (via game_id) and resolves it to a leagues.id.
+
+    Returns None if game_id is None, the games row doesn't exist, or the
+    games.league value isn't in the lookup cache (same permissive semantics
+    as the other `*_or_none` helpers during the A1 -> A2 window).
+    """
+    if game_id is None:
+        return None
+    try:
+        from .connection import fetch_one
+
+        row = fetch_one(
+            "SELECT league FROM games WHERE id = %s",
+            (game_id,),
+        )
+    except Exception:
+        return None
+    if row is None:
+        return None
+    league_key = row.get("league")
+    return get_league_id_or_none(league_key)
+
+
 def resolve_sport_id_for_mixed_value(value: str | None) -> int | None:
     """Handle the `game_odds.sport` mixed-convention case.
 

--- a/src/precog/database/crud_teams.py
+++ b/src/precog/database/crud_teams.py
@@ -919,7 +919,7 @@ def upsert_external_team_code(
             team_id = EXCLUDED.team_id,
             confidence = EXCLUDED.confidence,
             notes = EXCLUDED.notes,
-            league_id = EXCLUDED.league_id,
+            league_id = COALESCE(EXCLUDED.league_id, external_team_codes.league_id),
             updated_at = NOW()
         RETURNING id
     """

--- a/src/precog/database/crud_teams.py
+++ b/src/precog/database/crud_teams.py
@@ -17,6 +17,7 @@ from typing import Any, cast
 import psycopg2.errors
 
 from .connection import fetch_all, fetch_one, get_cursor
+from .crud_lookups import get_league_id_or_none, get_sport_id_or_none
 
 logger = logging.getLogger(__name__)
 
@@ -301,13 +302,20 @@ def create_team(
             )
             return team_id
 
-    # Step 3: Team doesn't exist — INSERT it
+    # Step 3: Team doesn't exist — INSERT it.
+    # Dual-write (#738 A1): populate both the VARCHAR sport/league and the
+    # new FK columns sport_id/league_id.  FK resolution is best-effort —
+    # unknown keys leave the FK NULL, which is valid during A1 (columns are
+    # nullable).  A2 enforces NOT NULL and B drops the VARCHAR.
+    sport_id_value = get_sport_id_or_none(sport)
+    league_id_value = get_league_id_or_none(league)
     insert_query = """
         INSERT INTO teams (
             team_code, team_name, display_name, sport, league,
-            espn_team_id, current_elo_rating, conference, division
+            espn_team_id, current_elo_rating, conference, division,
+            sport_id, league_id
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         RETURNING team_id
     """
     params = (
@@ -320,6 +328,8 @@ def create_team(
         current_elo_rating,
         conference,
         division,
+        sport_id_value,
+        league_id_value,
     )
 
     try:
@@ -723,16 +733,28 @@ def create_external_team_code(
         - Issue #516: External team codes table
         - Migration 0045: CREATE TABLE external_team_codes
     """
+    # Dual-write (#738 A1): also populate league_id FK.
+    league_id_value = get_league_id_or_none(league)
     query = """
         INSERT INTO external_team_codes
-            (team_id, source, source_team_code, league, confidence, verified_at, notes)
-        VALUES (%s, %s, %s, %s, %s, %s, %s)
+            (team_id, source, source_team_code, league, confidence,
+             verified_at, notes, league_id)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
         RETURNING id
     """
     with get_cursor(commit=True) as cur:
         cur.execute(
             query,
-            (team_id, source, source_team_code, league, confidence, verified_at, notes),
+            (
+                team_id,
+                source,
+                source_team_code,
+                league,
+                confidence,
+                verified_at,
+                notes,
+                league_id_value,
+            ),
         )
         row = cur.fetchone()
         return cast("int", row["id"])
@@ -886,20 +908,26 @@ def upsert_external_team_code(
         - Issue #516: External team codes table
         - scripts/seed_external_team_codes.py: Primary consumer
     """
+    # Dual-write (#738 A1): also populate league_id FK.
+    league_id_value = get_league_id_or_none(league)
     query = """
         INSERT INTO external_team_codes
-            (team_id, source, source_team_code, league, confidence, notes)
-        VALUES (%s, %s, %s, %s, %s, %s)
+            (team_id, source, source_team_code, league, confidence, notes, league_id)
+        VALUES (%s, %s, %s, %s, %s, %s, %s)
         ON CONFLICT (source, source_team_code, league)
         DO UPDATE SET
             team_id = EXCLUDED.team_id,
             confidence = EXCLUDED.confidence,
             notes = EXCLUDED.notes,
+            league_id = EXCLUDED.league_id,
             updated_at = NOW()
         RETURNING id
     """
     with get_cursor(commit=True) as cur:
-        cur.execute(query, (team_id, source, source_team_code, league, confidence, notes))
+        cur.execute(
+            query,
+            (team_id, source, source_team_code, league, confidence, notes, league_id_value),
+        )
         row = cur.fetchone()
         return cast("int", row["id"])
 

--- a/src/precog/database/seeding/epa_seeder.py
+++ b/src/precog/database/seeding/epa_seeder.py
@@ -40,6 +40,7 @@ from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from sqlalchemy import text
 
+from precog.database.crud_lookups import get_sport_id_from_league_or_none
 from precog.database.seeding.sources.sports.nflreadpy_adapter import (
     EPARecord,
     NFLReadPySource,
@@ -318,6 +319,11 @@ class EPASeeder:
         """
         now = datetime.datetime.now(datetime.UTC)
 
+        # Dual-write (#738 A1): historical_epa.sport uses league codes
+        # (only 'nfl' today, per migration 0013 CHECK).  Populate both the
+        # VARCHAR and the sport_id FK.  The `sport` column has a server
+        # default of 'nfl' so prior callers omitted it; we now set it
+        # explicitly to keep the INSERT self-documenting.
         self.connection.execute(
             text(
                 """
@@ -326,13 +332,13 @@ class EPASeeder:
                     off_epa_per_play, pass_epa_per_play, rush_epa_per_play,
                     def_epa_per_play, def_pass_epa_per_play, def_rush_epa_per_play,
                     epa_differential, games_played, source,
-                    created_at, updated_at
+                    created_at, updated_at, sport, sport_id
                 ) VALUES (
                     :team_id, :season, :week,
                     :off_epa, :pass_epa, :rush_epa,
                     :def_epa, :def_pass_epa, :def_rush_epa,
                     :epa_diff, :games_played, :source,
-                    :created_at, :updated_at
+                    :created_at, :updated_at, :sport, :sport_id
                 )
                 """
             ),
@@ -351,6 +357,8 @@ class EPASeeder:
                 "source": record["source"],
                 "created_at": now,
                 "updated_at": now,
+                "sport": "nfl",
+                "sport_id": get_sport_id_from_league_or_none("nfl"),
             },
         )
 

--- a/src/precog/database/seeding/game_odds_loader.py
+++ b/src/precog/database/seeding/game_odds_loader.py
@@ -45,6 +45,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from precog.database.connection import get_cursor
+from precog.database.crud_lookups import resolve_sport_id_for_mixed_value
 from precog.database.seeding.batch_result import (
     BatchInsertResult,
     ErrorHandlingMode,
@@ -174,6 +175,9 @@ def insert_game_odds(record: OddsRecord) -> bool:
     source = normalize_source_name(record["source"])
     sportsbook = record.get("sportsbook") or "consensus"
 
+    # Dual-write (#738 A1): game_odds.sport holds EITHER sport names OR
+    # league codes (mixed convention).  Resolve via the helper.
+    sport_id_value = resolve_sport_id_for_mixed_value(record["sport"])
     with get_cursor(commit=True) as cursor:
         cursor.execute(
             """
@@ -187,13 +191,13 @@ def insert_game_odds(record: OddsRecord) -> bool:
                 total_open, total_close,
                 over_odds_open, over_odds_close,
                 home_covered, game_went_over,
-                source, source_file
+                source, source_file, sport_id
             ) VALUES (
                 %s, %s, %s, %s, %s, %s,
                 %s, %s, %s, %s,
                 %s, %s, %s, %s,
                 %s, %s, %s, %s,
-                %s, %s, %s, %s
+                %s, %s, %s, %s, %s
             )
             ON CONFLICT (sport, game_date, home_team_code, away_team_code, sportsbook)
                 WHERE row_current_ind = TRUE
@@ -214,7 +218,8 @@ def insert_game_odds(record: OddsRecord) -> bool:
                 home_covered = COALESCE(EXCLUDED.home_covered, game_odds.home_covered),
                 game_went_over = COALESCE(EXCLUDED.game_went_over, game_odds.game_went_over),
                 source = EXCLUDED.source,
-                source_file = EXCLUDED.source_file
+                source_file = EXCLUDED.source_file,
+                sport_id = COALESCE(EXCLUDED.sport_id, game_odds.sport_id)
             """,
             (
                 game_id,
@@ -239,6 +244,7 @@ def insert_game_odds(record: OddsRecord) -> bool:
                 record.get("game_went_over"),
                 source,
                 record.get("source_file"),
+                sport_id_value,
             ),
         )
         return True
@@ -313,6 +319,9 @@ def bulk_insert_game_odds(
             source = normalize_source_name(record["source"])
             sportsbook = record.get("sportsbook") or "consensus"
 
+            # Dual-write (#738 A1): resolve sport_id for the mixed-
+            # convention `sport` column (sport names OR league codes).
+            sport_id_value = resolve_sport_id_for_mixed_value(record["sport"])
             batch.append(
                 (
                     game_id,
@@ -337,6 +346,7 @@ def bulk_insert_game_odds(
                     record.get("game_went_over"),
                     source,
                     record.get("source_file"),
+                    sport_id_value,
                 )
             )
 
@@ -374,6 +384,7 @@ def _flush_odds_batch(batch: list[tuple[Any, ...]]) -> int:
     with get_cursor(commit=True) as cursor:
         from psycopg2.extras import execute_values
 
+        # Dual-write (#738 A1): batch tuples now include sport_id at tail.
         query = """
             INSERT INTO game_odds (
                 game_id, sport, game_date,
@@ -385,7 +396,7 @@ def _flush_odds_batch(batch: list[tuple[Any, ...]]) -> int:
                 total_open, total_close,
                 over_odds_open, over_odds_close,
                 home_covered, game_went_over,
-                source, source_file
+                source, source_file, sport_id
             ) VALUES %s
             ON CONFLICT (sport, game_date, home_team_code, away_team_code, sportsbook)
                 WHERE row_current_ind = TRUE
@@ -396,7 +407,8 @@ def _flush_odds_batch(batch: list[tuple[Any, ...]]) -> int:
                 home_covered = COALESCE(EXCLUDED.home_covered, game_odds.home_covered),
                 game_went_over = COALESCE(EXCLUDED.game_went_over, game_odds.game_went_over),
                 source = EXCLUDED.source,
-                source_file = EXCLUDED.source_file
+                source_file = EXCLUDED.source_file,
+                sport_id = COALESCE(EXCLUDED.sport_id, game_odds.sport_id)
         """
         execute_values(cursor, query, batch)
         return len(batch)

--- a/src/precog/database/seeding/game_odds_loader.py
+++ b/src/precog/database/seeding/game_odds_loader.py
@@ -45,7 +45,10 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from precog.database.connection import get_cursor
-from precog.database.crud_lookups import resolve_sport_id_for_mixed_value
+from precog.database.crud_lookups import (
+    resolve_league_id_via_game,
+    resolve_sport_id_for_mixed_value,
+)
 from precog.database.seeding.batch_result import (
     BatchInsertResult,
     ErrorHandlingMode,
@@ -178,6 +181,9 @@ def insert_game_odds(record: OddsRecord) -> bool:
     # Dual-write (#738 A1): game_odds.sport holds EITHER sport names OR
     # league codes (mixed convention).  Resolve via the helper.
     sport_id_value = resolve_sport_id_for_mixed_value(record["sport"])
+    # Dual-write (#738 A1 amendment): resolve league_id via the linked
+    # games row (game_odds has no native `league` VARCHAR column).
+    league_id_value = resolve_league_id_via_game(game_id)
     with get_cursor(commit=True) as cursor:
         cursor.execute(
             """
@@ -191,13 +197,13 @@ def insert_game_odds(record: OddsRecord) -> bool:
                 total_open, total_close,
                 over_odds_open, over_odds_close,
                 home_covered, game_went_over,
-                source, source_file, sport_id
+                source, source_file, sport_id, league_id
             ) VALUES (
                 %s, %s, %s, %s, %s, %s,
                 %s, %s, %s, %s,
                 %s, %s, %s, %s,
                 %s, %s, %s, %s,
-                %s, %s, %s, %s, %s
+                %s, %s, %s, %s, %s, %s
             )
             ON CONFLICT (sport, game_date, home_team_code, away_team_code, sportsbook)
                 WHERE row_current_ind = TRUE
@@ -219,7 +225,8 @@ def insert_game_odds(record: OddsRecord) -> bool:
                 game_went_over = COALESCE(EXCLUDED.game_went_over, game_odds.game_went_over),
                 source = EXCLUDED.source,
                 source_file = EXCLUDED.source_file,
-                sport_id = COALESCE(EXCLUDED.sport_id, game_odds.sport_id)
+                sport_id = COALESCE(EXCLUDED.sport_id, game_odds.sport_id),
+                league_id = COALESCE(EXCLUDED.league_id, game_odds.league_id)
             """,
             (
                 game_id,
@@ -245,6 +252,7 @@ def insert_game_odds(record: OddsRecord) -> bool:
                 source,
                 record.get("source_file"),
                 sport_id_value,
+                league_id_value,
             ),
         )
         return True
@@ -322,6 +330,9 @@ def bulk_insert_game_odds(
             # Dual-write (#738 A1): resolve sport_id for the mixed-
             # convention `sport` column (sport names OR league codes).
             sport_id_value = resolve_sport_id_for_mixed_value(record["sport"])
+            # Dual-write (#738 A1 amendment): resolve league_id via
+            # the linked games row.
+            league_id_value = resolve_league_id_via_game(game_id)
             batch.append(
                 (
                     game_id,
@@ -347,6 +358,7 @@ def bulk_insert_game_odds(
                     source,
                     record.get("source_file"),
                     sport_id_value,
+                    league_id_value,
                 )
             )
 
@@ -384,7 +396,7 @@ def _flush_odds_batch(batch: list[tuple[Any, ...]]) -> int:
     with get_cursor(commit=True) as cursor:
         from psycopg2.extras import execute_values
 
-        # Dual-write (#738 A1): batch tuples now include sport_id at tail.
+        # Dual-write (#738 A1): batch tuples include sport_id + league_id at tail.
         query = """
             INSERT INTO game_odds (
                 game_id, sport, game_date,
@@ -396,7 +408,7 @@ def _flush_odds_batch(batch: list[tuple[Any, ...]]) -> int:
                 total_open, total_close,
                 over_odds_open, over_odds_close,
                 home_covered, game_went_over,
-                source, source_file, sport_id
+                source, source_file, sport_id, league_id
             ) VALUES %s
             ON CONFLICT (sport, game_date, home_team_code, away_team_code, sportsbook)
                 WHERE row_current_ind = TRUE
@@ -408,7 +420,8 @@ def _flush_odds_batch(batch: list[tuple[Any, ...]]) -> int:
                 game_went_over = COALESCE(EXCLUDED.game_went_over, game_odds.game_went_over),
                 source = EXCLUDED.source,
                 source_file = EXCLUDED.source_file,
-                sport_id = COALESCE(EXCLUDED.sport_id, game_odds.sport_id)
+                sport_id = COALESCE(EXCLUDED.sport_id, game_odds.sport_id),
+                league_id = COALESCE(EXCLUDED.league_id, game_odds.league_id)
         """
         execute_values(cursor, query, batch)
         return len(batch)

--- a/src/precog/database/seeding/historical_games_loader.py
+++ b/src/precog/database/seeding/historical_games_loader.py
@@ -46,6 +46,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from precog.database.connection import get_cursor
+from precog.database.crud_lookups import (
+    get_league_id_or_none,
+    get_sport_id_or_none,
+)
 from precog.database.seeding.batch_result import (
     BatchInsertResult,
     ErrorHandlingMode,
@@ -539,6 +543,10 @@ def bulk_insert_historical_games(
 
             league_code = record["sport"]
             sport_name = _LEAGUE_TO_SPORT.get(league_code, league_code)
+            # Dual-write (#738 A1): resolve FK ids for games.sport_id and
+            # games.league_id.  sport_name may be a sport ('football') or
+            # a league code fallback (if the map misses); use the direct
+            # sport lookup — misses are OK during A1 (nullable).
             batch.append(
                 (
                     sport_name,
@@ -559,6 +567,8 @@ def bulk_insert_historical_games(
                     record["external_game_id"],
                     league_code,  # league = league code for historical imports
                     game_status,
+                    get_sport_id_or_none(sport_name),
+                    get_league_id_or_none(league_code),
                 )
             )
 
@@ -596,13 +606,14 @@ def _flush_games_batch(batch: list[tuple[Any, ...]]) -> int:
     with get_cursor(commit=True) as cursor:
         from psycopg2.extras import execute_values
 
+        # Dual-write (#738 A1): batch tuples now include sport_id + league_id at tail.
         query = """
             INSERT INTO games (
                 sport, season, game_date, home_team_code, away_team_code,
                 home_team_id, away_team_id, home_score, away_score,
                 neutral_site, is_playoff, game_type, venue_name,
                 data_source, source_file, external_game_id,
-                league, game_status
+                league, game_status, sport_id, league_id
             ) VALUES %s
             ON CONFLICT (sport, game_date, home_team_code, away_team_code) DO UPDATE SET
                 home_team_id = COALESCE(EXCLUDED.home_team_id, games.home_team_id),
@@ -616,7 +627,9 @@ def _flush_games_batch(batch: list[tuple[Any, ...]]) -> int:
                 data_source = EXCLUDED.data_source,
                 source_file = COALESCE(EXCLUDED.source_file, games.source_file),
                 external_game_id = COALESCE(EXCLUDED.external_game_id, games.external_game_id),
-                updated_at = NOW()
+                updated_at = NOW(),
+                sport_id = COALESCE(EXCLUDED.sport_id, games.sport_id),
+                league_id = COALESCE(EXCLUDED.league_id, games.league_id)
         """
         execute_values(cursor, query, batch)
         return len(batch)

--- a/tests/unit/database/test_crud_operations_unit.py
+++ b/tests/unit/database/test_crud_operations_unit.py
@@ -2411,7 +2411,11 @@ class TestCreateTeamUnit:
         params = call_args[1]
         assert "INSERT INTO teams" in sql
         assert "RETURNING team_id" in sql
-        # Verify all 9 params are passed in correct order
+        # Verify all 11 params are passed in correct order.
+        # The trailing sport_id/league_id pair lands from the #738 A1
+        # dual-write path; the cache falls back to None when the
+        # lookup tables aren't populated in the unit-test DB, so both
+        # FK values resolve to None here.
         assert params == (
             "ALA",
             "Alabama Crimson Tide",
@@ -2422,6 +2426,8 @@ class TestCreateTeamUnit:
             None,
             "SEC",
             "West",
+            None,
+            None,
         )
 
     @patch("precog.database.crud_teams.get_cursor")


### PR DESCRIPTION
## Summary

Closes #738 Migration A1 (of 3-migration arc: A1/A2/B).

Adds canonical `sports` + `leagues` lookup tables with seed data, nullable FK columns on 10 tables (12 FK columns total -- `game_odds` gets both `sport_id` and `league_id`), deterministic backfill, and dual-write CRUD updates so every new INSERT populates BOTH the legacy VARCHAR value AND the resolved FK id.

Unblocks UFC (#795) via the seeded `ufc` row on `mma` sport.

A2 (NOT NULL enforcement + drop the 9 CHECK constraints + view recreation + fixture updates) and B (drop VARCHAR) land in future sessions.

## Changes

### Schema
- Migration 0060: creates `sports` (6 seeds) + `leagues` (11 seeds).
- Adds nullable `sport_id` / `league_id` FK columns (ON DELETE RESTRICT) + partial indexes (`WHERE col IS NOT NULL`) on 10 tables (12 FK columns):
  - `teams` (sport + league)
  - `games` (sport + league)
  - `game_states` (league only)
  - `game_odds` (sport + league -- sport via mixed-convention resolver, league via JOIN through `game_id -> games.league -> leagues.id`)
  - `historical_stats`, `historical_rankings`, `historical_epa` (sport only)
  - `elo_calculation_log` (league only)
  - `external_team_codes` (league only)
- Backfill resolves each row's existing VARCHAR value to its FK id.  For `game_odds.sport` the helper handles BOTH sport names (`football`) AND league codes (`nfl`).  For `game_odds.league_id`, the backfill JOINs through `game_id -> games.league -> leagues.league_key` (works regardless of games.league_id backfill order).
- Zero-NULL assertion: the migration `RAISE`s a `RuntimeError` with up to 20 sample unmatched values if any row fails to backfill -- no silent NULLs.  For `game_odds.league_id`, rows with NULL `game_id` are excluded from the assertion (no game row to join through).

### Dual-write CRUD layer
- New: `src/precog/database/crud_lookups.py`
  - `get_sport_id` / `get_league_id` / `get_sport_id_from_league` (raise on unknown)
  - `*_or_none` variants (tolerant)
  - `resolve_sport_id_for_mixed_value` for the `game_odds.sport` mixed case
  - `resolve_league_id_via_game` for `game_odds.league_id` (looks up games row by game_id, resolves league key to leagues.id)
  - Cache degrades gracefully (empty dicts) if the tables are absent, so unit tests that mock `get_cursor` but not `fetch_all` continue to pass on a pre-0060 test DB.
- Dual-write INSERT updates in:
  - `crud_teams.py` -- `create_team`, `create_external_team_code`, `upsert_external_team_code`
  - `crud_game_states.py` -- `create_game_state` (x2), `upsert_game_state`, `get_or_create_game`, `upsert_game_odds` (sport_id + league_id)
  - `crud_historical.py` -- `insert_historical_stat` (+batch), `insert_historical_ranking` (+batch)
  - `crud_elo.py` -- `insert_elo_calculation_log`
  - `analytics/elo_computation_service.py` -- direct `elo_calculation_log` INSERT
  - `database/seeding/epa_seeder.py` -- `historical_epa` INSERT (now sets `sport` + `sport_id` explicitly)
  - `database/seeding/game_odds_loader.py` -- upsert + batch flush (sport_id + league_id)
  - `database/seeding/historical_games_loader.py` -- batch flush

### Test updates
- `tests/unit/database/test_crud_operations_unit.py::test_insert_includes_all_fields` updated to expect 11 params (was 9) -- the trailing `(None, None)` is the dual-write pair, which resolves to NULL when the unit-test DB has no lookup tables.

## PM answers to the 7 open design questions (locked in this PR)

| # | Question | Answer |
|---|----------|--------|
| Q1 | Add espn_slug / kalshi_prefix to leagues? | DEFER -- not in this PR |
| Q2 | Migration split? | Three-migration arc A1/A2/B -- THIS is A1 |
| Q3 | VARCHAR aliasing? | FORCE JOIN -- CRUD dual-writes here, reads flip in A2 |
| Q4 | `game_odds.sport` mixed convention | **AMENDED**: Originally sport_id only. PM review added `league_id` for schema symmetry with other multi-sport tables + robustness against future unmatched imports (game_id is nullable). Backfill via `games.league` JOIN; 100% match rate on current data (198/198). |
| Q5 | Include `games.league` + `external_team_codes.league`? | YES |
| Q6 | Conferences / divisions as 3rd level? | NO -- out of scope |
| Q7 | Seed `mls`? | YES -- included |

## Verification

- [x] Migration applies cleanly on dev DB (0058 -> 0060).
- [x] Backfill leaves zero NULLs across all 12 new FK columns at migration time. One anomaly in live `game_states` post-migration was traced to a background ESPN poller running pre-PR code concurrently with the upgrade -- not a migration bug, not a correctness regression. Will self-heal on next service restart with the new dual-write code.
- [x] All 2,605 unit tests pass.
- [x] All unit + integration + e2e tests pass (3,782 passed, 20 skipped) in 406s.
- [x] Pre-push parallel tiers: unit 57s, integration+e2e 353s, stress+chaos+race 222s -- all green.
- [x] UFC seed row exists (`leagues.ufc` -> `sports.mma`), unblocking #795.
- [x] Ruff format + check clean on all changed files.
- [x] **Amendment**: `game_odds.league_id` backfill verified: 198/198 rows populated, 0 NULLs where `game_id IS NOT NULL`. Round-trip (downgrade 0058 + upgrade head) clean.

## Explicitly OUT OF SCOPE (future PRs)

- A2: NOT NULL enforcement on new FK columns, drop the 9 CHECK constraints, recreate the 4 sport/league-referencing views, test fixture updates, seed SQL updates.
- B: Drop the deprecated VARCHAR `sport` / `league` columns.

## Notes for reviewers

- Migration `down_revision` is `"0058"`, not `"0059"`.  #725/0059 was not yet on main when this branch was cut.  If #725 lands first, this migration needs a trivial rebase (change `down_revision` + rename to 0061).
- The backfill uses dynamic SQL interpolation from a hardcoded `_FK_COLUMN_SPEC` module-level constant; S608 suppressions are explicit and scoped.
- The `crud_lookups.py` cache is process-local and invalidated via `invalidate_cache()` -- primarily for tests that mutate lookup rows across scenarios.
- **Amendment commit** (`89a8ba9`): adds `game_odds.league_id` per PM review. New `join_via_game` lookup_kind resolves league via `game_id -> games.league -> leagues.league_key`. The zero-NULL assertion for this column filters `WHERE game_id IS NOT NULL` (rows with NULL game_id allowed to have NULL league_id).

## Agent Review Trail

- Holden + Galadriel (S54 design review, captured in `design_738_lookup_tables.md`)
- PM S57 live-DB diagnostic (answered all 7 open design questions)
- Samwise (build, S57)
- Samwise (amendment build, S57 -- added `game_odds.league_id` per PM review)
- (Joe Chip review + Ripley QA to follow in separate dispatch)

Closes #738 (partial -- A1 of 3)