### PR TITLE
fix: Make 0061 CHECK drops idempotent + fix docstring count

### DIFF
--- a/src/precog/database/alembic/versions/0061_lookup_tables_a2_not_null.py
+++ b/src/precog/database/alembic/versions/0061_lookup_tables_a2_not_null.py
@@ -12,7 +12,7 @@ Steps:
        via a different path (e.g., game_odds.league_id via game lookup)
        are verified but not backfilled — they should already be clean.
     2. Verify zero NULLs on ALL FK columns (hard fail if any remain).
-    3. SET NOT NULL on all 11 FK columns.
+    3. SET NOT NULL on all 12 FK columns.
     4. DROP 9 redundant VARCHAR CHECK constraints.
 
 The VARCHAR sport/league columns are NOT dropped here — that's arc B.
@@ -117,8 +117,10 @@ def upgrade() -> None:
         op.alter_column(table, col, nullable=False)
 
     # ── Step 4: DROP redundant CHECK constraints ────────────────────────
+    # Use raw SQL with IF EXISTS for idempotency — the downgrade does NOT
+    # recreate CHECKs, so a downgrade+upgrade cycle would fail without this.
     for table, constraint_name in _CHECKS_TO_DROP:
-        op.drop_constraint(constraint_name, table, type_="check")
+        op.execute(sa.text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {constraint_name}"))
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary

- Switch CHECK constraint drops from `op.drop_constraint()` to raw SQL `ALTER TABLE ... DROP CONSTRAINT IF EXISTS` for idempotency
- Fix docstring count (11→12 FK columns)

**Why:** The downgrade of 0061 does NOT recreate CHECK constraints (by design). A downgrade+upgrade cycle fails because `op.drop_constraint` raises on missing constraints. Discovered during S59 dev DB remediation when migration 0059 was found missing from the live DB.

Closes #856

## Test plan
- [x] Pre-push: migration-only fast path (integration+E2E passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)