### PR TITLE
feat: #725 item 11 — Migration 0063 orderbook_snapshot_id FK on orders + edges

### DIFF
--- a/src/precog/database/alembic/versions/0063_orderbook_snapshot_fk.py
+++ b/src/precog/database/alembic/versions/0063_orderbook_snapshot_fk.py
@@ -1,0 +1,200 @@
+"""Wire orderbook_snapshot_id provenance FK onto orders + edges.
+
+Closes #725 item 11. Links every order and every edge to the specific
+``orderbook_snapshots`` row that was visible at decision time — completing
+the provenance chain that ``0059`` started (items 1-7) but deferred item 11
+per Holden's S57 split recommendation.
+
+Revision ID: 0063
+Revises: 0062
+Create Date: 2026-04-16
+
+Issue: #725 (item 11)
+Epic: #745 (Schema Hardening Arc, residual from Cohort C2)
+
+Design review:
+    Holden (S59) — see ``design_725_item11_orderbook.md``. PM-approved.
+    Migration numbered 0063 (chains off 0062 C2c business keys, which
+    landed as PR #861). The C2c SCD2 prep migration takes 0064.
+
+Columns added (both nullable, both ON DELETE RESTRICT per ADR-116):
+
+    1. orders.orderbook_snapshot_id  -> orderbook_snapshots(id)
+    2. edges.orderbook_snapshot_id   -> orderbook_snapshots(id)
+
+Why nullable:
+    Forward-only. The orderbook polling pipeline is not yet built; until
+    it is, every order and every edge is created without an orderbook
+    snapshot context. Adding ``NOT NULL`` now would force a backfill
+    decision for production rows that never had this provenance. The
+    orderbook pipeline (Phase 3) will start populating the column when
+    it lands; a follow-up migration can then ``SET NOT NULL`` once the
+    write-side is reliably populating.
+
+Why RESTRICT:
+    Matches 0057 + 0059 convention. RESTRICT preserves provenance:
+    blocking parent ``orderbook_snapshots`` deletion while orders/edges
+    reference it is the whole point of the wiring. SET NULL would
+    silently orphan the provenance; CASCADE would silently destroy
+    the referencing order/edge record.
+
+Why partial indexes:
+    On day-of-land every row is NULL (no orderbook pipeline yet). A
+    full btree on a NULL-dominant column would bloat disk with NULLs.
+    ``WHERE orderbook_snapshot_id IS NOT NULL`` keeps the index tight
+    while still giving lookup speed for non-NULL rows once the pipeline
+    writes them. Same pattern as 0059's 7 partial indexes.
+
+CRUD impact (same PR):
+    - ``crud_orders.create_order()`` -- add optional
+      ``orderbook_snapshot_id: int | None = None`` kwarg. INSERT column
+      list + params tuple both grow by one position (appended at end).
+    - ``crud_analytics.create_edge()`` -- same treatment.
+
+    No SCD supersede path exists for edges today (``create_edge`` +
+    direct lifecycle UPDATEs via ``update_edge_outcome`` /
+    ``update_edge_status``). Orders are not SCD at all (mutable rows).
+    If a future PR adds SCD supersede for edges, Pattern 49 copy-forward
+    applies: source ``orderbook_snapshot_id`` from ``current`` on the
+    new version.
+
+    ``update_order`` / ``update_edge_*`` paths are NOT updated. This is
+    a write-at-creation-time-only column for now -- callers that need
+    to backfill an orderbook snapshot onto an existing row can do so
+    with a direct UPDATE until a mutator is warranted.
+
+Write-protection trigger interaction (0056):
+    ``ALTER TABLE ADD COLUMN`` is DDL and bypasses 0056's row-level
+    write-protection triggers (which fire on INSERT/UPDATE/DELETE only).
+    No ``session_replication_role`` adjustment required.
+
+View dependencies (Pattern 38):
+    ``current_edges`` (``SELECT * FROM edges WHERE row_current_ind = TRUE``)
+    binds its column list at view-creation time -- an ``ALTER TABLE ADD
+    COLUMN`` on edges does NOT propagate into the view. This migration
+    DROPs and re-creates the view around the ALTER, mirroring the pattern
+    used in 0023 and 0058. ``orders`` has no views (verified via
+    information_schema), so no orders-side view handling is needed.
+
+Downgrade semantics:
+    Forward-only data is lost on downgrade (rows that had non-NULL
+    values revert to having never had the column). Safe on day-of-land
+    because every row is NULL; downgrade discipline over time is a
+    separate process concern.
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0063"
+down_revision: str = "0062"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# =============================================================================
+# FK addition specification
+# =============================================================================
+# Each tuple: (child_table, child_column, parent_table, parent_column)
+# Both columns: nullable INTEGER, ON DELETE RESTRICT, partial btree index.
+
+NEW_FKS: list[tuple[str, str, str, str]] = [
+    # Item 11a: orders provenance back to the orderbook snapshot at decision time
+    ("orders", "orderbook_snapshot_id", "orderbook_snapshots", "id"),
+    # Item 11b: edges provenance back to the orderbook snapshot at edge detection
+    ("edges", "orderbook_snapshot_id", "orderbook_snapshots", "id"),
+]
+
+
+def _fk_name(child_table: str, child_column: str) -> str:
+    """Return the auto-naming FK constraint name used by PostgreSQL.
+
+    Matches the ``{table}_{column}_fkey`` pattern that 0057/0059 use,
+    keeping information_schema discovery uniform.
+    """
+    return f"{child_table}_{child_column}_fkey"
+
+
+def _index_name(child_table: str, child_column: str) -> str:
+    """Return the partial-index name for a new FK column."""
+    return f"idx_{child_table}_{child_column}"
+
+
+def upgrade() -> None:
+    """Add 2 nullable FK columns with RESTRICT + partial indexes."""
+    for child_table, child_column, parent_table, parent_column in NEW_FKS:
+        constraint_name = _fk_name(child_table, child_column)
+        index_name = _index_name(child_table, child_column)
+
+        # Pattern 38: SELECT * views bind their column list at view
+        # creation time, so an ALTER TABLE ADD COLUMN does NOT propagate
+        # into the view. ``current_edges`` (last refreshed by 0058) must
+        # be dropped BEFORE the edges ALTER and re-created after so the
+        # new ``orderbook_snapshot_id`` column surfaces through the view.
+        # ``orders`` has no views -- only the edges iteration needs this.
+        if child_table == "edges":
+            op.execute("DROP VIEW IF EXISTS current_edges")
+
+        # Combined column-add + FK constraint. Postgres validates the
+        # constraint instantly because the column is nullable and no
+        # existing rows violate it (all NULL).
+        op.execute(
+            f"""
+            ALTER TABLE {child_table}
+            ADD COLUMN {child_column} INTEGER
+            CONSTRAINT {constraint_name}
+            REFERENCES {parent_table}({parent_column}) ON DELETE RESTRICT
+            """
+        )
+
+        # Partial index to keep the NULL-dominant column's index tight.
+        op.execute(
+            f"""
+            CREATE INDEX {index_name}
+            ON {child_table}({child_column})
+            WHERE {child_column} IS NOT NULL
+            """
+        )
+
+        # Pattern 38 (part 2): re-create the view now that the edges
+        # column list includes ``orderbook_snapshot_id``. SELECT *
+        # re-expands against the current column list at view creation.
+        if child_table == "edges":
+            op.execute(
+                "CREATE OR REPLACE VIEW current_edges AS "
+                "SELECT * FROM edges WHERE row_current_ind = TRUE"
+            )
+
+
+def downgrade() -> None:
+    """Drop the 2 FK columns + partial indexes. Forward-only data is lost."""
+    # Drop in reverse order of upgrade so indexes come down before their
+    # backing columns (Postgres tolerates either order today, but the
+    # explicit teardown sequence matches the upgrade narrative and
+    # matches 0059's downgrade style).
+    for child_table, child_column, _parent_table, _parent_column in reversed(NEW_FKS):
+        index_name = _index_name(child_table, child_column)
+
+        # Pattern 38: drop the view BEFORE the DROP COLUMN. Even though
+        # ``current_edges`` is defined via SELECT *, PostgreSQL resolves
+        # and binds the expansion to specific column references at view
+        # creation time, and will refuse to drop a column the view
+        # depends on. Mirror of the upgrade guard.
+        if child_table == "edges":
+            op.execute("DROP VIEW IF EXISTS current_edges")
+
+        op.execute(f"DROP INDEX IF EXISTS {index_name}")
+        # ``DROP COLUMN`` cascades the FK constraint automatically.
+        op.execute(f"ALTER TABLE {child_table} DROP COLUMN IF EXISTS {child_column}")
+
+        # Pattern 38 (part 2): re-create the view with SELECT *, which
+        # now re-expands to the pre-0063 column list (since we just
+        # dropped ``orderbook_snapshot_id``). This is the correct "undo"
+        # -- the view is restored to its pre-0063 shape.
+        if child_table == "edges":
+            op.execute(
+                "CREATE OR REPLACE VIEW current_edges AS "
+                "SELECT * FROM edges WHERE row_current_ind = TRUE"
+            )

--- a/src/precog/database/crud_analytics.py
+++ b/src/precog/database/crud_analytics.py
@@ -69,6 +69,7 @@ def create_edge(
     recommended_action: str | None = None,
     category: str | None = None,
     subcategory: str | None = None,
+    orderbook_snapshot_id: int | None = None,
 ) -> int:
     """
     Create a new edge record with SCD Type 2 row_current_ind = TRUE.
