### PR TITLE
feat: #791 C2c — Migration 0062 business key columns + CRUD two-step INSERT

### DIFF
--- a/src/precog/database/alembic/versions/0061_lookup_tables_a2_not_null.py
+++ b/src/precog/database/alembic/versions/0061_lookup_tables_a2_not_null.py
@@ -12,7 +12,7 @@ Steps:
        via a different path (e.g., game_odds.league_id via game lookup)
        are verified but not backfilled — they should already be clean.
     2. Verify zero NULLs on ALL FK columns (hard fail if any remain).
-    3. SET NOT NULL on all 11 FK columns.
+    3. SET NOT NULL on all 12 FK columns.
     4. DROP 9 redundant VARCHAR CHECK constraints.
 
 The VARCHAR sport/league columns are NOT dropped here — that's arc B.
@@ -117,8 +117,10 @@ def upgrade() -> None:
         op.alter_column(table, col, nullable=False)
 
     # ── Step 4: DROP redundant CHECK constraints ────────────────────────
+    # Use raw SQL with IF EXISTS for idempotency — the downgrade does NOT
+    # recreate CHECKs, so a downgrade+upgrade cycle would fail without this.
     for table, constraint_name in _CHECKS_TO_DROP:
-        op.drop_constraint(constraint_name, table, type_="check")
+        op.execute(sa.text(f"ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {constraint_name}"))
 
 
 def downgrade() -> None:

--- a/src/precog/database/alembic/versions/0062_business_key_columns.py
+++ b/src/precog/database/alembic/versions/0062_business_key_columns.py
@@ -1,0 +1,189 @@
+"""0062: C2c business key columns on markets/events/game_states/games.
+
+Arc: Phase B kickoff of the Schema Hardening Arc (epic #745, issue #791).
+
+Adds a stable, human-readable business key (``market_key``, ``event_key``,
+``game_state_key``, ``game_key``) to each of the four core entity tables.
+These ``<entity>_key`` columns provide:
+
+  * Cross-platform identity for non-Kalshi markets (Polymarket, Manifold, etc.)
+  * Stable SCD2 natural keys (carried forward on supersede, preserved across
+    versions of the same logical entity)
+  * Human-readable primary reference in logs and analytics
+
+Design memo: S59 Holden + Galadriel review (design_791_c2c_business_keys.md).
+Sibling migration 0063 adds SCD2 temporal columns to strategies +
+probability_models (separate PR).  Sibling migration 0064 wires
+``orderbook_snapshot_id`` onto orders + edges (#725 item 11, separate PR).
+
+Steps:
+    1. ADD COLUMN <x>_key VARCHAR NULL on each of markets / events /
+       game_states / games.
+    2. Backfill ``<PREFIX>-<id>`` into each column using a single UPDATE
+       per table (row counts from MCP: markets 8,242; events 4,121;
+       game_states 29,087; games 5,074 — all sub-second).
+    3. SET NOT NULL on all four columns.
+    4. Indexes:
+         - markets, events, games: full UNIQUE btree on ``<x>_key``
+           (these tables are dimensions, not SCD2 — one row per business key).
+         - game_states: a non-unique btree on ``game_state_key`` for
+           lookup, PLUS a partial UNIQUE (``game_state_key``) WHERE
+           ``row_current_ind = true`` (SCD2-aware — at most one current
+           row per business key).
+
+Downgrade: strict reverse (drop indexes → DROP NOT NULL → drop columns).
+
+CRUD impact (same PR, lands alongside this migration):
+    * ``crud_markets.create_market`` — two-step INSERT (TEMP sentinel →
+      ``MKT-{id}`` via UPDATE) so the ``NOT NULL`` column is always
+      populated before any other transaction can see the row.
+    * ``crud_events.create_event`` — two-step INSERT (TEMP → ``EVT-{id}``).
+    * ``crud_game_states.create_game_state`` — two-step INSERT (TEMP → ``GST-{id}``).
+    * ``crud_game_states.upsert_game_state`` — expand the FOR UPDATE lock
+      query SELECT list to include ``game_state_key``; carry existing key
+      forward on supersede (SCD Type 2 rule — never regenerate).
+    * ``crud_game_states.get_or_create_game`` — two-step INSERT (TEMP →
+      ``GAM-{id}``) on the CREATE path; COALESCE on the ON CONFLICT path.
+    * ``seeding/historical_games_loader._flush_games_batch`` — follow-up
+      UPDATE on the batch to set ``game_key = 'GAM-' || id`` for newly
+      inserted rows.
+
+Issue: #791
+Epic: #745 (Schema Hardening Arc, Cohort C2c)
+Session: S60
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import sqlalchemy as sa
+from alembic import op
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# revision identifiers, used by Alembic.
+revision: str = "0062"
+down_revision: str = "0061"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# ─── Per-table spec ─────────────────────────────────────────────────────────
+# (table, key_column, prefix, is_scd2)
+#
+# ``is_scd2=True`` means the table has a ``row_current_ind`` column and the
+# UNIQUE constraint on the new ``<x>_key`` must be a *partial* UNIQUE that
+# only fires for the current version (allowing historical versions to share
+# the same business key).  Non-SCD2 tables (dimensions) get a full UNIQUE.
+_KEY_SPEC: list[tuple[str, str, str, bool]] = [
+    ("markets", "market_key", "MKT", False),
+    ("events", "event_key", "EVT", False),
+    ("game_states", "game_state_key", "GST", True),
+    ("games", "game_key", "GAM", False),
+]
+
+
+def upgrade() -> None:
+    """Add + backfill + index the four new business-key columns."""
+    conn = op.get_bind()
+
+    # ─── Step 1: ADD COLUMN (nullable) ──────────────────────────────────────
+    # Must be nullable first so the backfill in step 2 can run.  Step 3
+    # enforces NOT NULL once every row has a value.
+    for table, key_col, _prefix, _is_scd2 in _KEY_SPEC:
+        op.execute(f"ALTER TABLE {table} ADD COLUMN {key_col} VARCHAR")
+
+    # ─── Step 2: Backfill from surrogate id ─────────────────────────────────
+    # Pattern: <PREFIX>-<id>, e.g. "MKT-42", "GAM-1007".  All four tables
+    # have an INTEGER ``id`` column (PK, SERIAL).  Row counts verified via
+    # MCP are sub-second trivial for PostgreSQL — no batching required.
+    #
+    # ``WHERE <key_col> IS NULL`` is a defensive filter: allows this
+    # migration to be re-run (or re-applied after a partial failure)
+    # without corrupting rows that already got a key value from CRUD
+    # writes between steps.
+    #
+    # ``prefix`` is sent as a bound parameter (not f-string interpolated)
+    # to keep the SQL stable for PostgreSQL statement caching and to eliminate
+    # any residual injection surface — table/key_col are hardcoded module
+    # constants, but routing ``prefix`` through binds is still the correct
+    # default pattern (Glokta S60 review W1).
+    for table, key_col, prefix, _is_scd2 in _KEY_SPEC:
+        # safe: table/key_col are hardcoded module constants; prefix is a bind
+        conn.execute(
+            sa.text(
+                f"UPDATE {table} SET {key_col} = :prefix || '-' || id "  # noqa: S608
+                f"WHERE {key_col} IS NULL"
+            ),
+            {"prefix": prefix},
+        )
+
+    # ─── Step 2.5: Zero-NULL assertion ──────────────────────────────────────
+    # If any row failed to backfill, surface the row count (not a sample,
+    # since id is monotonic and a count tells ops everything they need).
+    # A NULL here would cause step 3 (SET NOT NULL) to fail opaquely.
+    for table, key_col, _prefix, _is_scd2 in _KEY_SPEC:
+        null_count = conn.execute(
+            sa.text(
+                f"SELECT COUNT(*) FROM {table} WHERE {key_col} IS NULL"  # noqa: S608
+            )
+        ).scalar()
+        if null_count and int(null_count) > 0:
+            raise RuntimeError(
+                f"[0062] Backfill failure on {table}.{key_col}: "
+                f"{null_count} row(s) still NULL after backfill. "
+                f"This should be impossible — every row has a non-NULL "
+                f"``id`` — and indicates a data-integrity issue that must "
+                f"be investigated before retrying."
+            )
+
+    # ─── Step 3: SET NOT NULL ───────────────────────────────────────────────
+    for table, key_col, _prefix, _is_scd2 in _KEY_SPEC:
+        op.alter_column(table, key_col, nullable=False)
+
+    # ─── Step 4: Indexes ────────────────────────────────────────────────────
+    # Non-SCD2 tables (markets, events, games): full UNIQUE btree.  One row
+    # per logical entity, enforced at every point in time.
+    #
+    # SCD2 table (game_states): two indexes —
+    #   (a) non-unique btree for efficient lookup of any version by key;
+    #   (b) partial UNIQUE WHERE row_current_ind = true, mirroring the
+    #       existing ``idx_game_states_current_unique`` pattern (which is
+    #       on ``espn_event_id``).  The partial predicate allows historical
+    #       versions to share the same ``game_state_key`` while guaranteeing
+    #       at most one CURRENT row per business key.
+    for table, key_col, _prefix, is_scd2 in _KEY_SPEC:
+        if is_scd2:
+            # game_states: lookup btree (all versions)
+            op.execute(f"CREATE INDEX idx_{table}_{key_col} ON {table}({key_col})")
+            # game_states: SCD2-aware partial UNIQUE (current version only)
+            op.execute(
+                f"CREATE UNIQUE INDEX idx_{table}_{key_col}_current "
+                f"ON {table}({key_col}) WHERE row_current_ind = true"
+            )
+        else:
+            # markets / events / games: full UNIQUE (one row per key)
+            op.execute(f"CREATE UNIQUE INDEX idx_{table}_{key_col} ON {table}({key_col})")
+
+
+def downgrade() -> None:
+    """Strict reverse of upgrade (indexes → nullability → columns)."""
+    # ─── Reverse Step 4: drop indexes ───────────────────────────────────────
+    # For SCD2 table, drop BOTH indexes (lookup + partial UNIQUE).
+    for table, key_col, _prefix, is_scd2 in reversed(_KEY_SPEC):
+        if is_scd2:
+            op.execute(f"DROP INDEX IF EXISTS idx_{table}_{key_col}_current")
+            op.execute(f"DROP INDEX IF EXISTS idx_{table}_{key_col}")
+        else:
+            op.execute(f"DROP INDEX IF EXISTS idx_{table}_{key_col}")
+
+    # ─── Reverse Step 3: restore nullable ───────────────────────────────────
+    for table, key_col, _prefix, _is_scd2 in reversed(_KEY_SPEC):
+        op.alter_column(table, key_col, nullable=True)
+
+    # ─── Reverse Step 1: drop columns ───────────────────────────────────────
+    # (Step 2 backfill is inherently reversed by column drop.)
+    for table, key_col, _prefix, _is_scd2 in reversed(_KEY_SPEC):
+        op.execute(f"ALTER TABLE {table} DROP COLUMN IF EXISTS {key_col}")

--- a/src/precog/database/crud_events.py
+++ b/src/precog/database/crud_events.py
@@ -9,6 +9,7 @@ Tables covered:
 
 import json
 import logging
+import uuid
 from typing import Any, cast
 
 from .connection import fetch_one, get_cursor
@@ -575,15 +576,26 @@ def create_event(
         - Migration 0038: events.game_id FK to games(id)
         - Migration 0047: Dropped redundant event_id column
     """
+    # Migration 0062 (#791): events.event_key is NOT NULL + UNIQUE.  We
+    # only know ``id`` after INSERT, so we use a two-step pattern: insert
+    # with a uniquely-generated TEMP sentinel, then UPDATE to
+    # ``EVT-{id}`` in the same transaction.  The TEMP sentinel uses
+    # ``uuid.uuid4`` so concurrent INSERTs cannot collide on the UNIQUE
+    # index during the window between INSERT and UPDATE.  The ``commit=True``
+    # cursor ensures both steps land atomically; external readers never
+    # observe the TEMP value.
+    temp_event_key = f"TEMP-{uuid.uuid4()}"
+
+    # Migration 0062: event_key added to INSERT (two-step: TEMP → EVT-{id}).
     query = """
         INSERT INTO events (
             platform_id, series_id, external_id,
             category, subcategory, title, description,
             start_time, end_time, status, metadata,
-            game_id,
+            game_id, event_key,
             created_at, updated_at
         )
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW(), NOW())
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW(), NOW())
         RETURNING id
     """
 
@@ -600,12 +612,21 @@ def create_event(
         status,
         json.dumps(metadata) if metadata else None,
         game_id,
+        temp_event_key,
     )
 
     with get_cursor(commit=True) as cur:
         cur.execute(query, params)
         result = cur.fetchone()
-        return cast("int", result["id"])
+        event_pk = cast("int", result["id"])
+
+        # Step 1b: Replace TEMP event_key with canonical ``EVT-{id}``.
+        cur.execute(
+            "UPDATE events SET event_key = %s WHERE id = %s",
+            (f"EVT-{event_pk}", event_pk),
+        )
+
+        return event_pk
 
 
 def _fill_event_null_fields(

--- a/src/precog/database/crud_game_states.py
+++ b/src/precog/database/crud_game_states.py
@@ -10,6 +10,7 @@ Tables covered:
 
 import json
 import logging
+import uuid
 from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any, cast
@@ -154,17 +155,29 @@ def create_game_state(
     """
     # Dual-write (#738 A1): populate league_id FK alongside the VARCHAR.
     league_id_value = get_league_id_or_none(league)
+
+    # Migration 0062 (#791): game_states.game_state_key is NOT NULL + partial
+    # UNIQUE (WHERE row_current_ind = true).  Two-step INSERT: insert with a
+    # uniquely-generated TEMP sentinel, then UPDATE to ``GST-{id}``.  Using
+    # ``uuid.uuid4`` for the TEMP value guarantees concurrent first-inserts
+    # cannot collide on the partial UNIQUE during the narrow window between
+    # steps.  Both steps run inside the same ``get_cursor(commit=True)``
+    # transaction so the TEMP value is never externally visible.
+    temp_game_state_key = f"TEMP-{uuid.uuid4()}"
+
+    # Migration 0062: game_state_key added (two-step: TEMP → GST-{id}).
     insert_query = """
         INSERT INTO game_states (
             espn_event_id, home_team_id, away_team_id, venue_id,
             home_score, away_score, period, clock_seconds, clock_display,
             game_status, game_date, broadcast, neutral_site,
             season_type, week_number, league, situation, linescores,
-            data_source, game_id, league_id, row_current_ind, row_start_ts
+            data_source, game_id, league_id, game_state_key,
+            row_current_ind, row_start_ts
         )
         VALUES (
             %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-            %s, %s, %s, TRUE, NOW()
+            %s, %s, %s, %s, TRUE, NOW()
         )
         RETURNING id
     """
@@ -193,10 +206,19 @@ def create_game_state(
                 data_source,
                 game_id,
                 league_id_value,
+                temp_game_state_key,
             ),
         )
         result = cur.fetchone()
-        return cast("int", result["id"])
+        game_state_pk = cast("int", result["id"])
+
+        # Step 1b: Replace TEMP key with canonical ``GST-{id}``.
+        cur.execute(
+            "UPDATE game_states SET game_state_key = %s WHERE id = %s",
+            (f"GST-{game_state_pk}", game_state_pk),
+        )
+
+        return game_state_pk
 
 
 def get_current_game_state(espn_event_id: str) -> dict[str, Any] | None:
@@ -434,8 +456,14 @@ def upsert_game_state(
     # where the sibling caller's row is now visible and the close+insert
     # proceeds normally.
 
+    # Migration 0062 (#791): game_state_key added.  Lock query SELECT list
+    # is expanded to also fetch ``game_state_key`` (zero extra round-trips —
+    # same row, same index entry).  This is the critical SCD2 copy-forward
+    # contract: on the supersede path, the existing key is carried forward
+    # to the new version verbatim; on the first-insert path it will be NULL
+    # and we fall through to the two-step TEMP sentinel pattern.
     lock_query = """
-        SELECT id FROM game_states
+        SELECT id, game_state_key FROM game_states
         WHERE espn_event_id = %s
           AND row_current_ind = TRUE
         FOR UPDATE
@@ -451,17 +479,23 @@ def upsert_game_state(
 
     # Dual-write (#738 A1): populate league_id FK alongside the VARCHAR.
     league_id_value = get_league_id_or_none(league)
+
+    # Migration 0062: game_state_key added to INSERT.  On the supersede
+    # path the caller provides the existing key (carried forward from the
+    # locked row); on first-insert path we send a uniquely-generated TEMP
+    # sentinel and replace it with ``GST-{id}`` after RETURNING id.
     insert_query = """
         INSERT INTO game_states (
             espn_event_id, home_team_id, away_team_id, venue_id,
             home_score, away_score, period, clock_seconds, clock_display,
             game_status, game_date, broadcast, neutral_site,
             season_type, week_number, league, situation, linescores,
-            data_source, game_id, league_id, row_current_ind, row_start_ts
+            data_source, game_id, league_id, game_state_key,
+            row_current_ind, row_start_ts
         )
         VALUES (
             %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-            %s, %s, %s, TRUE, %s
+            %s, %s, %s, %s, TRUE, %s
         )
         RETURNING id
     """
@@ -475,21 +509,57 @@ def upsert_game_state(
         each attempt so the close and insert use a single timestamp per
         attempt -- never carrying a timestamp across the retry boundary,
         which would create backward temporal intervals.
+
+        Migration 0062 (#791): game_state_key handling —
+          * Supersede path (current row exists): the locked row yields
+            ``game_state_key``; that value is carried forward verbatim to
+            the new row (SCD Type 2 rule — the logical entity's business
+            key is stable across versions, never regenerated).
+          * First-insert path (no current row): insert with a TEMP sentinel
+            and UPDATE to ``GST-{id}`` in the same transaction.  The TEMP
+            uses ``uuid.uuid4`` so concurrent first-inserts cannot collide
+            on the partial UNIQUE index during the INSERT → UPDATE window.
         """
         with get_cursor(commit=True) as cur:
             # Capture timestamp once for temporal continuity within THIS attempt.
             cur.execute("SELECT NOW() AS ts")
             now = cur.fetchone()["ts"]
 
-            # Step 1: Lock current row (if any). On the first-insert path
-            # this returns zero rows; on retry the sibling caller's row is
-            # now visible and gets locked.
+            # Step 1: Lock current row (if any) and fetch its game_state_key.
+            # On the first-insert path this returns zero rows; on retry the
+            # sibling caller's row is now visible and gets locked.
             cur.execute(lock_query, (espn_event_id,))
+            locked = cur.fetchone()
+
+            # Determine the game_state_key for the new row.
+            #   * supersede path: carry forward the locked row's key
+            #     (Pattern 18 / design memo §"game_states key carry-forward").
+            #   * first-insert path: use a TEMP sentinel, we'll rewrite it
+            #     to ``GST-{id}`` after RETURNING id.
+            if locked is not None:
+                # Defensive guard (Glokta S60 review W2): surface a broken
+                # 0062 backfill as a clear Python RuntimeError instead of a
+                # NOT NULL constraint violation at INSERT time.  game_state_key
+                # is NOT NULL post-0062 on every current row, so a None here
+                # means the migration backfill or a CRUD path wrote a NULL —
+                # a data-integrity bug that needs Python-level attention.
+                if locked["game_state_key"] is None:
+                    raise RuntimeError(
+                        f"game_state_key is NULL on current row id="
+                        f"{locked['id']} for espn_event_id={espn_event_id} "
+                        f"-- migration 0062 backfill broken?"
+                    )
+                new_game_state_key = locked["game_state_key"]
+                is_first_insert = False
+            else:
+                new_game_state_key = f"TEMP-{uuid.uuid4()}"
+                is_first_insert = True
 
             # Step 2: Close current row (no-op if no current row exists).
             cur.execute(close_query, (now, espn_event_id))
 
-            # Step 3: Insert new row with matching row_start_ts.
+            # Step 3: Insert new row with matching row_start_ts and the
+            # carried-forward (or TEMP) game_state_key.
             cur.execute(
                 insert_query,
                 (
@@ -514,6 +584,7 @@ def upsert_game_state(
                     data_source,
                     game_id,
                     league_id_value,
+                    new_game_state_key,
                     now,
                 ),
             )
@@ -524,7 +595,19 @@ def upsert_game_state(
                     "this should be impossible after a successful INSERT and "
                     "indicates a DB trigger or constraint suppressed the return."
                 )
-            return cast("int", result["id"])
+            new_id = cast("int", result["id"])
+
+            # Step 4 (first-insert path only): rewrite the TEMP sentinel to
+            # the canonical ``GST-{id}``.  On the supersede path the key is
+            # already correct (copied from the locked row), so no follow-up
+            # UPDATE is needed — preserving the hot-path performance.
+            if is_first_insert:
+                cur.execute(
+                    "UPDATE game_states SET game_state_key = %s WHERE id = %s",
+                    (f"GST-{new_id}", new_id),
+                )
+
+            return new_id
 
     # Wrap the attempt in the SCD race-prevention retry helper. See issue #623
     # and crud_shared.retry_on_scd_unique_conflict for the full design.
@@ -775,6 +858,26 @@ def get_or_create_game(
     # `league` column uses league codes ('nfl').
     sport_id_value = get_sport_id_or_none(sport)
     league_id_value = get_league_id_or_none(league)
+
+    # Migration 0062 (#791): games.game_key is NOT NULL + UNIQUE.  This is
+    # an upsert (ON CONFLICT), which complicates the two-step pattern:
+    #   * CREATE path: insert with a uniquely-generated TEMP sentinel,
+    #     then UPDATE to ``GAM-{id}`` after RETURNING id.
+    #   * CONFLICT path: the existing row already has a valid game_key
+    #     (guaranteed NOT NULL post-0062); we preserve it verbatim by
+    #     assigning ``game_key = games.game_key`` in the SET clause.
+    #     This is a no-op update but keeps the column in the RETURNING
+    #     clause's row image and makes the preservation semantics explicit.
+    #     (Glokta S60 review W5: dead ``COALESCE(games.game_key, EXCLUDED.game_key)``
+    #     simplified — EXCLUDED fallback was unreachable with NOT NULL.)
+    #
+    # The INSERT sends a TEMP sentinel so that IF the insert branch wins
+    # (new row), the row has a unique non-NULL value satisfying the NOT
+    # NULL + UNIQUE constraints; we then immediately rewrite it to the
+    # canonical ``GAM-{id}``.  IF the conflict branch wins, the TEMP
+    # sentinel never reaches the row (``games.game_key`` is preserved).
+    temp_game_key = f"TEMP-{uuid.uuid4()}"
+
     query = """
         INSERT INTO games (
             sport, game_date, home_team_code, away_team_code,
@@ -784,13 +887,13 @@ def get_or_create_game(
             game_time, espn_event_id, external_game_id,
             game_status, data_source,
             home_score, away_score, source_file, attendance,
-            sport_id, league_id
+            sport_id, league_id, game_key
         )
         VALUES (
             %s, %s, %s, %s, %s, %s, %s, %s,
             %s, %s, %s, %s, %s, %s, %s,
             %s, %s, %s, %s, %s, %s, %s, %s, %s,
-            %s, %s
+            %s, %s, %s
         )
         ON CONFLICT (sport, game_date, home_team_code, away_team_code) DO UPDATE SET
             updated_at = NOW(),
@@ -815,8 +918,9 @@ def get_or_create_game(
             source_file = COALESCE(EXCLUDED.source_file, games.source_file),
             attendance = COALESCE(EXCLUDED.attendance, games.attendance),
             sport_id = COALESCE(EXCLUDED.sport_id, games.sport_id),
-            league_id = COALESCE(EXCLUDED.league_id, games.league_id)
-        RETURNING id
+            league_id = COALESCE(EXCLUDED.league_id, games.league_id),
+            game_key = games.game_key
+        RETURNING id, game_key
     """
     params = (
         sport,
@@ -845,11 +949,25 @@ def get_or_create_game(
         attendance,
         sport_id_value,
         league_id_value,
+        temp_game_key,
     )
     with get_cursor(commit=True) as cur:
         cur.execute(query, params)
         result = cur.fetchone()
-        return cast("int", result["id"])
+        game_pk = cast("int", result["id"])
+        returned_key = cast("str", result["game_key"])
+
+        # Step 1b: If the INSERT branch fired (returned_key equals our
+        # TEMP sentinel), rewrite it to the canonical ``GAM-{id}``.  If the
+        # CONFLICT branch fired (returned_key is the existing row's stable
+        # key), skip the UPDATE — the key is already canonical.
+        if returned_key == temp_game_key:
+            cur.execute(
+                "UPDATE games SET game_key = %s WHERE id = %s",
+                (f"GAM-{game_pk}", game_pk),
+            )
+
+        return game_pk
 
 
 def update_game_result(

--- a/src/precog/database/crud_markets.py
+++ b/src/precog/database/crud_markets.py
@@ -9,6 +9,7 @@ Tables covered:
 
 import json
 import logging
+import uuid
 from decimal import Decimal
 from typing import Any, cast
 
@@ -181,12 +182,23 @@ def create_market(
     if previous_price is not None:
         previous_price = validate_decimal(previous_price, "previous_price")
 
+    # Migration 0062 (#791): markets.market_key is NOT NULL + UNIQUE.  We
+    # can only know the surrogate ``id`` after INSERT, so we use a
+    # two-step pattern: insert with a uniquely-generated TEMP sentinel,
+    # then UPDATE to ``MKT-{id}`` in the same transaction.  The TEMP
+    # sentinel uses ``uuid.uuid4`` so concurrent INSERTs never collide
+    # on the UNIQUE index during the ~microseconds between INSERT and
+    # UPDATE.  Because both steps share ``get_cursor(commit=True)``,
+    # readers outside the transaction never see the TEMP value.
+    temp_market_key = f"TEMP-{uuid.uuid4()}"
+
     with get_cursor(commit=True) as cur:
-        # Step 1: Insert dimension row
+        # Step 1: Insert dimension row with TEMP market_key placeholder.
         # Migration 0022: market_id VARCHAR dropped — no longer inserted.
         # Migration 0033: enrichment columns added (subtitle, timestamps, etc.)
         # Migration 0037: league renamed to subcategory
         # Migration 0046: expiration_value, notional_value added
+        # Migration 0062: market_key added (two-step: TEMP → MKT-{id})
         cur.execute(
             """
             INSERT INTO markets (
@@ -195,9 +207,9 @@ def create_market(
                 subtitle, open_time, close_time, expiration_time,
                 outcome_label, subcategory, bracket_count, source_url,
                 expiration_value, notional_value,
-                metadata, updated_at
+                metadata, market_key, updated_at
             )
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
             RETURNING id
             """,
             (
@@ -220,10 +232,19 @@ def create_market(
                 expiration_value,
                 notional_value,
                 json.dumps(metadata) if metadata else None,
+                temp_market_key,
             ),
         )
         dim_row = cur.fetchone()
         market_pk = cast("int", dim_row["id"])
+
+        # Step 1b: Replace TEMP market_key with the canonical ``MKT-{id}``.
+        # Must happen before transaction commit so the TEMP value is never
+        # observable externally.
+        cur.execute(
+            "UPDATE markets SET market_key = %s WHERE id = %s",
+            (f"MKT-{market_pk}", market_pk),
+        )
 
         # Step 2: Insert initial snapshot (fact row)
         # Migration 0021: yes_bid_price, no_bid_price, last_price, liquidity

--- a/src/precog/database/seeding/historical_games_loader.py
+++ b/src/precog/database/seeding/historical_games_loader.py
@@ -41,6 +41,7 @@ import csv
 import json
 import logging
 import time
+import uuid
 from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
@@ -547,6 +548,15 @@ def bulk_insert_historical_games(
             # games.league_id.  sport_name may be a sport ('football') or
             # a league code fallback (if the map misses); use the direct
             # sport lookup — misses are OK during A1 (nullable).
+            #
+            # Migration 0062 (#791): games.game_key is NOT NULL + UNIQUE.
+            # Batch inserts don't know the surrogate ``id`` at INSERT time,
+            # so each row gets a uniquely-generated TEMP sentinel.  Rows
+            # that hit ON CONFLICT preserve the existing game_key (via the
+            # COALESCE in _flush_games_batch).  Rows that actually INSERT
+            # are rewritten to ``GAM-{id}`` by the post-insert UPDATE in
+            # _flush_games_batch.  ``uuid.uuid4`` guarantees uniqueness
+            # across rows in the same batch and across concurrent batches.
             batch.append(
                 (
                     sport_name,
@@ -569,6 +579,7 @@ def bulk_insert_historical_games(
                     game_status,
                     get_sport_id_or_none(sport_name),
                     get_league_id_or_none(league_code),
+                    f"TEMP-{uuid.uuid4()}",  # game_key sentinel; rewritten after INSERT
                 )
             )
 
@@ -606,14 +617,31 @@ def _flush_games_batch(batch: list[tuple[Any, ...]]) -> int:
     with get_cursor(commit=True) as cursor:
         from psycopg2.extras import execute_values
 
-        # Dual-write (#738 A1): batch tuples now include sport_id + league_id at tail.
+        # Dual-write (#738 A1): batch tuples include sport_id + league_id.
+        # Migration 0062 (#791): batch tuples also include a TEMP game_key
+        # sentinel per row (uniquely generated in the caller).  On the
+        # INSERT path the TEMP value lands in the row (satisfies NOT NULL +
+        # UNIQUE); on the ON CONFLICT path the existing row's game_key is
+        # preserved by assigning ``game_key = games.game_key`` (no-op update
+        # that makes preservation explicit).  The follow-up UPDATE below
+        # rewrites only the just-inserted rows' TEMP sentinels to the
+        # canonical ``GAM-{id}``.
+        #
+        # RETURNING id + WHERE id = ANY(...) (Glokta S60 review W3) narrows
+        # the post-insert UPDATE to only the rows this call actually
+        # inserted.  This (a) avoids a table scan / index sweep looking
+        # for stray ``LIKE 'TEMP-%'`` rows, and (b) makes the semantics
+        # fully local — the UPDATE cannot accidentally touch rows left
+        # behind by any crashed prior transaction (defensive; should never
+        # happen inside a single transaction, but keeps the write surface
+        # minimal and auditable).
         query = """
             INSERT INTO games (
                 sport, season, game_date, home_team_code, away_team_code,
                 home_team_id, away_team_id, home_score, away_score,
                 neutral_site, is_playoff, game_type, venue_name,
                 data_source, source_file, external_game_id,
-                league, game_status, sport_id, league_id
+                league, game_status, sport_id, league_id, game_key
             ) VALUES %s
             ON CONFLICT (sport, game_date, home_team_code, away_team_code) DO UPDATE SET
                 home_team_id = COALESCE(EXCLUDED.home_team_id, games.home_team_id),
@@ -629,9 +657,24 @@ def _flush_games_batch(batch: list[tuple[Any, ...]]) -> int:
                 external_game_id = COALESCE(EXCLUDED.external_game_id, games.external_game_id),
                 updated_at = NOW(),
                 sport_id = COALESCE(EXCLUDED.sport_id, games.sport_id),
-                league_id = COALESCE(EXCLUDED.league_id, games.league_id)
+                league_id = COALESCE(EXCLUDED.league_id, games.league_id),
+                game_key = games.game_key
+            RETURNING id, game_key
         """
-        execute_values(cursor, query, batch)
+        # execute_values with fetch=True returns all RETURNING rows as a
+        # single list.  Rows where game_key starts with 'TEMP-' hit the
+        # INSERT branch; rows with an existing key hit ON CONFLICT.
+        returned = execute_values(cursor, query, batch, fetch=True)
+        inserted_ids = [row["id"] for row in returned if str(row["game_key"]).startswith("TEMP-")]
+
+        # Post-insert canonicalization: rewrite ONLY the just-inserted rows'
+        # TEMP sentinels to the canonical ``GAM-{id}``.  Same transaction as
+        # the INSERT so external readers never observe a TEMP value.
+        if inserted_ids:
+            cursor.execute(
+                "UPDATE games SET game_key = 'GAM-' || id WHERE id = ANY(%s)",
+                (inserted_ids,),
+            )
         return len(batch)
 
 

--- a/tests/chaos/test_crud_operations_chaos.py
+++ b/tests/chaos/test_crud_operations_chaos.py
@@ -380,6 +380,7 @@ class TestGameStateNullHandling:
         # closure, so no placeholder is needed for it.
         mock_cursor.fetchone.side_effect = [
             {"ts": datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)},  # SELECT NOW() AS ts
+            None,  # FOR UPDATE lock query — first-insert path (0062 added game_state_key SELECT)
             {"id": 1},  # INSERT RETURNING id
         ]
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
@@ -413,6 +414,7 @@ class TestGameStateNullHandling:
         # closure, so no placeholder is needed for it.
         mock_cursor.fetchone.side_effect = [
             {"ts": datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)},  # SELECT NOW() AS ts
+            None,  # FOR UPDATE lock query — first-insert path (0062 added game_state_key SELECT)
             {"id": 1},  # INSERT RETURNING id
         ]
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
@@ -458,6 +460,7 @@ class TestGameStateBoundaryValues:
         # closure, so no placeholder is needed for it.
         mock_cursor.fetchone.side_effect = [
             {"ts": datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)},  # SELECT NOW() AS ts
+            None,  # FOR UPDATE lock query — first-insert path (0062 added game_state_key SELECT)
             {"id": 1},  # INSERT RETURNING id
         ]
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
@@ -492,6 +495,7 @@ class TestGameStateBoundaryValues:
         # closure, so no placeholder is needed for it.
         mock_cursor.fetchone.side_effect = [
             {"ts": datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)},  # SELECT NOW() AS ts
+            None,  # FOR UPDATE lock query — first-insert path (0062 added game_state_key SELECT)
             {"id": 1},  # INSERT RETURNING id
         ]
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
@@ -526,6 +530,7 @@ class TestGameStateBoundaryValues:
         # closure, so no placeholder is needed for it.
         mock_cursor.fetchone.side_effect = [
             {"ts": datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)},  # SELECT NOW() AS ts
+            None,  # FOR UPDATE lock query — first-insert path (0062 added game_state_key SELECT)
             {"id": 1},  # INSERT RETURNING id
         ]
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
@@ -572,6 +577,7 @@ class TestGameStateEdgeCases:
         # closure, so no placeholder is needed for it.
         mock_cursor.fetchone.side_effect = [
             {"ts": datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)},  # SELECT NOW() AS ts
+            None,  # FOR UPDATE lock query — first-insert path (0062 added game_state_key SELECT)
             {"id": 1},  # INSERT RETURNING id
         ]
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
@@ -605,6 +611,7 @@ class TestGameStateEdgeCases:
         # closure, so no placeholder is needed for it.
         mock_cursor.fetchone.side_effect = [
             {"ts": datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)},  # SELECT NOW() AS ts
+            None,  # FOR UPDATE lock query — first-insert path (0062 added game_state_key SELECT)
             {"id": 1},  # INSERT RETURNING id
         ]
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
@@ -660,6 +667,7 @@ class TestGameStateEdgeCases:
         # closure, so no placeholder is needed for it.
         mock_cursor.fetchone.side_effect = [
             {"ts": datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)},  # SELECT NOW() AS ts
+            None,  # FOR UPDATE lock query — first-insert path (0062 added game_state_key SELECT)
             {"id": 1},  # INSERT RETURNING id
         ]
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
@@ -781,6 +789,7 @@ class TestDecimalPrecisionChaos:
         # closure, so no placeholder is needed for it.
         mock_cursor.fetchone.side_effect = [
             {"ts": datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)},  # SELECT NOW() AS ts
+            None,  # FOR UPDATE lock query — first-insert path (0062 added game_state_key SELECT)
             {"id": 1},  # INSERT RETURNING id
         ]
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
@@ -814,6 +823,7 @@ class TestDecimalPrecisionChaos:
         # closure, so no placeholder is needed for it.
         mock_cursor.fetchone.side_effect = [
             {"ts": datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)},  # SELECT NOW() AS ts
+            None,  # FOR UPDATE lock query — first-insert path (0062 added game_state_key SELECT)
             {"id": 1},  # INSERT RETURNING id
         ]
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
@@ -847,6 +857,7 @@ class TestDecimalPrecisionChaos:
         # closure, so no placeholder is needed for it.
         mock_cursor.fetchone.side_effect = [
             {"ts": datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC)},  # SELECT NOW() AS ts
+            None,  # FOR UPDATE lock query — first-insert path (0062 added game_state_key SELECT)
             {"id": 1},  # INSERT RETURNING id
         ]
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,25 +273,37 @@ def clean_test_data(db_cursor):
     _series_row = db_cursor.fetchone()
     _test_series_pk = _series_row["id"] if _series_row else None
 
-    # Create test event (uses series_id integer FK to series.id)
-    # external_id is the canonical business key (migration 0047 dropped the old event_id column)
-    db_cursor.execute(
-        """
-        INSERT INTO events (platform_id, series_id, external_id, category, title, status)
-        VALUES ('test_platform', %s, 'TEST-EVT-NFL-KC-BUF', 'sports', 'Test Event: KC vs BUF', 'scheduled')
-        ON CONFLICT (platform_id, external_id) DO NOTHING
-    """,
-        (_test_series_pk,),
+    # Create test events via CRUD helper (migration 0062 #791 — #C2c):
+    # ``get_or_create_event`` runs the two-step ``TEMP → EVT-{id}`` key
+    # assignment inside the canonical code path, keeping this fixture in
+    # sync with production semantics and avoiding hand-rolled sentinels.
+    # The db_cursor we hold is uncommitted here; flush the series INSERT
+    # so the CRUD helper (which opens its own cursor) can see the parent
+    # series row via its own MVCC snapshot.
+    db_cursor.connection.commit()
+
+    from precog.database.crud_events import get_or_create_event
+
+    # external_id is the canonical business key (migration 0047 dropped event_id column)
+    get_or_create_event(
+        event_id="TEST-EVT-NFL-KC-BUF",
+        platform_id="test_platform",
+        external_id="TEST-EVT-NFL-KC-BUF",
+        category="sports",
+        title="Test Event: KC vs BUF",
+        series_id=_test_series_pk,
+        status="scheduled",
     )
 
-    # Create additional test event for test_execute_query
-    db_cursor.execute(
-        """
-        INSERT INTO events (platform_id, series_id, external_id, category, title, status)
-        VALUES ('test_platform', %s, 'TEST-EVT-2', 'sports', 'Test Event 2', 'scheduled')
-        ON CONFLICT (platform_id, external_id) DO NOTHING
-    """,
-        (_test_series_pk,),
+    # Additional test event for test_execute_query
+    get_or_create_event(
+        event_id="TEST-EVT-2",
+        platform_id="test_platform",
+        external_id="TEST-EVT-2",
+        category="sports",
+        title="Test Event 2",
+        series_id=_test_series_pk,
+        status="scheduled",
     )
 
     # Create test strategy and probability model (required parent records for positions/trades)

--- a/tests/fixtures/transaction_fixtures.py
+++ b/tests/fixtures/transaction_fixtures.py
@@ -187,25 +187,51 @@ def db_transaction_with_setup(
     _series_pk = _sr["id"] if _sr else None
 
     # Create test event (uses series_id integer FK to series.id)
-    # external_id is the canonical business key (migration 0047 dropped event_id column)
+    # external_id is the canonical business key (migration 0047 dropped event_id column).
+    #
+    # Migration 0062 (#791): events.event_key is NOT NULL + UNIQUE.  This
+    # fixture's whole reason for existing (Issue #171) is transaction
+    # rollback isolation — the cursor has autocommit=False and the parent
+    # ``db_transaction`` fixture rolls back at teardown.  Routing through
+    # the ``create_event`` CRUD helper here would open a separate connection
+    # with its own ``commit=True`` and defeat the rollback guarantee.
+    # Instead, we insert with a uniquely-generated TEMP event_key sentinel
+    # inline and immediately rewrite it to the canonical ``EVT-{id}`` in
+    # the same cursor — same transaction, fully rolled back at teardown.
+    import uuid as _uuid
+
     cursor.execute(
         """
-        INSERT INTO events (platform_id, series_id, external_id, category, title, status)
-        VALUES ('test_platform', %s, 'TEST-EVT-NFL-KC-BUF', 'sports', 'Test Event: KC vs BUF', 'scheduled')
+        INSERT INTO events (platform_id, series_id, external_id, category, title, status, event_key)
+        VALUES ('test_platform', %s, 'TEST-EVT-NFL-KC-BUF', 'sports', 'Test Event: KC vs BUF', 'scheduled', %s)
         ON CONFLICT (platform_id, external_id) DO NOTHING
+        RETURNING id
     """,
-        (_series_pk,),
+        (_series_pk, f"TEMP-{_uuid.uuid4()}"),
     )
+    _evt_row = cursor.fetchone()
+    if _evt_row is not None:
+        cursor.execute(
+            "UPDATE events SET event_key = %s WHERE id = %s",
+            (f"EVT-{_evt_row['id']}", _evt_row["id"]),
+        )
 
     # Create additional test event for compatibility
     cursor.execute(
         """
-        INSERT INTO events (platform_id, series_id, external_id, category, title, status)
-        VALUES ('test_platform', %s, 'TEST-EVT-2', 'sports', 'Test Event 2', 'scheduled')
+        INSERT INTO events (platform_id, series_id, external_id, category, title, status, event_key)
+        VALUES ('test_platform', %s, 'TEST-EVT-2', 'sports', 'Test Event 2', 'scheduled', %s)
         ON CONFLICT (platform_id, external_id) DO NOTHING
+        RETURNING id
     """,
-        (_series_pk,),
+        (_series_pk, f"TEMP-{_uuid.uuid4()}"),
     )
+    _evt_row = cursor.fetchone()
+    if _evt_row is not None:
+        cursor.execute(
+            "UPDATE events SET event_key = %s WHERE id = %s",
+            (f"EVT-{_evt_row['id']}", _evt_row["id"]),
+        )
 
     # Create test strategy (high ID to avoid SERIAL collision)
     cursor.execute("""

--- a/tests/integration/database/test_crud_positions_trailing_stop_integration.py
+++ b/tests/integration/database/test_crud_positions_trailing_stop_integration.py
@@ -101,28 +101,25 @@ def trailing_stop_position(db_pool: Any) -> Any:
         # RESTRICT-safe cleanup: delete all children before parents.
         delete_market_with_children(cur, "ticker = %s", (_TEST_TICKER,))
 
-        # Create the underlying market (positions FK to markets.id).
-        cur.execute(
-            """
-            INSERT INTO markets (
-                platform_id, event_id, external_id, ticker, title,
-                market_type, status
-            )
-            VALUES (%s, %s, %s, %s, %s, %s, %s)
-            RETURNING id
-            """,
-            (
-                "kalshi",
-                None,
-                f"{_TEST_TICKER}-EXT",
-                _TEST_TICKER,
-                "Issue 629 Integration Market",
-                "binary",
-                "open",
-            ),
-        )
-        market_pk = cur.fetchone()["id"]
+    # Create the underlying market (positions FK to markets.id) via the
+    # CRUD helper.  Migration 0062 (#791): markets.market_key is NOT NULL +
+    # UNIQUE; ``create_market`` handles the ``TEMP → MKT-{id}`` two-step
+    # internally.
+    from precog.database.crud_markets import create_market
 
+    market_pk = create_market(
+        platform_id="kalshi",
+        event_id=None,
+        external_id=f"{_TEST_TICKER}-EXT",
+        ticker=_TEST_TICKER,
+        title="Issue 629 Integration Market",
+        yes_ask_price=Decimal("0.5000"),
+        no_ask_price=Decimal("0.5000"),
+        market_type="binary",
+        status="open",
+    )
+
+    with get_cursor(commit=True) as cur:
         # Create the initial open position (current row, no trailing stop yet).
         # execution_environment defaults to 'live' per migration 0008.
         cur.execute(
@@ -828,27 +825,22 @@ def create_position_market(db_pool: Any) -> Any:
             ),
         )
 
-        # Seed the market (positions FK to markets.id).
-        cur.execute(
-            """
-            INSERT INTO markets (
-                platform_id, event_id, external_id, ticker, title,
-                market_type, status
-            )
-            VALUES (%s, %s, %s, %s, %s, %s, %s)
-            RETURNING id
-            """,
-            (
-                "kalshi",
-                None,
-                f"{_CREATE_POS_TEST_TICKER}-EXT",
-                _CREATE_POS_TEST_TICKER,
-                "Issue 706 Integration Market",
-                "binary",
-                "open",
-            ),
-        )
-        market_pk = cur.fetchone()["id"]
+    # Seed the market (positions FK to markets.id) via the CRUD helper so
+    # migration 0062 (#791) ``market_key`` TEMP→MKT-{id} canonicalization
+    # runs inside the production code path.
+    from precog.database.crud_markets import create_market
+
+    market_pk = create_market(
+        platform_id="kalshi",
+        event_id=None,
+        external_id=f"{_CREATE_POS_TEST_TICKER}-EXT",
+        ticker=_CREATE_POS_TEST_TICKER,
+        title="Issue 706 Integration Market",
+        yes_ask_price=Decimal("0.5000"),
+        no_ask_price=Decimal("0.5000"),
+        market_type="binary",
+        status="open",
+    )
 
     yield market_pk
 

--- a/tests/integration/database/test_migration_0052_0055_execution_environment.py
+++ b/tests/integration/database/test_migration_0052_0055_execution_environment.py
@@ -40,6 +40,7 @@ Markers:
 
 from __future__ import annotations
 
+import uuid
 from decimal import Decimal
 from typing import Any
 
@@ -111,19 +112,26 @@ def migration_test_platform(db_pool: Any) -> Any:
             (platform_id,),
         )
 
-        # Market (FK target for settlements via market_id)
+        # Market (FK target for settlements via market_id).  Migration 0062
+        # (#791): markets.market_key is NOT NULL + UNIQUE.  Raw-SQL migration
+        # test — inline the TEMP→MKT-{id} two-step.
         cur.execute(
             """
             INSERT INTO markets (
-                platform_id, external_id, ticker, title, market_type, status
+                platform_id, external_id, ticker, title, market_type, status,
+                market_key
             )
             VALUES (%s, 'MIG-52-55-TEST', 'MIG-52-55-TEST',
-                    'Migration 0052-0055 test market', 'binary', 'open')
+                    'Migration 0052-0055 test market', 'binary', 'open', %s)
             RETURNING id
             """,
-            (platform_id,),
+            (platform_id, f"TEMP-{uuid.uuid4()}"),
         )
         market_id = cur.fetchone()["id"]
+        cur.execute(
+            "UPDATE markets SET market_key = %s WHERE id = %s",
+            (f"MKT-{market_id}", market_id),
+        )
 
         # Position (FK target for position_exits / exit_attempts via
         # position_internal_id). Uses a unique business key so concurrent

--- a/tests/integration/database/test_migration_0056_write_protection_triggers.py
+++ b/tests/integration/database/test_migration_0056_write_protection_triggers.py
@@ -17,6 +17,7 @@ Markers:
 from __future__ import annotations
 
 import json
+import uuid
 from decimal import Decimal
 from typing import Any
 
@@ -116,19 +117,26 @@ def trigger_test_scaffold(db_pool: Any) -> Any:
         )
         model_id = cur.fetchone()["model_id"]
 
-        # Market (FK target for trades, settlements)
+        # Market (FK target for trades, settlements).  Migration 0062
+        # (#791): markets.market_key is NOT NULL + UNIQUE.  Raw-SQL migration
+        # test — inline the TEMP→MKT-{id} two-step.
         cur.execute(
             """
             INSERT INTO markets (
-                platform_id, external_id, ticker, title, market_type, status
+                platform_id, external_id, ticker, title, market_type, status,
+                market_key
             )
             VALUES (%s, 'MIG-0056-TEST', 'MIG-0056-TEST',
-                    'Migration 0056 trigger test market', 'binary', 'open')
+                    'Migration 0056 trigger test market', 'binary', 'open', %s)
             RETURNING id
             """,
-            (TEST_PLATFORM_ID,),
+            (TEST_PLATFORM_ID, f"TEMP-{uuid.uuid4()}"),
         )
         market_id = cur.fetchone()["id"]
+        cur.execute(
+            "UPDATE markets SET market_key = %s WHERE id = %s",
+            (f"MKT-{market_id}", market_id),
+        )
 
         # Position (FK target for trades, position_exits, exit_attempts)
         cur.execute(

--- a/tests/integration/database/test_migration_0057_fk_restrict.py
+++ b/tests/integration/database/test_migration_0057_fk_restrict.py
@@ -26,6 +26,7 @@ Markers:
 
 from __future__ import annotations
 
+import uuid
 from decimal import Decimal
 from typing import Any
 
@@ -675,33 +676,45 @@ class TestRestrictBlocksDeletion:
             )
             strategy_id = cur.fetchone()["strategy_id"]
 
-            # Create event for market
+            # Create event for market.  Migration 0062 (#791): events.event_key
+            # is NOT NULL + UNIQUE.  This test is migration-layer — we keep
+            # raw INSERT and inline the canonical two-step key assignment
+            # (TEMP sentinel → ``EVT-{id}``) so the test stays at the raw
+            # SQL layer where it belongs.
             cur.execute(
                 """
                 INSERT INTO events (
                     platform_id, external_id,
-                    category, title
+                    category, title, event_key
                 )
-                VALUES (%s, %s, 'sports', 'Test Event')
+                VALUES (%s, %s, 'sports', 'Test Event', %s)
                 RETURNING id
                 """,
-                (platform_id, "MIG57-EVT-EXT"),
+                (platform_id, "MIG57-EVT-EXT", f"TEMP-{uuid.uuid4()}"),
             )
             event_id = cur.fetchone()["id"]
+            cur.execute(
+                "UPDATE events SET event_key = %s WHERE id = %s",
+                (f"EVT-{event_id}", event_id),
+            )
 
-            # Create market
+            # Create market (same TEMP→MKT-{id} pattern for market_key).
             cur.execute(
                 """
                 INSERT INTO markets (
                     platform_id, event_id, external_id,
-                    ticker, title, market_type, status
+                    ticker, title, market_type, status, market_key
                 )
-                VALUES (%s, %s, %s, %s, 'Test Market', 'binary', 'open')
+                VALUES (%s, %s, %s, %s, 'Test Market', 'binary', 'open', %s)
                 RETURNING id
                 """,
-                (platform_id, event_id, "MIG57-MKT-EXT", "MIG57-TICK"),
+                (platform_id, event_id, "MIG57-MKT-EXT", "MIG57-TICK", f"TEMP-{uuid.uuid4()}"),
             )
             market_id = cur.fetchone()["id"]
+            cur.execute(
+                "UPDATE markets SET market_key = %s WHERE id = %s",
+                (f"MKT-{market_id}", market_id),
+            )
 
             # Create order referencing strategy
             cur.execute(
@@ -760,19 +773,27 @@ class TestRestrictBlocksDeletion:
         platform_id = fk_test_platform
 
         with get_cursor(commit=True) as cur:
-            # Create market
+            # Create market.  Migration 0062 (#791): markets.market_key is
+            # NOT NULL + UNIQUE.  Raw-SQL migration test — inline the
+            # canonical TEMP→MKT-{id} two-step rather than routing through
+            # the CRUD helper (which would also insert a market_snapshots
+            # row, masking the FK behavior this test exercises).
             cur.execute(
                 """
                 INSERT INTO markets (
                     platform_id, external_id, ticker, title,
-                    market_type, status
+                    market_type, status, market_key
                 )
-                VALUES (%s, %s, %s, 'Snapshot Test Market', 'binary', 'open')
+                VALUES (%s, %s, %s, 'Snapshot Test Market', 'binary', 'open', %s)
                 RETURNING id
                 """,
-                (platform_id, "MIG57-SNAP-MKT-EXT", "MIG57-SNAP-TICK"),
+                (platform_id, "MIG57-SNAP-MKT-EXT", "MIG57-SNAP-TICK", f"TEMP-{uuid.uuid4()}"),
             )
             market_id = cur.fetchone()["id"]
+            cur.execute(
+                "UPDATE markets SET market_key = %s WHERE id = %s",
+                (f"MKT-{market_id}", market_id),
+            )
 
             # Create snapshot referencing market
             cur.execute(
@@ -811,19 +832,24 @@ class TestRestrictBlocksDeletion:
         platform_id = fk_test_platform
 
         with get_cursor(commit=True) as cur:
-            # Create market for position
+            # Create market for position.  Migration 0062 (#791): markets.market_key
+            # is NOT NULL + UNIQUE.  Raw-SQL migration test — inline TEMP→MKT-{id}.
             cur.execute(
                 """
                 INSERT INTO markets (
                     platform_id, external_id, ticker, title,
-                    market_type, status
+                    market_type, status, market_key
                 )
-                VALUES (%s, %s, %s, 'Position Test Market', 'binary', 'open')
+                VALUES (%s, %s, %s, 'Position Test Market', 'binary', 'open', %s)
                 RETURNING id
                 """,
-                (platform_id, "MIG57-POS-MKT-EXT", "MIG57-POS-TICK"),
+                (platform_id, "MIG57-POS-MKT-EXT", "MIG57-POS-TICK", f"TEMP-{uuid.uuid4()}"),
             )
             market_id = cur.fetchone()["id"]
+            cur.execute(
+                "UPDATE markets SET market_key = %s WHERE id = %s",
+                (f"MKT-{market_id}", market_id),
+            )
 
             # Create position
             cur.execute(

--- a/tests/integration/database/test_migration_0062_business_keys.py
+++ b/tests/integration/database/test_migration_0062_business_keys.py
@@ -1,0 +1,694 @@
+"""Integration tests for migration 0062 — C2c business key columns.
+
+Verifies the POST-MIGRATION state of ``market_key``, ``event_key``,
+``game_state_key``, and ``game_key`` on their four tables, plus the
+CRUD contracts that keep those columns populated through create and
+SCD2 supersede paths.
+
+Test groups:
+    - TestBusinessKeyColumnsPresent: column exists, NOT NULL, VARCHAR,
+      on each of markets/events/game_states/games.
+    - TestBusinessKeyIndexes: full UNIQUE on non-SCD2 tables; partial
+      UNIQUE WHERE row_current_ind=true on game_states.
+    - TestBackfillFormat: every pre-migration row has a key matching
+      the ``<PREFIX>-<id>`` pattern (sampled; full-scan for small tables).
+    - TestCreateAssignsCanonicalKey: ``create_market`` / ``create_event``
+      / ``create_game_state`` all produce ``<PREFIX>-<id>``.
+    - TestUpsertGameStateCarriesKeyForward: **the critical SCD2
+      contract** — on supersede, the NEW row carries the same
+      ``game_state_key`` as the CLOSED row.  If this regresses, the
+      logical-entity identity across SCD versions breaks.
+    - TestGetOrCreateGamePaths: CREATE branch produces ``GAM-{id}``;
+      CONFLICT branch preserves the existing ``game_key``.
+    - TestHistoricalGamesBatchLoader: batch-inserted games all get
+      non-TEMP ``GAM-<id>`` keys; ON CONFLICT rows keep existing keys.
+    - TestUniquenessEnforced: markets/events/games reject duplicate
+      keys; game_states rejects duplicate keys ONLY for current rows.
+
+Issues: #791
+Epic: #745 (Schema Hardening Arc, Cohort C2c)
+
+Markers:
+    @pytest.mark.integration: real DB required (testcontainer per ADR-057)
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+import psycopg2
+import pytest
+
+from precog.database.connection import get_cursor
+from precog.database.crud_events import create_event
+from precog.database.crud_game_states import (
+    create_game_state,
+    get_or_create_game,
+    upsert_game_state,
+)
+from precog.database.crud_markets import create_market
+
+pytestmark = [pytest.mark.integration]
+
+
+# =============================================================================
+# Per-table spec (mirrors migration 0062 ``_KEY_SPEC``)
+# =============================================================================
+
+# (table, key_column, prefix, is_scd2)
+_KEY_SPEC: list[tuple[str, str, str, bool]] = [
+    ("markets", "market_key", "MKT", False),
+    ("events", "event_key", "EVT", False),
+    ("game_states", "game_state_key", "GST", True),
+    ("games", "game_key", "GAM", False),
+]
+
+
+# =============================================================================
+# Group 1: Column presence + type + nullability
+# =============================================================================
+
+
+@pytest.mark.parametrize(("table", "key_col", "prefix", "is_scd2"), _KEY_SPEC)
+def test_business_key_column_exists_and_not_null(
+    db_pool: Any, table: str, key_col: str, prefix: str, is_scd2: bool
+) -> None:
+    """Column exists, is VARCHAR, and is NOT NULL on every table."""
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            SELECT column_name, data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_name = %s AND column_name = %s
+            """,
+            (table, key_col),
+        )
+        row = cur.fetchone()
+    assert row is not None, f"{table}.{key_col} column missing post-0062"
+    assert row["data_type"] in ("character varying", "text"), (
+        f"{table}.{key_col} has unexpected type: {row['data_type']}"
+    )
+    assert row["is_nullable"] == "NO", f"{table}.{key_col} must be NOT NULL"
+
+
+# =============================================================================
+# Group 2: Indexes
+# =============================================================================
+
+
+def test_non_scd2_tables_have_full_unique_index(db_pool: Any) -> None:
+    """markets/events/games have a plain (non-partial) UNIQUE on <x>_key."""
+    for table, key_col, _prefix, is_scd2 in _KEY_SPEC:
+        if is_scd2:
+            continue
+        with get_cursor() as cur:
+            cur.execute(
+                """
+                SELECT indexname, indexdef
+                FROM pg_indexes
+                WHERE tablename = %s AND indexname = %s
+                """,
+                (table, f"idx_{table}_{key_col}"),
+            )
+            row = cur.fetchone()
+        assert row is not None, f"Missing UNIQUE index on {table}.{key_col}"
+        indexdef = row["indexdef"]
+        assert "UNIQUE" in indexdef, f"{table}.{key_col} index must be UNIQUE"
+        # Full (non-partial) UNIQUE: no WHERE clause in the index def.
+        assert " WHERE " not in indexdef, (
+            f"{table}.{key_col} should be a FULL UNIQUE (no partial predicate); got: {indexdef}"
+        )
+
+
+def test_game_states_has_lookup_plus_partial_unique(db_pool: Any) -> None:
+    """game_states has non-unique lookup btree + partial UNIQUE (current rows)."""
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            SELECT indexname, indexdef
+            FROM pg_indexes
+            WHERE tablename = 'game_states'
+              AND indexname IN (
+                  'idx_game_states_game_state_key',
+                  'idx_game_states_game_state_key_current'
+              )
+            ORDER BY indexname
+            """
+        )
+        rows = cur.fetchall()
+    index_defs = {r["indexname"]: r["indexdef"] for r in rows}
+
+    # Lookup btree: non-unique, no partial predicate.
+    lookup = index_defs.get("idx_game_states_game_state_key")
+    assert lookup is not None, "Missing lookup btree on game_states.game_state_key"
+    assert "UNIQUE" not in lookup, "Lookup btree must NOT be UNIQUE"
+
+    # Partial UNIQUE: SCD2-aware, fires only on current rows.
+    partial = index_defs.get("idx_game_states_game_state_key_current")
+    assert partial is not None, "Missing partial UNIQUE on game_states.game_state_key"
+    assert "UNIQUE" in partial, "Partial index must be UNIQUE"
+    assert "row_current_ind = true" in partial, (
+        "Partial UNIQUE must filter on row_current_ind = true (SCD2 contract)"
+    )
+
+
+# =============================================================================
+# Group 3: Backfill format (<PREFIX>-<id>)
+# =============================================================================
+
+
+@pytest.mark.parametrize(("table", "key_col", "prefix", "is_scd2"), _KEY_SPEC)
+def test_backfill_matches_prefix_pattern(
+    db_pool: Any, table: str, key_col: str, prefix: str, is_scd2: bool
+) -> None:
+    """Every existing row has ``<PREFIX>-<id>`` or a canonical downstream value.
+
+    Post-migration, all rows should carry a key in one of these shapes:
+      * ``<PREFIX>-<id>`` — the backfilled format
+      * ``<PREFIX>-<id>`` produced by CRUD after the migration
+    No TEMP- values should ever be observable (they are replaced in-txn).
+    """
+    # safe: table/key_col are hardcoded in _KEY_SPEC
+    with get_cursor() as cur:
+        # First: no TEMP- values must be externally visible.
+        cur.execute(
+            f"SELECT COUNT(*) AS c FROM {table} WHERE {key_col} LIKE 'TEMP-%%'"  # noqa: S608
+        )
+        temp_count = int(cur.fetchone()["c"])
+        assert temp_count == 0, (
+            f"{table}.{key_col} has {temp_count} TEMP- sentinels — "
+            f"two-step INSERT pattern is not atomic (transaction boundary bug)"
+        )
+
+        # Spot-check format on a sample (bounded to avoid megatable scans).
+        # game_states has ~29k rows — LIMIT 100 is plenty.
+        cur.execute(
+            f"SELECT id, {key_col} FROM {table} "  # noqa: S608
+            f"ORDER BY id LIMIT 100"
+        )
+        rows = cur.fetchall()
+    for row in rows:
+        expected = f"{prefix}-{row['id']}"
+        assert row[key_col] == expected, (
+            f"{table}.{key_col} for id={row['id']} is {row[key_col]!r}, expected {expected!r}"
+        )
+
+
+# =============================================================================
+# Group 4: CRUD create paths produce canonical keys
+# =============================================================================
+
+
+def test_create_market_assigns_canonical_market_key(db_pool: Any) -> None:
+    """``create_market`` inserts with TEMP and rewrites to ``MKT-{id}``."""
+    from tests.fixtures.cleanup_helpers import delete_market_with_children
+
+    test_ticker = f"TEST-0062-MKT-{uuid.uuid4().hex[:8]}"
+    with get_cursor(commit=True) as cur:
+        delete_market_with_children(cur, "ticker = %s", (test_ticker,))
+
+    market_pk = create_market(
+        platform_id="kalshi",
+        event_id=None,
+        external_id=f"{test_ticker}-EXT",
+        ticker=test_ticker,
+        title="Test market for 0062 key format",
+        yes_ask_price=Decimal("0.5000"),
+        no_ask_price=Decimal("0.5000"),
+    )
+    try:
+        with get_cursor() as cur:
+            cur.execute("SELECT market_key FROM markets WHERE id = %s", (market_pk,))
+            row = cur.fetchone()
+        assert row is not None
+        assert row["market_key"] == f"MKT-{market_pk}"
+    finally:
+        with get_cursor(commit=True) as cur:
+            delete_market_with_children(cur, "ticker = %s", (test_ticker,))
+
+
+def test_create_event_assigns_canonical_event_key(db_pool: Any) -> None:
+    """``create_event`` inserts with TEMP and rewrites to ``EVT-{id}``."""
+    from tests.fixtures.cleanup_helpers import delete_event_with_children
+
+    test_ext = f"TEST-0062-EVT-{uuid.uuid4().hex[:8]}"
+    with get_cursor(commit=True) as cur:
+        delete_event_with_children(cur, "external_id = %s", (test_ext,))
+
+    event_pk = create_event(
+        event_id=test_ext,
+        platform_id="kalshi",
+        external_id=test_ext,
+        category="sports",
+        title="Test event for 0062 key format",
+    )
+    try:
+        with get_cursor() as cur:
+            cur.execute("SELECT event_key FROM events WHERE id = %s", (event_pk,))
+            row = cur.fetchone()
+        assert row is not None
+        assert row["event_key"] == f"EVT-{event_pk}"
+    finally:
+        with get_cursor(commit=True) as cur:
+            delete_event_with_children(cur, "external_id = %s", (test_ext,))
+
+
+def test_create_game_state_assigns_canonical_game_state_key(db_pool: Any) -> None:
+    """``create_game_state`` inserts with TEMP and rewrites to ``GST-{id}``."""
+    espn_event_id = f"TEST-0062-GST-{uuid.uuid4().hex[:8]}"
+    with get_cursor(commit=True) as cur:
+        cur.execute(
+            "DELETE FROM game_states WHERE espn_event_id = %s",
+            (espn_event_id,),
+        )
+
+    state_id = create_game_state(
+        espn_event_id=espn_event_id,
+        league="nfl",
+        game_status="pre",
+    )
+    try:
+        with get_cursor() as cur:
+            cur.execute(
+                "SELECT game_state_key FROM game_states WHERE id = %s",
+                (state_id,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["game_state_key"] == f"GST-{state_id}"
+    finally:
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM game_states WHERE espn_event_id = %s",
+                (espn_event_id,),
+            )
+
+
+# =============================================================================
+# Group 5: **Critical SCD2 contract** — upsert carries key forward
+# =============================================================================
+
+
+def test_upsert_game_state_carries_key_forward_on_supersede(db_pool: Any) -> None:
+    """Regression guard: SCD supersede must preserve game_state_key.
+
+    This is the load-bearing test for migration 0062.  ``upsert_game_state``
+    is the hot SCD2 path (~190 calls/live game).  On supersede, the new
+    row MUST carry the same ``game_state_key`` as the CLOSED row — a
+    regeneration would fork the logical-entity identity across versions,
+    breaking every downstream consumer that joins across SCD history.
+
+    Shape:
+        - First upsert (no current row): INSERT path assigns GST-{id}.
+        - Second upsert (score change): SUPERSEDE path closes the old
+          row and inserts a new one.  Assert both rows share the same
+          game_state_key.
+    """
+    espn_event_id = f"TEST-0062-SCD-{uuid.uuid4().hex[:8]}"
+    with get_cursor(commit=True) as cur:
+        cur.execute(
+            "DELETE FROM game_states WHERE espn_event_id = %s",
+            (espn_event_id,),
+        )
+
+    try:
+        # First upsert: first-insert path.  Assigns a fresh GST-{id}.
+        first_id = upsert_game_state(
+            espn_event_id=espn_event_id,
+            home_score=0,
+            away_score=0,
+            period=0,
+            game_status="pre",
+            league="nfl",
+        )
+        assert first_id is not None, "First upsert should have inserted"
+
+        with get_cursor() as cur:
+            cur.execute(
+                "SELECT game_state_key FROM game_states WHERE id = %s",
+                (first_id,),
+            )
+            original_key = cur.fetchone()["game_state_key"]
+        assert original_key == f"GST-{first_id}", "First-insert path must assign canonical GST-{id}"
+
+        # Second upsert: supersede path (score changed).
+        second_id = upsert_game_state(
+            espn_event_id=espn_event_id,
+            home_score=7,
+            away_score=0,
+            period=1,
+            game_status="in_progress",
+            league="nfl",
+        )
+        assert second_id is not None, "Score change must create a new version"
+        assert second_id != first_id, "New version must get a new surrogate id"
+
+        # Assert SCD state: exactly 2 rows for this espn_event_id, both
+        # carrying the same game_state_key (the one assigned at first-insert).
+        with get_cursor() as cur:
+            cur.execute(
+                """
+                SELECT id, game_state_key, row_current_ind
+                FROM game_states
+                WHERE espn_event_id = %s
+                ORDER BY id
+                """,
+                (espn_event_id,),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 2, f"Expected 2 SCD rows, got {len(rows)}"
+        assert all(r["game_state_key"] == original_key for r in rows), (
+            f"SCD copy-forward broken: keys diverged across versions: "
+            f"{[(r['id'], r['game_state_key'], r['row_current_ind']) for r in rows]}"
+        )
+        # Sanity: historical row is closed, new row is current.
+        historical = next(r for r in rows if r["id"] == first_id)
+        current = next(r for r in rows if r["id"] == second_id)
+        assert historical["row_current_ind"] is False
+        assert current["row_current_ind"] is True
+    finally:
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM game_states WHERE espn_event_id = %s",
+                (espn_event_id,),
+            )
+
+
+# =============================================================================
+# Group 6: get_or_create_game — CREATE + CONFLICT branches
+# =============================================================================
+
+
+def test_get_or_create_game_create_path_assigns_canonical_key(db_pool: Any) -> None:
+    """CREATE branch produces ``GAM-{id}``; no TEMP value leaks out."""
+    # Unique matchup to force the CREATE branch.
+    suffix = uuid.uuid4().hex[:6].upper()
+    home = f"T{suffix[:2]}H"
+    away = f"T{suffix[2:4]}A"
+    game_date_val = date(2099, 1, 1)
+
+    with get_cursor(commit=True) as cur:
+        cur.execute(
+            "DELETE FROM games WHERE sport = 'football' "
+            "AND home_team_code = %s AND away_team_code = %s",
+            (home, away),
+        )
+
+    try:
+        game_id = get_or_create_game(
+            sport="football",
+            game_date=game_date_val,
+            home_team_code=home,
+            away_team_code=away,
+            season=2099,
+            league="nfl",
+        )
+        with get_cursor() as cur:
+            cur.execute("SELECT game_key FROM games WHERE id = %s", (game_id,))
+            row = cur.fetchone()
+        assert row["game_key"] == f"GAM-{game_id}", (
+            f"CREATE path must assign GAM-{{id}}; got {row['game_key']!r}"
+        )
+    finally:
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM games WHERE sport = 'football' "
+                "AND home_team_code = %s AND away_team_code = %s",
+                (home, away),
+            )
+
+
+def test_get_or_create_game_conflict_path_preserves_existing_key(db_pool: Any) -> None:
+    """CONFLICT branch does NOT overwrite the existing game_key."""
+    suffix = uuid.uuid4().hex[:6].upper()
+    home = f"T{suffix[:2]}C"
+    away = f"T{suffix[2:4]}D"
+    game_date_val = date(2099, 1, 2)
+
+    with get_cursor(commit=True) as cur:
+        cur.execute(
+            "DELETE FROM games WHERE sport = 'football' "
+            "AND home_team_code = %s AND away_team_code = %s",
+            (home, away),
+        )
+
+    try:
+        # First call: creates the row.
+        first_id = get_or_create_game(
+            sport="football",
+            game_date=game_date_val,
+            home_team_code=home,
+            away_team_code=away,
+            season=2099,
+            league="nfl",
+        )
+        with get_cursor() as cur:
+            cur.execute("SELECT game_key FROM games WHERE id = %s", (first_id,))
+            original_key = cur.fetchone()["game_key"]
+
+        # Second call: hits ON CONFLICT, must NOT change game_key.
+        second_id = get_or_create_game(
+            sport="football",
+            game_date=game_date_val,
+            home_team_code=home,
+            away_team_code=away,
+            season=2099,
+            league="nfl",
+            home_score=14,
+            away_score=7,
+            game_status="final",
+        )
+        assert second_id == first_id, "CONFLICT path must return the same id"
+
+        with get_cursor() as cur:
+            cur.execute("SELECT game_key FROM games WHERE id = %s", (first_id,))
+            post_key = cur.fetchone()["game_key"]
+        assert post_key == original_key, (
+            f"ON CONFLICT path must preserve game_key: was {original_key!r}, now {post_key!r}"
+        )
+        # Sanity: no TEMP sentinel leaked into the row.
+        assert not post_key.startswith("TEMP-"), (
+            f"TEMP sentinel leaked through CONFLICT path: {post_key!r}"
+        )
+    finally:
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM games WHERE sport = 'football' "
+                "AND home_team_code = %s AND away_team_code = %s",
+                (home, away),
+            )
+
+
+# =============================================================================
+# Group 7: historical_games batch loader
+# =============================================================================
+
+
+def test_historical_games_batch_loader_assigns_canonical_keys(db_pool: Any) -> None:
+    """Batch-inserted games all end up with ``GAM-<id>`` (no TEMP leaks)."""
+    from precog.database.seeding.historical_games_loader import _flush_games_batch
+
+    suffix = uuid.uuid4().hex[:6].upper()
+    # Two rows with distinct natural keys — both hit the INSERT branch.
+    home1 = f"T{suffix[:2]}E"
+    away1 = f"T{suffix[2:4]}F"
+    home2 = f"T{suffix[:2]}G"
+    away2 = f"T{suffix[2:4]}H"
+
+    with get_cursor(commit=True) as cur:
+        cur.execute(
+            "DELETE FROM games WHERE home_team_code = ANY(%s)",
+            ([home1, home2],),
+        )
+
+    # Look up real sport_id + league_id via CRUD helpers BEFORE building
+    # the tuples (Glokta S60 review W4: eliminates fragile ``row[:-3]``
+    # tuple-slicing patch that was tightly coupled to the batch tuple
+    # column order).
+    from precog.database.crud_lookups import get_league_id, get_sport_id
+
+    sport_id = get_sport_id("football")
+    league_id = get_league_id("nfl")
+
+    try:
+        # Build a minimal batch mirroring the tuple shape in
+        # historical_games_loader.bulk_insert_historical_games.  The TEMP
+        # sentinel is the last field; sport_id + league_id are the two
+        # fields immediately before it.
+        batch = [
+            (
+                "football",  # sport
+                2099,  # season
+                date(2099, 2, 1),  # game_date
+                home1,
+                away1,
+                None,  # home_team_id
+                None,  # away_team_id
+                21,  # home_score
+                14,  # away_score
+                False,  # neutral_site
+                False,  # is_playoff
+                "regular",  # game_type
+                None,  # venue_name
+                "fivethirtyeight",  # data_source
+                None,  # source_file
+                None,  # external_game_id
+                "nfl",  # league
+                "final",  # game_status
+                sport_id,  # sport_id (NOT NULL as of 0061)
+                league_id,  # league_id
+                f"TEMP-{uuid.uuid4()}",  # game_key sentinel
+            ),
+            (
+                "football",
+                2099,
+                date(2099, 2, 2),
+                home2,
+                away2,
+                None,
+                None,
+                28,
+                24,
+                False,
+                False,
+                "regular",
+                None,
+                "fivethirtyeight",
+                None,
+                None,
+                "nfl",
+                "final",
+                sport_id,
+                league_id,
+                f"TEMP-{uuid.uuid4()}",
+            ),
+        ]
+
+        _flush_games_batch(batch)
+
+        with get_cursor() as cur:
+            cur.execute(
+                "SELECT id, game_key FROM games WHERE home_team_code = ANY(%s) ORDER BY id",
+                ([home1, home2],),
+            )
+            rows = cur.fetchall()
+        assert len(rows) == 2, "Both rows should have inserted"
+        for row in rows:
+            assert row["game_key"] == f"GAM-{row['id']}", (
+                f"Batch INSERT path must rewrite TEMP to GAM-{{id}}; got {row['game_key']!r}"
+            )
+            assert not row["game_key"].startswith("TEMP-"), "TEMP sentinel leaked out of batch path"
+    finally:
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM games WHERE home_team_code = ANY(%s)",
+                ([home1, home2],),
+            )
+
+
+# =============================================================================
+# Group 8: Uniqueness is enforced
+# =============================================================================
+
+
+def test_markets_market_key_full_unique_enforced(db_pool: Any) -> None:
+    """A duplicate market_key on markets must raise IntegrityError."""
+    from tests.fixtures.cleanup_helpers import delete_market_with_children
+
+    test_ticker1 = f"TEST-0062-UQ1-{uuid.uuid4().hex[:8]}"
+    test_ticker2 = f"TEST-0062-UQ2-{uuid.uuid4().hex[:8]}"
+    with get_cursor(commit=True) as cur:
+        delete_market_with_children(cur, "ticker = %s", (test_ticker1,))
+        delete_market_with_children(cur, "ticker = %s", (test_ticker2,))
+
+    try:
+        pk1 = create_market(
+            platform_id="kalshi",
+            event_id=None,
+            external_id=f"{test_ticker1}-EXT",
+            ticker=test_ticker1,
+            title="0062 uniqueness test row 1",
+            yes_ask_price=Decimal("0.5000"),
+            no_ask_price=Decimal("0.5000"),
+        )
+        # Create a second market, then try to force-overwrite its market_key
+        # to the first row's value.  The partial UNIQUE should reject.
+        pk2 = create_market(
+            platform_id="kalshi",
+            event_id=None,
+            external_id=f"{test_ticker2}-EXT",
+            ticker=test_ticker2,
+            title="0062 uniqueness test row 2",
+            yes_ask_price=Decimal("0.5000"),
+            no_ask_price=Decimal("0.5000"),
+        )
+        with pytest.raises(psycopg2.errors.UniqueViolation):
+            with get_cursor(commit=True) as cur:
+                cur.execute(
+                    "UPDATE markets SET market_key = %s WHERE id = %s",
+                    (f"MKT-{pk1}", pk2),
+                )
+    finally:
+        with get_cursor(commit=True) as cur:
+            delete_market_with_children(cur, "ticker = %s", (test_ticker1,))
+            delete_market_with_children(cur, "ticker = %s", (test_ticker2,))
+
+
+def test_game_states_partial_unique_allows_historical_duplicates(db_pool: Any) -> None:
+    """Partial UNIQUE on game_states.game_state_key permits historical dups.
+
+    This tests the SCD2-aware index: two rows can share the same
+    ``game_state_key`` as long as at most ONE has ``row_current_ind = TRUE``.
+    After an ``upsert_game_state`` supersede, exactly this situation exists
+    (old row: key=X, current=FALSE; new row: key=X, current=TRUE).
+    """
+    espn_event_id = f"TEST-0062-UQP-{uuid.uuid4().hex[:8]}"
+    with get_cursor(commit=True) as cur:
+        cur.execute(
+            "DELETE FROM game_states WHERE espn_event_id = %s",
+            (espn_event_id,),
+        )
+    try:
+        # Do a real supersede — this is the production shape of the partial UNIQUE.
+        upsert_game_state(
+            espn_event_id=espn_event_id,
+            home_score=0,
+            away_score=0,
+            period=0,
+            game_status="pre",
+            league="nfl",
+        )
+        upsert_game_state(
+            espn_event_id=espn_event_id,
+            home_score=7,
+            away_score=0,
+            period=1,
+            game_status="in_progress",
+            league="nfl",
+        )
+        with get_cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) AS c FROM game_states WHERE espn_event_id = %s",
+                (espn_event_id,),
+            )
+            total = int(cur.fetchone()["c"])
+            cur.execute(
+                "SELECT COUNT(*) AS c FROM game_states "
+                "WHERE espn_event_id = %s AND row_current_ind = TRUE",
+                (espn_event_id,),
+            )
+            current = int(cur.fetchone()["c"])
+        assert total == 2, "SCD2 supersede should have produced 2 rows"
+        assert current == 1, (
+            "Partial UNIQUE WHERE row_current_ind=TRUE must allow exactly "
+            "one current row per game_state_key"
+        )
+    finally:
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM game_states WHERE espn_event_id = %s",
+                (espn_event_id,),
+            )

--- a/tests/integration/database/test_scd_copy_forward.py
+++ b/tests/integration/database/test_scd_copy_forward.py
@@ -51,6 +51,7 @@ Markers:
 
 from __future__ import annotations
 
+import uuid
 from decimal import Decimal
 from typing import Any
 
@@ -104,13 +105,17 @@ def position_with_edge(db_pool: Any) -> Any:
         delete_market_with_children(cur, "ticker = %s", (_TEST_TICKER,))
 
         # Underlying market (positions and edges both FK to markets.id).
+        # Migration 0062 (#791): markets.market_key is NOT NULL + UNIQUE.
+        # SCD-mechanics test — keep raw INSERT (the surrounding test is
+        # verifying SCD supersede semantics on positions/edges, not market
+        # creation) and inline the TEMP→MKT-{id} two-step.
         cur.execute(
             """
             INSERT INTO markets (
                 platform_id, event_id, external_id, ticker, title,
-                market_type, status
+                market_type, status, market_key
             )
-            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -121,9 +126,14 @@ def position_with_edge(db_pool: Any) -> Any:
                 "Issue 725 SCD Copy-Forward Market",
                 "binary",
                 "open",
+                f"TEMP-{uuid.uuid4()}",
             ),
         )
         market_pk = cur.fetchone()["id"]
+        cur.execute(
+            "UPDATE markets SET market_key = %s WHERE id = %s",
+            (f"MKT-{market_pk}", market_pk),
+        )
 
         # Seed a minimal edge row. All non-NULL columns on edges are either
         # business-identity (edge_key), FK (market_id), or metric fields

--- a/tests/integration/trading/test_position_manager.py
+++ b/tests/integration/trading/test_position_manager.py
@@ -34,61 +34,46 @@ def test_market_pks(db_cursor, clean_test_data):
         Dictionary mapping ticker strings to integer surrogate PKs.
         e.g. {"NFL-TEST-001": 42, "NFL-001": 43, "NFL-002": 44, "NFL-003": 45}
     """
-    conn = get_connection()
-    try:
-        with conn.cursor() as cur:
-            # Look up event surrogate PK (migration 0020: markets use integer FK)
-            # Note: get_connection() returns raw psycopg2 (tuple rows), not dict cursor
-            cur.execute("SELECT id FROM events WHERE external_id = 'TEST-EVT-NFL-KC-BUF'")
-            _evt = cur.fetchone()
-            event_pk = _evt[0] if _evt else None
+    # Migration 0062 (#791): markets.market_key is NOT NULL + UNIQUE.
+    # Route through the ``create_market`` CRUD helper so the two-step
+    # ``TEMP → MKT-{id}`` key assignment + initial ``market_snapshots``
+    # fact row both happen inside the canonical code path.  This keeps the
+    # fixture in sync with production semantics (a raw INSERT here would
+    # drift from the CRUD-inserted rows that production / other tests
+    # observe).
+    from precog.database.connection import fetch_one
+    from precog.database.crud_markets import create_market
 
-            # Create test markets (required for get_current_positions() JOIN)
-            # Multiple markets needed for filtering tests
-            # Migration 0022: market_id VARCHAR dropped, use ticker as identifier
-            markets_to_create = [
-                ("MKT-TEST-001", "Test Market: KC to beat BUF", "NFL-TEST-001"),
-                ("MKT-001", "Test Market 1", "NFL-001"),
-                ("MKT-002", "Test Market 2", "NFL-002"),
-                ("MKT-003", "Test Market 3", "NFL-003"),
-            ]
+    # Look up event surrogate PK (migration 0020: markets use integer FK)
+    _evt_row = fetch_one("SELECT id FROM events WHERE external_id = %s", ("TEST-EVT-NFL-KC-BUF",))
+    event_pk = _evt_row["id"] if _evt_row else None
 
-            market_pks = {}  # ticker -> integer PK mapping
-            for external_id, title, ticker in markets_to_create:
-                cur.execute(
-                    """
-                    INSERT INTO markets (
-                        platform_id, event_id, external_id, ticker, title,
-                        market_type, status
-                    )
-                    VALUES (%s, %s, %s, %s, %s, %s, %s)
-                    RETURNING id
-                    """,
-                    (
-                        "test_platform",
-                        event_pk,
-                        external_id,
-                        ticker,
-                        title,
-                        "binary",
-                        "open",
-                    ),
-                )
-                market_pk = cur.fetchone()[0]  # raw cursor returns tuples
-                market_pks[ticker] = market_pk
-                cur.execute(
-                    """
-                    INSERT INTO market_snapshots (
-                        market_id, yes_ask_price, no_ask_price,
-                        volume, open_interest, row_current_ind
-                    )
-                    VALUES (%s, %s, %s, %s, %s, TRUE)
-                    """,
-                    (market_pk, Decimal("0.5200"), Decimal("0.4800"), 1000, 500),
-                )
-            conn.commit()
-    finally:
-        release_connection(conn)
+    # Create test markets (required for get_current_positions() JOIN)
+    # Multiple markets needed for filtering tests
+    # Migration 0022: market_id VARCHAR dropped, use ticker as identifier
+    markets_to_create = [
+        ("MKT-TEST-001", "Test Market: KC to beat BUF", "NFL-TEST-001"),
+        ("MKT-001", "Test Market 1", "NFL-001"),
+        ("MKT-002", "Test Market 2", "NFL-002"),
+        ("MKT-003", "Test Market 3", "NFL-003"),
+    ]
+
+    market_pks: dict[str, int] = {}  # ticker -> integer PK mapping
+    for external_id, title, ticker in markets_to_create:
+        market_pk = create_market(
+            platform_id="test_platform",
+            event_id=event_pk,
+            external_id=external_id,
+            ticker=ticker,
+            title=title,
+            yes_ask_price=Decimal("0.5200"),
+            no_ask_price=Decimal("0.4800"),
+            market_type="binary",
+            status="open",
+            volume=1000,
+            open_interest=500,
+        )
+        market_pks[ticker] = market_pk
 
     yield market_pks
 

--- a/tests/integration/trading/test_position_manager_trailing_stop_integration.py
+++ b/tests/integration/trading/test_position_manager_trailing_stop_integration.py
@@ -97,28 +97,28 @@ def trailing_stop_open_position(db_pool: Any) -> Any:
 
         delete_market_with_children(cur, "ticker = %s", (_TEST_TICKER,))
 
-        # Create the underlying market (positions FK to markets.id).
-        cur.execute(
-            """
-            INSERT INTO markets (
-                platform_id, event_id, external_id, ticker, title,
-                market_type, status
-            )
-            VALUES (%s, %s, %s, %s, %s, %s, %s)
-            RETURNING id
-            """,
-            (
-                "kalshi",
-                None,
-                f"{_TEST_TICKER}-EXT",
-                _TEST_TICKER,
-                "Issue 669 Integration Market",
-                "binary",
-                "open",
-            ),
-        )
-        market_pk = cur.fetchone()["id"]
+    # Create the underlying market (positions FK to markets.id) via the
+    # CRUD helper.  Migration 0062 (#791): markets.market_key is NOT NULL +
+    # UNIQUE; ``create_market`` handles the canonical ``TEMP → MKT-{id}``
+    # two-step internally, keeping this fixture in sync with production
+    # semantics.
+    from decimal import Decimal as _Decimal
 
+    from precog.database.crud_markets import create_market
+
+    market_pk = create_market(
+        platform_id="kalshi",
+        event_id=None,
+        external_id=f"{_TEST_TICKER}-EXT",
+        ticker=_TEST_TICKER,
+        title="Issue 669 Integration Market",
+        yes_ask_price=_Decimal("0.5000"),
+        no_ask_price=_Decimal("0.5000"),
+        market_type="binary",
+        status="open",
+    )
+
+    with get_cursor(commit=True) as cur:
         # Create the initial open position (current row, no trailing stop yet).
         # We bypass PositionManager.open_position() here because it requires
         # a strategy_id + model_id + market_snapshot, and the bug under test

--- a/tests/property/test_database_crud_properties.py
+++ b/tests/property/test_database_crud_properties.py
@@ -121,19 +121,39 @@ def setup_kalshi_platform(db_pool, clean_test_data):
         series_row = cur.fetchone()
         series_pk = series_row["id"] if series_row else None
 
-        # Create events for test markets (idempotent)
-        # Uses series_id (integer FK) instead of old series_key VARCHAR
-        # Migration 0047: event_id column dropped, external_id is canonical business key
-        cur.execute(
-            """
-            INSERT INTO events (platform_id, series_id, external_id, category, title, status)
-            VALUES
-                ('kalshi', %s, 'KXNFLGAME-25DEC15CLEKC', 'sports', 'NFL Games Dec 15', 'scheduled'),
-                ('kalshi', %s, 'KXNFLGAME-25DEC08LACKC', 'sports', 'NFL Games Dec 08', 'scheduled')
-            ON CONFLICT (platform_id, external_id) DO NOTHING
-        """,
-            (series_pk, series_pk),
-        )
+        # Create events for test markets (idempotent).  Uses series_id
+        # (integer FK) instead of old series_key VARCHAR.  Migration 0047:
+        # event_id column dropped, external_id is canonical business key.
+        #
+        # Migration 0062 (#791): events.event_key is NOT NULL + UNIQUE.
+        # Raw-SQL property-test setup — inline TEMP→EVT-{id} per row.
+        # The RETURNING id clause gives us the surrogate PK only for rows
+        # actually inserted (not for ON CONFLICT skips), so we UPDATE only
+        # those and leave any pre-existing rows' canonical event_key alone.
+        import uuid as _uuid
+
+        for ext_id, title in [
+            ("KXNFLGAME-25DEC15CLEKC", "NFL Games Dec 15"),
+            ("KXNFLGAME-25DEC08LACKC", "NFL Games Dec 08"),
+        ]:
+            cur.execute(
+                """
+                INSERT INTO events (
+                    platform_id, series_id, external_id, category, title, status,
+                    event_key
+                )
+                VALUES ('kalshi', %s, %s, 'sports', %s, 'scheduled', %s)
+                ON CONFLICT (platform_id, external_id) DO NOTHING
+                RETURNING id
+                """,
+                (series_pk, ext_id, title, f"TEMP-{_uuid.uuid4()}"),
+            )
+            _evt_row = cur.fetchone()
+            if _evt_row is not None:
+                cur.execute(
+                    "UPDATE events SET event_key = %s WHERE id = %s",
+                    (f"EVT-{_evt_row['id']}", _evt_row["id"]),
+                )
 
     # NO TEARDOWN - Setup cleanup handles it, Issue #171 DB reset for final cleanup
 
@@ -1075,21 +1095,33 @@ def test_restrict_prevents_platform_delete_with_markets(db_pool, clean_test_data
         )
         series_pk = cur.fetchone()["id"]
 
-        # Create test event (uses series_id integer FK to series.id)
-        # Migration 0047: event_id column dropped, external_id is canonical
+        # Create test event (uses series_id integer FK to series.id).
+        # Migration 0047: event_id column dropped, external_id is canonical.
+        # Migration 0062 (#791): events.event_key is NOT NULL + UNIQUE.
+        # Raw-SQL property-test setup — inline TEMP→EVT-{id}.
+        import uuid as _uuid
+
         cur.execute(
             """
-            INSERT INTO events (platform_id, series_id, external_id, category, title, status)
-            VALUES (%s, %s, %s, 'sports', 'Test Event', 'scheduled')
+            INSERT INTO events (
+                platform_id, series_id, external_id, category, title, status,
+                event_key
+            )
+            VALUES (%s, %s, %s, 'sports', 'Test Event', 'scheduled', %s)
             RETURNING id
         """,
             (
                 test_platform_id,
                 series_pk,
                 test_event_id,
+                f"TEMP-{_uuid.uuid4()}",
             ),
         )
         event_pk = cur.fetchone()["id"]
+        cur.execute(
+            "UPDATE events SET event_key = %s WHERE id = %s",
+            (f"EVT-{event_pk}", event_pk),
+        )
 
     # Create market for this test platform
     market_pk = create_market(

--- a/tests/race/test_scd_sibling_first_insert_races.py
+++ b/tests/race/test_scd_sibling_first_insert_races.py
@@ -60,6 +60,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, date, datetime
 from decimal import Decimal
@@ -298,16 +299,21 @@ def game_odds_race_setup(db_pool: Any) -> Any:
 
         # Create a fresh game row. Natural key is
         # (sport, game_date, home_team_code, away_team_code).
+        #
+        # Migration 0062 (#791): games.game_key is NOT NULL + UNIQUE.  Race
+        # test — need precise control over the INSERT (race timing is
+        # triggered by the CRUD layer under test, not the seed setup).
+        # Inline the TEMP→GAM-{id} two-step.
         cur.execute(
             """
             INSERT INTO games (
                 sport, game_date, home_team_code, away_team_code,
                 season, league, game_status, data_source,
-                sport_id, league_id
+                sport_id, league_id, game_key
             )
             VALUES (%s, %s, %s, %s, %s, %s, %s, %s,
                     (SELECT id FROM sports WHERE sport_key = 'football'),
-                    (SELECT id FROM leagues WHERE league_key = 'nfl'))
+                    (SELECT id FROM leagues WHERE league_key = 'nfl'), %s)
             RETURNING id
             """,
             (
@@ -319,10 +325,15 @@ def game_odds_race_setup(db_pool: Any) -> Any:
                 "nfl",
                 "scheduled",
                 "espn",
+                f"TEMP-{uuid.uuid4()}",
             ),
         )
         row = cur.fetchone()
         game_id = row["id"]
+        cur.execute(
+            "UPDATE games SET game_key = %s WHERE id = %s",
+            (f"GAM-{game_id}", game_id),
+        )
 
     yield game_id, test_sportsbook, test_home_code, test_away_code, test_game_date
 
@@ -445,14 +456,17 @@ def market_race_setup(db_pool: Any) -> Any:
         )
         cur.execute("DELETE FROM markets WHERE ticker = %s", (_TEST_MARKET_TICKER,))
 
-        # Insert the dimension row.
+        # Insert the dimension row.  Migration 0062 (#791): markets.market_key
+        # is NOT NULL + UNIQUE.  Race test — inline TEMP→MKT-{id} (the
+        # surrounding test exercises a market_snapshots race, so we keep
+        # precise raw-SQL control over the market dimension row).
         cur.execute(
             """
             INSERT INTO markets (
                 platform_id, event_id, external_id, ticker, title,
-                market_type, status
+                market_type, status, market_key
             )
-            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -463,9 +477,14 @@ def market_race_setup(db_pool: Any) -> Any:
                 "Race Test Market 625",
                 "binary",
                 "open",
+                f"TEMP-{uuid.uuid4()}",
             ),
         )
         market_pk = cur.fetchone()["id"]
+        cur.execute(
+            "UPDATE markets SET market_key = %s WHERE id = %s",
+            (f"MKT-{market_pk}", market_pk),
+        )
 
         # Insert the initial current snapshot. The concurrent-update race
         # needs an existing current row so both callers pass get_current_market.
@@ -605,13 +624,16 @@ def position_race_setup(db_pool: Any) -> Any:
         cur.execute("DELETE FROM markets WHERE ticker = %s", (test_ticker,))
 
         # Create the underlying market (positions FK to markets.id).
+        # Migration 0062 (#791): markets.market_key is NOT NULL + UNIQUE.
+        # Race test — inline TEMP→MKT-{id} (the surrounding test exercises
+        # a positions race, so we keep raw-SQL control over the market seed).
         cur.execute(
             """
             INSERT INTO markets (
                 platform_id, event_id, external_id, ticker, title,
-                market_type, status
+                market_type, status, market_key
             )
-            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id
             """,
             (
@@ -622,9 +644,14 @@ def position_race_setup(db_pool: Any) -> Any:
                 "Race Test Market Positions",
                 "binary",
                 "open",
+                f"TEMP-{uuid.uuid4()}",
             ),
         )
         market_pk = cur.fetchone()["id"]
+        cur.execute(
+            "UPDATE markets SET market_key = %s WHERE id = %s",
+            (f"MKT-{market_pk}", market_pk),
+        )
 
         # Create the initial current position row.
         # execution_environment is explicit (not relying on the DB default)

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -129,20 +129,31 @@ def sample_series(db_pool, clean_test_data, sample_platform) -> str:
 
 @pytest.fixture
 def sample_event(db_pool, clean_test_data, sample_platform, sample_series) -> str:
-    """Create sample event for testing."""
-    from precog.database.connection import execute_query, fetch_one
+    """Create sample event for testing.
+
+    Migration 0062 (#791): events.event_key is NOT NULL + UNIQUE.  We route
+    through the ``get_or_create_event`` CRUD helper so the two-step
+    ``TEMP → EVT-{id}`` key assignment is handled inside the canonical code
+    path — avoiding the need to hand-roll the sentinel here and keeping the
+    test fixture in sync with production semantics (Glokta S60 review).
+    """
+    from precog.database.connection import fetch_one
+    from precog.database.crud_events import get_or_create_event
 
     # Look up series surrogate PK (migration 0019: events use integer FK)
     series_row = fetch_one("SELECT id FROM series WHERE series_key = 'NFL-2025'")
     series_pk = series_row["id"] if series_row else None
 
-    query = """
-        INSERT INTO events (platform_id, series_id, external_id, category, subcategory, title, status)
-        VALUES ('kalshi', %s, 'HIGHTEST', 'sports', 'nfl', 'Super Bowl LIX', 'scheduled')
-        ON CONFLICT (platform_id, external_id) DO NOTHING
-        RETURNING external_id
-    """
-    execute_query(query, (series_pk,))
+    get_or_create_event(
+        event_id="HIGHTEST",
+        platform_id="kalshi",
+        external_id="HIGHTEST",
+        category="sports",
+        subcategory="nfl",
+        title="Super Bowl LIX",
+        series_id=series_pk,
+        status="scheduled",
+    )
     return "HIGHTEST"
 
 

--- a/tests/test_database_connection.py
+++ b/tests/test_database_connection.py
@@ -96,12 +96,21 @@ def test_execute_query(db_pool, clean_test_data):
     # Note: We can't easily test with temp tables since execute_query uses its own connection
     # Instead, test with a real table (markets) using TEST- prefix for cleanup
 
-    # Create test market using execute_query (markets is a dimension table post-0021)
+    # Create test market using execute_query (markets is a dimension table post-0021).
+    # Migration 0062 (#791): markets.market_key is NOT NULL + UNIQUE.  Since
+    # this test exercises the raw ``execute_query`` helper (not the CRUD
+    # wrapper), we provide a uniquely-generated TEMP key inline.  The follow-up
+    # DELETE below prevents any cross-test leakage; there is no SCD supersede
+    # or readback — the test only asserts rowcount == 1.
+    import uuid as _uuid
+
+    temp_key = f"TEMP-{_uuid.uuid4()}"
     rowcount = execute_query(
         """INSERT INTO markets (
             platform_id, external_id,
-            ticker, title, market_type, status
-        ) VALUES (%s, %s, %s, %s, %s, %s)""",
+            ticker, title, market_type, status,
+            market_key
+        ) VALUES (%s, %s, %s, %s, %s, %s, %s)""",
         (
             "test_platform",
             "TEST-EXT",
@@ -109,6 +118,7 @@ def test_execute_query(db_pool, clean_test_data):
             "Test Market",
             "binary",
             "open",
+            temp_key,
         ),
         commit=True,
     )

--- a/tests/unit/database/test_crud_operations_unit.py
+++ b/tests/unit/database/test_crud_operations_unit.py
@@ -513,12 +513,15 @@ class TestUpsertGameStateUnit:
         from datetime import datetime as _dt
 
         mock_cursor = MagicMock()
-        # Mock fetchone to return: NOW() ts row, then INSERT RETURNING id.
-        # (The FOR UPDATE lock query's fetchone result is not consumed by
-        # the closure, so no placeholder is needed for it.)
+        # Mock fetchone to return: NOW() ts row, FOR UPDATE lock row (supersede
+        # path — current row exists), then INSERT RETURNING id for the new
+        # superseding row. Migration 0062 expanded the lock query SELECT list to
+        # include game_state_key, and _attempt_close_and_insert reads that value
+        # to carry forward verbatim (Pattern 18 / SCD2 rule).
         mock_cursor.fetchone.side_effect = [
-            {"ts": _dt(2026, 1, 15, 12, 0, 0, tzinfo=UTC)},
-            {"id": 100},  # INSERT RETURNING id
+            {"ts": _dt(2026, 1, 15, 12, 0, 0, tzinfo=UTC)},  # SELECT NOW() AS ts
+            {"id": 99, "game_state_key": "GST-99"},  # FOR UPDATE lock — current row (supersede)
+            {"id": 100},  # INSERT RETURNING id — new superseding row
         ]
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
         mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
@@ -620,7 +623,10 @@ class TestGetOrCreateGameUnit:
     def test_get_or_create_game_returns_id(self, mock_get_cursor):
         """Test get_or_create_game returns the game id."""
         mock_cursor = MagicMock()
-        mock_cursor.fetchone.return_value = {"id": 42}
+        # Migration 0062: RETURNING clause now includes game_key. Returning a
+        # canonical (non-TEMP) key simulates the ON CONFLICT branch and avoids
+        # the follow-up UPDATE firing (keeping execute.call_count at 1).
+        mock_cursor.fetchone.return_value = {"id": 42, "game_key": "GAM-42"}
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
         mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -640,7 +646,7 @@ class TestGetOrCreateGameUnit:
     def test_get_or_create_game_derives_season_from_date(self, mock_get_cursor):
         """Test season is derived from game_date.year when not provided."""
         mock_cursor = MagicMock()
-        mock_cursor.fetchone.return_value = {"id": 1}
+        mock_cursor.fetchone.return_value = {"id": 1, "game_key": "GAM-1"}  # 0062
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
         mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -675,7 +681,7 @@ class TestGetOrCreateGameUnit:
         back to an earlier status when the same game is upserted again.
         """
         mock_cursor = MagicMock()
-        mock_cursor.fetchone.return_value = {"id": 1}
+        mock_cursor.fetchone.return_value = {"id": 1, "game_key": "GAM-1"}  # 0062
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
         mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -699,7 +705,7 @@ class TestGetOrCreateGameUnit:
     def test_get_or_create_game_passes_all_fields(self, mock_get_cursor):
         """Test all optional fields are passed through to SQL."""
         mock_cursor = MagicMock()
-        mock_cursor.fetchone.return_value = {"id": 99}
+        mock_cursor.fetchone.return_value = {"id": 99, "game_key": "GAM-99"}  # 0062
         mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
         mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
 
@@ -3119,8 +3125,9 @@ class TestCreateMarketEnrichment:
 
         assert result == 99
 
-        # Two execute calls: dimension INSERT + snapshot INSERT
-        assert mock_cursor.execute.call_count == 2
+        # Three execute calls: dimension INSERT + dimension UPDATE (0062 two-step
+        # canonical market_key) + snapshot INSERT
+        assert mock_cursor.execute.call_count == 3
 
         # Verify dimension INSERT includes expiration_value and notional_value
         dim_call = mock_cursor.execute.call_args_list[0]
@@ -3132,8 +3139,9 @@ class TestCreateMarketEnrichment:
         assert "above 42.5" in dim_params
         assert Decimal("1.0000") in dim_params
 
-        # Verify snapshot INSERT includes all 6 new fields
-        snap_call = mock_cursor.execute.call_args_list[1]
+        # Verify snapshot INSERT includes all 6 new fields (now at index 2 after
+        # the 0062 canonical market_key UPDATE at index 1)
+        snap_call = mock_cursor.execute.call_args_list[2]
         snap_sql = snap_call[0][0]
         snap_params = snap_call[0][1]
         assert "volume_24h" in snap_sql
@@ -3183,8 +3191,9 @@ class TestCreateMarketEnrichment:
         assert "expiration_value" in dim_sql
         assert "notional_value" in dim_sql
 
-        # Verify snapshot INSERT: all 6 new fields are None
-        snap_params = mock_cursor.execute.call_args_list[1][0][1]
+        # Verify snapshot INSERT: all 6 new fields are None (index shifted to 2
+        # by the 0062 two-step market_key UPDATE at index 1)
+        snap_params = mock_cursor.execute.call_args_list[2][0][1]
         # The last 6 params before row_current_ind/updated_at should be None
         # Snapshot params: market_pk, yes_ask, no_ask, yes_bid, no_bid, last_price,
         #                  spread, volume, open_interest, liquidity,
@@ -3228,8 +3237,9 @@ class TestCreateMarketEnrichment:
             previous_price=Decimal("0.6000"),
         )
 
-        # Verify the function completed (2 SQL calls = dim + snap)
-        assert mock_cursor.execute.call_count == 2
+        # Verify the function completed (3 SQL calls: dim INSERT + 0062
+        # canonical market_key UPDATE + snap INSERT)
+        assert mock_cursor.execute.call_count == 3
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Phase B kickoff of the Schema Hardening Arc (Epic #745). Adds stable, human-readable business key columns (`market_key`, `event_key`, `game_state_key`, `game_key`) to the 4 core entity tables. All 4 columns are `VARCHAR NOT NULL` post-migration. Foundation for cross-platform identity, SCD2 natural-key uniqueness, and downstream analytics.

## Migration 0062 (4-step)

1. `ADD COLUMN <x>_key VARCHAR NULL` on markets/events/game_states/games
2. Backfill `UPDATE <x>_key = '<PREFIX>-' || id` (parameterized bind)
3. `SET NOT NULL` on each
4. Indexes:
   - markets/events/games → full `UNIQUE`
   - game_states → lookup btree + SCD2-aware partial `UNIQUE WHERE row_current_ind = true`

## CRUD two-step INSERT pattern

5 write paths updated to use TEMP sentinel → UPDATE to canonical `PREFIX-{id}` within a single transaction:

| Path | Prefix | Notes |
|---|---|---|
| `crud_markets.create_market` | MKT | +Snapshot insert at end |
| `crud_events.create_event` | EVT | |
| `crud_game_states.create_game_state` | GST | |
| `crud_game_states.upsert_game_state` | GST | **Hot path** — lock-query expanded; supersede carries key forward (Pattern 18) |
| `crud_game_states.get_or_create_game` | GAM | INSERT branch fires UPDATE; CONFLICT branch preserves existing key |
| `seeding/historical_games_loader` | GAM | Batch INSERT + follow-up UPDATE via `RETURNING id + ANY()` |

**Critical SCD2 property:** `upsert_game_state`'s supersede path carries the EXISTING `game_state_key` forward verbatim. Pinned by `test_upsert_game_state_carries_key_forward_on_supersede` regression test.

## Agent Review Trail

| Step | Agent | Outcome |
|---|---|---|
| Design (S59) | Holden + Galadriel | MCP-verified row counts, migration split approved, PK renames deferred to C2d. See `memory/design_791_c2c_business_keys.md` |
| Builder | Samwise | 19 integration tests PASS, MCP-verified dev DB at 0061 |
| Reviewer | Glokta | **REQUEST CHANGES** → 1 blocker (14 test fixtures missing `_key`) + 5 warnings |
| Remediation | Samwise | Hybrid Option C: 5 fixtures converted to CRUD helpers, 7 + 1 reclassified to Option A (raw + TEMP) |
| Sentinel | Ripley | **CLEAR TO MERGE** (18/19 files pass, 1 observation → follow-up #860) |
| Pre-push | Automated | Caught 18 additional stale-mock failures (chaos: 11, unit: 7) that all 3 agents missed — Pattern 43 violations — fixed in commit `af2e306` |

## Warnings Applied (Glokta)

- W1: Migration backfill f-string → SQLAlchemy bind-param
- W2: Runtime None guard in `upsert_game_state._attempt_close_and_insert`
- W3: Batch-loader narrow WHERE via `RETURNING id` + `ANY()`
- W4: Test batch-loader CRUD lookup pre-tuple (removed fragile slicing)
- W5: Simplified dead COALESCE in `get_or_create_game` ON CONFLICT

## Test Plan

- [x] `test_migration_0062_business_keys.py`: 19/19 PASS
- [x] `tests/unit/`: 2615 passed, 0 failed
- [x] `tests/chaos/test_crud_operations_chaos.py`: 32/32 PASS
- [x] Pre-push all tiers (integration + e2e + stress + chaos + race): 4853+ passed, 0 failed in 362s

Pre-existing failures verified unrelated (via `git stash` baseline):
- 8× `tests/test_attribution.py` — `create_trade` signature drift (migration 0025)
- 12× `tests/property/database/test_series_crud_properties.py` — isolated-run schema drift
- 1× `tests/test_crud_operations.py` — `close_position` import error

## Scope Boundary

Explicitly deferred (not in this PR):
- PK renames (`strategy_id`/`model_id` → `id`) — C2d
- `_key` on strategies/probability_models — natural composite suffices
- SCD2 temporal cols on strategies/probability_models — migration 0063 (separate PR)
- `orderbook_snapshot_id` on orders/edges — migration 0064 / #725 item 11 (separate PR)

## Follow-up Issues

- #859 — Add `_key` cols to `current_markets` / `current_game_states` views (Pattern 42 step 5)
- #860 — Migration downgrade reversibility test for 0062

Closes #791 (C2c business key enrichment)
Part of #745 (Schema Hardening Arc epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)