@@ -106,6 +107,10 @@ def create_edge(
             environment. The optional-default precedent removed in the
             #622+#686 synthesis PR was the literal cause of the
             #622/#662/#686 bug class. See findings_622_686_synthesis.md.
+        orderbook_snapshot_id: FK to orderbook_snapshots(id) visible at edge
+            detection time. Nullable -- None until orderbook pipeline is wired
+            (Phase 3). Added by migration 0063 for #725 item 11 (provenance
+            chain completion). See ``design_725_item11_orderbook.md``.
 
     Returns:
         Integer surrogate PK (edges.id) of the newly created edge.
@@ -172,6 +177,17 @@ def create_edge(
     if liquidity is not None:
         liquidity = validate_decimal(liquidity, "liquidity")
 
+    # NOTE: edges has NO SCD2 supersede path today -- the only writers are
+    # ``create_edge`` (this function) + direct lifecycle UPDATEs via
+    # ``update_edge_outcome`` / ``update_edge_status``. That means there
+    # is no Pattern 49 copy-forward requirement for ``orderbook_snapshot_id``
+    # YET. When a supersede path is added for edges (e.g. on price drift),
+    # the new INSERT in that path MUST carry ``orderbook_snapshot_id``
+    # forward from the current row -- see design memo
+    # ``design_725_item11_orderbook.md`` section on SCD copy-forward.
+    # ``orderbook_snapshot_id`` is appended at the end of the column list
+    # and params tuple so existing positional indexes into unit-test
+    # mocks remain stable.
     insert_query = """
         INSERT INTO edges (
             edge_key, market_id, model_id,
@@ -182,7 +198,8 @@ def create_edge(
             strategy_id, confidence_level, confidence_metrics,
             recommended_action, category, subcategory,
             execution_environment, edge_status,
-            row_current_ind, row_start_ts
+            row_current_ind, row_start_ts,
+            orderbook_snapshot_id
         )
         VALUES (
             'TEMP', %s, %s,
@@ -192,7 +209,8 @@ def create_edge(
             %s, %s, %s,
             %s, %s, %s,
             %s, 'detected',
-            TRUE, NOW()
+            TRUE, NOW(),
+            %s
         )
         RETURNING id
     """
@@ -218,6 +236,7 @@ def create_edge(
         category,
         subcategory,
         execution_environment,
+        orderbook_snapshot_id,
     )
 
     with get_cursor(commit=True) as cur:

--- a/src/precog/database/crud_orders.py
+++ b/src/precog/database/crud_orders.py
@@ -88,6 +88,7 @@ def create_order(
     client_order_id: str | None = None,
     trade_source: str = "automated",
     order_metadata: dict | None = None,
+    orderbook_snapshot_id: int | None = None,
 ) -> int:
     """
     Create a new order record.
@@ -121,6 +122,10 @@ def create_order(
             application boundary or pass an explicit literal.
         trade_source: 'automated' or 'manual'
         order_metadata: Additional data stored as JSONB
+        orderbook_snapshot_id: FK to orderbook_snapshots(id) visible at order
+            decision time. Nullable -- None until orderbook pipeline is wired
+            (Phase 3). Added by migration 0063 for #725 item 11 (provenance
+            chain completion). See ``design_725_item11_orderbook.md``.
 
     Returns:
         Integer surrogate PK (orders.id) of the newly created order.
@@ -195,7 +200,8 @@ def create_order(
             requested_price, requested_quantity,
             remaining_quantity, status,
             execution_environment, trade_source,
-            order_metadata
+            order_metadata,
+            orderbook_snapshot_id
         )
         VALUES (
             %s, %s, %s,
@@ -205,11 +211,16 @@ def create_order(
             %s, %s,
             %s, 'submitted',
             %s, %s,
+            %s,
             %s
         )
         RETURNING id
     """
 
+    # NOTE: orderbook_snapshot_id is appended at the end of the params tuple
+    # (matching the column list order) so existing positional indexes into
+    # ``call_args_list[0][0][1]`` used by unit tests remain stable. See
+    # migration 0063 for schema context.
     params = (
         platform_id,
         external_order_id,
@@ -229,6 +240,7 @@ def create_order(
         execution_environment,
         trade_source,
         json.dumps(order_metadata) if order_metadata is not None else None,
+        orderbook_snapshot_id,
     )
 
     with get_cursor(commit=True) as cur:

--- a/tests/integration/database/test_migration_0063_orderbook_fk.py
+++ b/tests/integration/database/test_migration_0063_orderbook_fk.py
@@ -1,0 +1,494 @@
+"""Integration tests for migration 0063 -- orderbook_snapshot_id FK on orders + edges.
+
+Verifies the POST-MIGRATION state of ``orderbook_snapshot_id`` on orders
+and edges, plus the CRUD create-path contracts that populate the column
+when callers pass it.
+
+Test groups:
+    - TestOrderbookSnapshotColumnsPresent: column exists and is nullable
+      on both orders + edges (query information_schema.columns).
+    - TestOrderbookSnapshotForeignKey: FK constraint exists and is
+      ON DELETE RESTRICT on both tables (query information_schema
+      table_constraints + referential_constraints).
+    - TestOrderbookSnapshotPartialIndex: partial btree index exists with
+      ``WHERE (orderbook_snapshot_id IS NOT NULL)`` predicate on both
+      tables (query pg_indexes).
+    - TestCreateOrderWritesFK: ``create_order(..., orderbook_snapshot_id=N)``
+      persists the FK; ``create_order(...)`` without it persists NULL
+      (backward-compat regression).
+    - TestCreateEdgeWritesFK: same two scenarios for ``create_edge``.
+    - TestOnDeleteRestrict: deleting a parent ``orderbook_snapshots`` row
+      while an order or edge references it raises a ForeignKeyViolation
+      (RESTRICT semantics enforced).
+
+Issue: #725 (item 11)
+Epic: #745 (Schema Hardening Arc, provenance chain completion)
+
+Markers:
+    @pytest.mark.integration: real DB required (testcontainer per ADR-057)
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from typing import Any
+
+import psycopg2
+import pytest
+
+from precog.database.connection import fetch_one, get_cursor
+from precog.database.crud_analytics import create_edge
+from precog.database.crud_markets import create_market, insert_orderbook_snapshot
+from precog.database.crud_orders import create_order
+
+pytestmark = [pytest.mark.integration]
+
+
+# =============================================================================
+# Per-table spec -- tables that got the new FK column
+# =============================================================================
+
+# (table, fk_column, index_name, constraint_name)
+_FK_SPEC: list[tuple[str, str, str, str]] = [
+    (
+        "orders",
+        "orderbook_snapshot_id",
+        "idx_orders_orderbook_snapshot_id",
+        "orders_orderbook_snapshot_id_fkey",
+    ),
+    (
+        "edges",
+        "orderbook_snapshot_id",
+        "idx_edges_orderbook_snapshot_id",
+        "edges_orderbook_snapshot_id_fkey",
+    ),
+]
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def orderbook_parent(db_pool: Any) -> Any:
+    """Create a parent orderbook_snapshots row + its market for FK tests.
+
+    Yields a dict with ``market_pk``, ``snapshot_id``, and ``test_ticker``.
+    Cleanup deletes dependents (orders, edges) + the snapshot + the market
+    in reverse FK order.
+    """
+    from tests.fixtures.cleanup_helpers import delete_market_with_children
+
+    test_ticker = f"TEST-0063-{uuid.uuid4().hex[:8]}"
+
+    with get_cursor(commit=True) as cur:
+        delete_market_with_children(cur, "ticker = %s", (test_ticker,))
+
+    market_pk = create_market(
+        platform_id="kalshi",
+        event_id=None,
+        external_id=f"{test_ticker}-EXT",
+        ticker=test_ticker,
+        title="Test market for 0063 orderbook FK",
+        yes_ask_price=Decimal("0.5000"),
+        no_ask_price=Decimal("0.5000"),
+    )
+    snapshot_id = insert_orderbook_snapshot(
+        market_id=market_pk,
+        best_bid=Decimal("0.5000"),
+        best_ask=Decimal("0.5100"),
+    )
+
+    yield {
+        "market_pk": market_pk,
+        "snapshot_id": snapshot_id,
+        "test_ticker": test_ticker,
+    }
+
+    with get_cursor(commit=True) as cur:
+        delete_market_with_children(cur, "ticker = %s", (test_ticker,))
+
+
+# =============================================================================
+# Group 1: Column presence + nullability
+# =============================================================================
+
+
+@pytest.mark.parametrize(("table", "fk_col", "_index", "_constraint"), _FK_SPEC)
+def test_orderbook_snapshot_column_exists_and_nullable(
+    db_pool: Any, table: str, fk_col: str, _index: str, _constraint: str
+) -> None:
+    """Column exists, is INTEGER, and is nullable on both tables."""
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            SELECT data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_name = %s AND column_name = %s
+            """,
+            (table, fk_col),
+        )
+        row = cur.fetchone()
+    assert row is not None, f"{table}.{fk_col} column missing post-0063"
+    assert row["data_type"] == "integer", (
+        f"{table}.{fk_col} must be INTEGER, got {row['data_type']}"
+    )
+    assert row["is_nullable"] == "YES", f"{table}.{fk_col} must be nullable"
+
+
+# =============================================================================
+# Group 2: Foreign key constraint + ON DELETE RESTRICT
+# =============================================================================
+
+
+@pytest.mark.parametrize(("table", "fk_col", "_index", "constraint_name"), _FK_SPEC)
+def test_orderbook_snapshot_fk_is_restrict(
+    db_pool: Any, table: str, fk_col: str, _index: str, constraint_name: str
+) -> None:
+    """FK constraint exists on both tables with ON DELETE RESTRICT.
+
+    Joins information_schema.table_constraints with referential_constraints
+    to read the delete_rule. Mirrors the pattern used by migration 0057's
+    test harness.
+    """
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            SELECT tc.constraint_name,
+                   tc.table_name,
+                   rc.delete_rule,
+                   ccu.table_name AS referenced_table,
+                   ccu.column_name AS referenced_column
+            FROM information_schema.table_constraints tc
+            JOIN information_schema.referential_constraints rc
+              ON tc.constraint_name = rc.constraint_name
+             AND tc.constraint_schema = rc.constraint_schema
+            JOIN information_schema.constraint_column_usage ccu
+              ON rc.unique_constraint_name = ccu.constraint_name
+             AND rc.unique_constraint_schema = ccu.constraint_schema
+            WHERE tc.constraint_type = 'FOREIGN KEY'
+              AND tc.table_name = %s
+              AND tc.constraint_name = %s
+            """,
+            (table, constraint_name),
+        )
+        row = cur.fetchone()
+    assert row is not None, (
+        f"FK constraint {constraint_name!r} missing on {table}.{fk_col} post-0063"
+    )
+    assert row["delete_rule"] == "RESTRICT", (
+        f"{table}.{fk_col} FK delete_rule must be RESTRICT "
+        f"(provenance preservation), got {row['delete_rule']!r}"
+    )
+    assert row["referenced_table"] == "orderbook_snapshots", (
+        f"{table}.{fk_col} must reference orderbook_snapshots, got {row['referenced_table']!r}"
+    )
+    assert row["referenced_column"] == "id", (
+        f"{table}.{fk_col} must reference orderbook_snapshots(id), "
+        f"got ...({row['referenced_column']!r})"
+    )
+
+
+# =============================================================================
+# Group 3: Partial btree index
+# =============================================================================
+
+
+@pytest.mark.parametrize(("table", "fk_col", "index_name", "_constraint"), _FK_SPEC)
+def test_orderbook_snapshot_partial_index_exists(
+    db_pool: Any, table: str, fk_col: str, index_name: str, _constraint: str
+) -> None:
+    """Partial btree index exists on both tables with IS NOT NULL predicate.
+
+    Postgres normalizes the index predicate in pg_indexes.indexdef to
+    ``WHERE (orderbook_snapshot_id IS NOT NULL)``. The parenthesization
+    is stable; the assertion uses a contains-check on that normalized form.
+    """
+    with get_cursor() as cur:
+        cur.execute(
+            """
+            SELECT indexname, indexdef
+            FROM pg_indexes
+            WHERE tablename = %s AND indexname = %s
+            """,
+            (table, index_name),
+        )
+        row = cur.fetchone()
+    assert row is not None, f"Partial index {index_name!r} missing on {table}.{fk_col}"
+    indexdef = row["indexdef"]
+    # Non-unique partial index (NULL-dominant). If this ever becomes UNIQUE
+    # the design is broken -- multiple orders CAN share a snapshot.
+    assert "UNIQUE" not in indexdef, (
+        f"{index_name} must NOT be UNIQUE (orders/edges both reference "
+        f"the same snapshot is expected); got: {indexdef}"
+    )
+    assert f"({fk_col} IS NOT NULL)" in indexdef, (
+        f"{index_name} must be partial WHERE ({fk_col} IS NOT NULL); got: {indexdef}"
+    )
+
+
+# =============================================================================
+# Group 4: create_order writes the FK column (both paths)
+# =============================================================================
+
+
+def test_create_order_with_orderbook_snapshot_id_persists_fk(
+    db_pool: Any, orderbook_parent: Any
+) -> None:
+    """``create_order(..., orderbook_snapshot_id=N)`` writes N to the row."""
+    snapshot_id = orderbook_parent["snapshot_id"]
+    market_pk = orderbook_parent["market_pk"]
+
+    order_pk = create_order(
+        platform_id="kalshi",
+        external_order_id=f"TEST-0063-ORD-{uuid.uuid4().hex[:8]}",
+        market_id=market_pk,
+        side="yes",
+        action="buy",
+        requested_price=Decimal("0.5000"),
+        requested_quantity=1,
+        execution_environment="paper",
+        orderbook_snapshot_id=snapshot_id,
+    )
+
+    with get_cursor() as cur:
+        cur.execute(
+            "SELECT orderbook_snapshot_id FROM orders WHERE id = %s",
+            (order_pk,),
+        )
+        row = cur.fetchone()
+    assert row is not None, "Order row must exist after create_order"
+    assert row["orderbook_snapshot_id"] == snapshot_id, (
+        f"create_order did not persist orderbook_snapshot_id; "
+        f"expected {snapshot_id}, got {row['orderbook_snapshot_id']!r}"
+    )
+
+
+def test_create_order_without_orderbook_snapshot_id_persists_null(
+    db_pool: Any, orderbook_parent: Any
+) -> None:
+    """Backward-compat: omitting ``orderbook_snapshot_id`` yields NULL.
+
+    This is the load-bearing regression test for #725 item 11. The whole
+    design relies on the column being a *forward-compatible addition*;
+    every existing caller (and every caller until the orderbook pipeline
+    lands) omits the new kwarg. If that path ever writes a non-NULL
+    accidental value, the nullable + partial-index assumption breaks.
+    """
+    market_pk = orderbook_parent["market_pk"]
+
+    order_pk = create_order(
+        platform_id="kalshi",
+        external_order_id=f"TEST-0063-ORD-NULL-{uuid.uuid4().hex[:8]}",
+        market_id=market_pk,
+        side="no",
+        action="buy",
+        requested_price=Decimal("0.5000"),
+        requested_quantity=1,
+        execution_environment="paper",
+        # orderbook_snapshot_id deliberately omitted
+    )
+
+    with get_cursor() as cur:
+        cur.execute(
+            "SELECT orderbook_snapshot_id FROM orders WHERE id = %s",
+            (order_pk,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row["orderbook_snapshot_id"] is None, (
+        f"create_order without orderbook_snapshot_id must persist NULL; "
+        f"got {row['orderbook_snapshot_id']!r}"
+    )
+
+
+# =============================================================================
+# Group 5: create_edge writes the FK column (both paths)
+# =============================================================================
+
+
+def test_create_edge_with_orderbook_snapshot_id_persists_fk(
+    db_pool: Any, orderbook_parent: Any
+) -> None:
+    """``create_edge(..., orderbook_snapshot_id=N)`` writes N to the row."""
+    snapshot_id = orderbook_parent["snapshot_id"]
+    market_pk = orderbook_parent["market_pk"]
+
+    edge_pk = create_edge(
+        market_id=market_pk,
+        model_id=None,  # edges.model_id is nullable; no probability_model needed
+        expected_value=Decimal("0.0500"),
+        true_win_probability=Decimal("0.5500"),
+        market_implied_probability=Decimal("0.5000"),
+        market_price=Decimal("0.5000"),
+        execution_environment="paper",
+        orderbook_snapshot_id=snapshot_id,
+    )
+
+    with get_cursor() as cur:
+        cur.execute(
+            "SELECT orderbook_snapshot_id FROM edges WHERE id = %s",
+            (edge_pk,),
+        )
+        row = cur.fetchone()
+    assert row is not None, "Edge row must exist after create_edge"
+    assert row["orderbook_snapshot_id"] == snapshot_id, (
+        f"create_edge did not persist orderbook_snapshot_id; "
+        f"expected {snapshot_id}, got {row['orderbook_snapshot_id']!r}"
+    )
+
+
+def test_create_edge_without_orderbook_snapshot_id_persists_null(
+    db_pool: Any, orderbook_parent: Any
+) -> None:
+    """Backward-compat: omitting ``orderbook_snapshot_id`` yields NULL."""
+    market_pk = orderbook_parent["market_pk"]
+
+    edge_pk = create_edge(
+        market_id=market_pk,
+        model_id=None,
+        expected_value=Decimal("0.0300"),
+        true_win_probability=Decimal("0.5300"),
+        market_implied_probability=Decimal("0.5000"),
+        market_price=Decimal("0.5000"),
+        execution_environment="paper",
+        # orderbook_snapshot_id deliberately omitted
+    )
+
+    with get_cursor() as cur:
+        cur.execute(
+            "SELECT orderbook_snapshot_id FROM edges WHERE id = %s",
+            (edge_pk,),
+        )
+        row = cur.fetchone()
+    assert row is not None
+    assert row["orderbook_snapshot_id"] is None, (
+        f"create_edge without orderbook_snapshot_id must persist NULL; "
+        f"got {row['orderbook_snapshot_id']!r}"
+    )
+
+
+# =============================================================================
+# Group 6: ON DELETE RESTRICT is enforced at runtime
+# =============================================================================
+
+
+def test_delete_orderbook_snapshot_blocked_when_order_references_it(
+    db_pool: Any, orderbook_parent: Any
+) -> None:
+    """RESTRICT semantics: parent DELETE fails while an order references it.
+
+    This is the whole point of RESTRICT over SET NULL -- provenance must
+    not be silently severed. The test attempts to DELETE the parent
+    ``orderbook_snapshots`` row while an order with
+    ``orderbook_snapshot_id = <parent.id>`` exists, and asserts that
+    psycopg2 raises ``ForeignKeyViolation``.
+    """
+    snapshot_id = orderbook_parent["snapshot_id"]
+    market_pk = orderbook_parent["market_pk"]
+
+    create_order(
+        platform_id="kalshi",
+        external_order_id=f"TEST-0063-RESTRICT-ORD-{uuid.uuid4().hex[:8]}",
+        market_id=market_pk,
+        side="yes",
+        action="buy",
+        requested_price=Decimal("0.5000"),
+        requested_quantity=1,
+        execution_environment="paper",
+        orderbook_snapshot_id=snapshot_id,
+    )
+
+    with pytest.raises(psycopg2.errors.ForeignKeyViolation):
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM orderbook_snapshots WHERE id = %s",
+                (snapshot_id,),
+            )
+
+    # Assert the parent row actually survived the blocked DELETE.
+    # RESTRICT raises before the delete commits, so the snapshot must
+    # still exist -- the whole point of RESTRICT over CASCADE is that
+    # provenance rows are preserved, not silently destroyed.
+    result = fetch_one(
+        "SELECT COUNT(*) AS c FROM orderbook_snapshots WHERE id = %s",
+        (snapshot_id,),
+    )
+    assert result is not None
+    assert result["c"] == 1, "RESTRICT should have preserved the parent row"
+
+
+def test_delete_orderbook_snapshot_blocked_when_edge_references_it(
+    db_pool: Any, orderbook_parent: Any
+) -> None:
+    """RESTRICT semantics: parent DELETE fails while an edge references it."""
+    snapshot_id = orderbook_parent["snapshot_id"]
+    market_pk = orderbook_parent["market_pk"]
+
+    create_edge(
+        market_id=market_pk,
+        model_id=None,
+        expected_value=Decimal("0.0500"),
+        true_win_probability=Decimal("0.5500"),
+        market_implied_probability=Decimal("0.5000"),
+        market_price=Decimal("0.5000"),
+        execution_environment="paper",
+        orderbook_snapshot_id=snapshot_id,
+    )
+
+    with pytest.raises(psycopg2.errors.ForeignKeyViolation):
+        with get_cursor(commit=True) as cur:
+            cur.execute(
+                "DELETE FROM orderbook_snapshots WHERE id = %s",
+                (snapshot_id,),
+            )
+
+    # Assert the parent row actually survived the blocked DELETE (see
+    # the orders sibling above for rationale).
+    result = fetch_one(
+        "SELECT COUNT(*) AS c FROM orderbook_snapshots WHERE id = %s",
+        (snapshot_id,),
+    )
+    assert result is not None
+    assert result["c"] == 1, "RESTRICT should have preserved the parent row"
+
+
+# =============================================================================
+# Group 7: View parity -- current_edges exposes orderbook_snapshot_id
+# =============================================================================
+
+
+def test_current_edges_view_includes_orderbook_snapshot_id(db_pool: Any) -> None:
+    """``current_edges`` view must expose ``orderbook_snapshot_id`` post-0063.
+
+    Pattern 38: ``SELECT * FROM edges`` views bind their column list at
+    view-creation time. If a migration appends a column to ``edges``
+    without re-creating the dependent view, the new column is silently
+    dropped from downstream queries against the view. Migration 0063
+    must DROP + CREATE OR REPLACE ``current_edges`` around the
+    ``ALTER TABLE edges ADD COLUMN orderbook_snapshot_id`` to avoid this
+    drift.
+
+    This test asserts the outcome: the view definition -- as normalized
+    and re-emitted by ``information_schema.views.view_definition`` --
+    must contain the literal ``orderbook_snapshot_id`` identifier. If a
+    future migration regresses by appending to ``edges`` without
+    re-creating the view, this test fails loudly.
+    """
+    result = fetch_one(
+        """
+        SELECT view_definition
+        FROM information_schema.views
+        WHERE table_name = 'current_edges'
+          AND table_schema = 'public'
+        """
+    )
+    assert result is not None, "current_edges view is missing from public schema"
+    view_def = result["view_definition"]
+    assert "orderbook_snapshot_id" in view_def, (
+        "current_edges view definition does not expose "
+        "orderbook_snapshot_id -- Pattern 38 view-drift regression. "
+        f"Actual view definition: {view_def!r}"
+    )

--- a/tests/unit/database/test_edge_crud.py
+++ b/tests/unit/database/test_edge_crud.py
@@ -152,6 +152,7 @@ class TestCreateEdge:
             category="sports",
             subcategory="nfl",
             execution_environment="paper",
+            orderbook_snapshot_id=7,
         )
 
         assert result == 99
@@ -160,6 +161,13 @@ class TestCreateEdge:
         insert_params = insert_call[0][1]
         # confidence_metrics should be JSON-serialized (16th param, 0-indexed 15)
         assert json.loads(insert_params[15]) == {"model_agreement": 0.95}
+        # orderbook_snapshot_id is appended last in the params tuple (see
+        # migration 0063 + crud_analytics.create_edge params ordering).
+        # Index 20 = 21st element (0-indexed), the final slot.
+        assert insert_params[20] == 7, (
+            "create_edge must pass orderbook_snapshot_id as the final positional "
+            f"param; got params[20]={insert_params[20]!r}"
+        )
 
     @patch("precog.database.crud_analytics.get_cursor")
     def test_create_edge_sets_edge_status_detected(self, mock_get_cursor):

--- a/tests/unit/database/test_order_crud.py
+++ b/tests/unit/database/test_order_crud.py
@@ -215,9 +215,18 @@ class TestCreateOrder:
             execution_environment="paper",
             trade_source="manual",
             order_metadata={"source": "test"},
+            orderbook_snapshot_id=7,
         )
 
         assert result == 99
+        # orderbook_snapshot_id is appended last in the params tuple (see
+        # migration 0063 + crud_orders.create_order params ordering). Index
+        # 18 = 19th element (0-indexed), the final slot.
+        insert_params = mock_cursor.execute.call_args_list[0][0][1]
+        assert insert_params[18] == 7, (
+            "create_order must pass orderbook_snapshot_id as the final positional "
+            f"param; got params[18]={insert_params[18]!r}"
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Adds nullable FK `orderbook_snapshot_id INTEGER` to `orders` + `edges` tables with partial btree indexes `WHERE IS NOT NULL` and `ON DELETE RESTRICT`. Updates `create_order` and `create_edge` to accept the new optional kwarg — append-only, fully backward-compatible. Zero backfill, zero existing-data impact — forward-only provenance link for the orderbook pipeline (Phase 3).

## Migration 0063

1. `orders.orderbook_snapshot_id INTEGER NULL` + FK to `orderbook_snapshots(id) ON DELETE RESTRICT` + partial btree index `WHERE IS NOT NULL`
2. `edges.orderbook_snapshot_id` (same shape) — **bracketed by `DROP VIEW current_edges` + `CREATE OR REPLACE VIEW ...` for Pattern 38 compliance**
3. Downgrade: reverse-order (drop view → drop column → recreate view → drop index)

## Pattern 38 compliance (critical)

`current_edges` is a `SELECT *` view that PostgreSQL freezes the column list on at view-creation time. `ALTER TABLE ADD COLUMN` does NOT propagate into the view. Migrations 0023 and 0058 handled this correctly via `DROP+RECREATE` bracketing. Migration 0063 does the same.

**Bonus discovery** (filed as #862): the view re-creation also recovered two pre-existing column drifts (`market_snapshot_id`, `prediction_id`) that had been silently missing from `current_edges` since earlier migrations — meaning at least 2 prior migrations skipped the Pattern 38 step. Worth a repo-wide sweep (tracked in #862).

## Agent Review Trail

| Step | Agent | Outcome |
|---|---|---|
| Design (S59) | Holden | MCP-verified. See `memory/design_725_item11_orderbook.md` |
| Builder | Samwise | 12 integration tests PASS, pre-push 4889/0/20 green, Pattern 43 4-grep audit empty |
| Reviewer (adversarial) | Glokta | **APPROVE** — 11 watch-items PASS, 2 minor nits |
| Reviewer (structural) | Brawne | **BLOCKED** → Pattern 38 view drift found on `current_edges` |
| Sentinel | Ripley | **CLEAR** with 4 info observations |
| Remediation | Samwise | Blocker fixed (view bracketing + parity test + Pattern 38 docstring) + Ripley P1 (all-optional-fields unit tests exercise new kwarg) + P3 (RESTRICT tests assert row survival) |

## Test Plan

- [x] `test_migration_0063_orderbook_fk.py`: 13/13 PASS (12 original + 1 new view-parity test)
- [x] `test_order_crud.py` + `test_edge_crud.py`: 78/78 PASS (unit regression)
- [x] Pre-push all tiers: 4889 passed, 0 failed, 20 skipped (361s)
- [x] MCP round-trip: `alembic downgrade 0062 && upgrade 0063` clean
- [x] MCP verification: `current_edges` view_definition now contains `orderbook_snapshot_id`

## Scope Boundary

Explicitly OUT of scope:
- Wiring `orderbook_snapshot_id` into any poller / pipeline (Phase 3 work, blocked on orderbook pipeline itself)
- Updating `update_order` / `update_edge_*` to set the FK (write-at-creation-time-only per design memo)
- SCD supersede path on edges (no supersede path exists today; future debt flagged in code comments)
- `DATABASE_SCHEMA_SUMMARY` doc update — separate lane

## Follow-ups Filed

- **#862** — Repo-wide Pattern 38 sweep audit (surfaced by bonus discovery)

## Related

- Closes #725 item 11
- Part of #745 (Schema Hardening Arc epic)
- Feedback memory applied: `feedback_mock_fidelity_pattern43_grep_scope.md` (Pattern 43 4-grep was empty as expected for pure-append change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)