### PR TITLE
feat: #867 — pre-push hook for test DB migration parity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -308,6 +308,18 @@ repos:
         pass_filenames: false
         description: "Warns (does NOT block) when staged files match paths referenced by the ADR document and the ADR itself is not staged (G7, Option B criterion 7)"
 
+      # #867: Test DB migration parity — block push if test DB is behind alembic head
+      # Runs at pre-push stage only (too expensive for the pre-commit edit loop).
+      # Sibling of the #792 dev-DB UserPromptSubmit hook, but blocks instead of warns.
+      # Gracefully SKIPs (exit 0) when the test DB is unreachable or unconfigured.
+      - id: test-db-migration-parity
+        name: Test DB Migration Parity (#867)
+        entry: python scripts/check_test_db_migration_parity.py
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+        description: "Blocks push if the test DB is behind alembic head (S61 silent-CI fix; #867)"
+
   # Standard pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/scripts/check_test_db_migration_parity.py
+++ b/scripts/check_test_db_migration_parity.py
@@ -43,13 +43,24 @@ def main() -> int:
     try:
         status = check_migration_parity()
     except Exception as e:
-        # Any unexpected exception escaping the helper — skip rather than block.
-        print(f"SKIP: test DB parity check raised unexpectedly ({e})")
-        return 0
+        # Unexpected exception from the helper itself = bug in migration_check,
+        # not a legitimate skip. Fail loudly (exit 2) — Glokta S62 review:
+        # swallowing this reintroduces the silent-CI pattern #867 exists to
+        # prevent. The developer sees the real error and fixes the helper.
+        print(f"FATAL: check_migration_parity raised unexpectedly ({e})", file=sys.stderr)
+        print(
+            "       This is a bug in migration_check.py, not a skippable condition.",
+            file=sys.stderr,
+        )
+        return 2
 
     if status.error:
-        # Typical cause: test DB unreachable, credentials unset, alembic dir
-        # missing. Warn-and-skip so contributors without a test DB can push.
+        if status.fatal:
+            # Multi-head alembic chain, etc. — block, do not skip.
+            print(f"ERROR: {status.error}")
+            return 1
+        # Skippable: test DB unreachable, credentials unset, alembic dir missing.
+        # Do not block contributors without a test DB.
         print(f"SKIP: test DB parity check not conclusive ({status.error})")
         return 0
 

--- a/scripts/check_test_db_migration_parity.py
+++ b/scripts/check_test_db_migration_parity.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""Pre-push hook: verify test DB is at alembic head.
+
+S61 root-caused a class of silent-CI failures where the local test DB was
+several migrations behind the head (0056 vs 0063), silently masking three
+real test bugs for multiple sessions. This is a sibling of umbrella #764:
+test-infrastructure state drifting from production reality lets bugs pile
+up unseen. Mechanical enforcement at pre-push is the fix class.
+
+Behavior:
+- Forces PRECOG_ENV=test so the precog DB helpers connect to the test DB.
+- Reads current alembic_version and compares to the alembic head.
+- Exits 0 if in parity, or if the test DB is unreachable / unconfigured
+  (graceful SKIP so developers without a test DB are not blocked).
+- Exits 1 with an actionable error message if behind.
+
+Mirrors the UserPromptSubmit dev-DB hook (scripts/check_migration_parity_hook.py)
+but (a) targets the test DB and (b) blocks instead of warning.
+
+Issue: #867
+Related: #792 (dev-DB UserPromptSubmit hook precedent)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    """Run the parity check. Returns exit code (0 OK/skip, 1 block)."""
+    # Force test DB — this hook only ever checks the test DB. The dev DB is
+    # covered by the UserPromptSubmit warning hook from #792.
+    os.environ["PRECOG_ENV"] = "test"
+
+    try:
+        from precog.database.migration_check import check_migration_parity
+    except Exception as e:
+        # Import failure = developer environment not set up. Skip (do not block).
+        print(f"SKIP: could not import migration_check ({e}); test DB parity not verified")
+        return 0
+
+    try:
+        status = check_migration_parity()
+    except Exception as e:
+        # Any unexpected exception escaping the helper — skip rather than block.
+        print(f"SKIP: test DB parity check raised unexpectedly ({e})")
+        return 0
+
+    if status.error:
+        # Typical cause: test DB unreachable, credentials unset, alembic dir
+        # missing. Warn-and-skip so contributors without a test DB can push.
+        print(f"SKIP: test DB parity check not conclusive ({status.error})")
+        return 0
+
+    if status.is_current:
+        print(f"OK: test DB at migration {status.db_version} (matches head)")
+        return 0
+
+    # Behind — block the push with an actionable message.
+    db_ver = status.db_version or "<empty>"
+    head_ver = status.head_version or "<unknown>"
+    behind = status.versions_behind
+    gap = f" ({behind} behind)" if behind else ""
+
+    print("")
+    print("ERROR: Test DB is behind alembic head.")
+    print(f"  Test DB version: {db_ver}")
+    print(f"  Alembic head:    {head_ver}{gap}")
+    print("")
+    print("A stale test DB can silently mask real test failures (S61 root cause).")
+    print("Upgrade the test DB before pushing:")
+    print("")
+    print("  PRECOG_ENV=test python -m alembic -c src/precog/database/alembic.ini upgrade head")
+    print("")
+    print("Reference: #867 (test DB migration parity hook), #792 (dev DB sibling)")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/pre-push-validation.sh
+++ b/scripts/pre-push-validation.sh
@@ -95,6 +95,23 @@ echo ""
 export PRECOG_ENV=test
 
 # ==============================================================================
+# STEP 0.2: Test DB Migration Parity Check (#867)
+# ==============================================================================
+# A stale test DB can silently mask real test failures — S61 root cause,
+# 8 files over months. Block the push if the test DB is behind alembic head.
+# Graceful skip if the test DB is unreachable (contributors without a test DB
+# are not blocked). Exit 2 = bug in migration_check itself (fail loudly so
+# the developer sees the real error and fixes it).
+python scripts/check_test_db_migration_parity.py
+PARITY_EXIT=$?
+if [[ $PARITY_EXIT -ne 0 ]]; then
+    echo ""
+    echo "Pre-push aborted by #867 test DB parity check (exit $PARITY_EXIT)."
+    echo "Bypass (at your own risk): git push --no-verify"
+    exit $PARITY_EXIT
+fi
+
+# ==============================================================================
 # STEP 0.25: Clean Stale Bytecode (prevents ghost test discovery)
 # ==============================================================================
 find tests/ -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true

--- a/src/precog/database/migration_check.py
+++ b/src/precog/database/migration_check.py
@@ -24,6 +24,7 @@ class MigrationStatus:
     db_version: str | None
     head_version: str | None
     error: str | None = None
+    fatal: bool = False  # True: error is a block condition (e.g. multi-head); False: skippable (e.g. DB unreachable)
 
     @property
     def versions_behind(self) -> int | None:
@@ -84,6 +85,28 @@ def get_db_version() -> str | None:
         return None
 
 
+def get_alembic_heads() -> list[str]:
+    """Return all alembic heads. Linear chain = 1 entry; branched = 2+.
+
+    Used by check_migration_parity() to detect multi-head as a block condition
+    (fatal=True) rather than silently skipping. Glokta S62 review on #867:
+    a branched migration chain is a genuine schema-hygiene problem — silently
+    exiting 0 on it reintroduces the exact silent-skip failure #867 prevents.
+    """
+    from alembic.config import Config
+    from alembic.script import ScriptDirectory
+
+    db_dir = Path(__file__).parent
+    alembic_ini = db_dir / "alembic.ini"
+    if not alembic_ini.exists():
+        return []
+
+    cfg = Config(str(alembic_ini))
+    cfg.set_main_option("script_location", str(db_dir / "alembic"))
+    script = ScriptDirectory.from_config(cfg)
+    return list(script.get_heads())
+
+
 def check_migration_parity() -> MigrationStatus:
     """Check if the database schema matches the alembic head.
 
@@ -92,16 +115,37 @@ def check_migration_parity() -> MigrationStatus:
     - db_version: current DB migration version (or None)
     - head_version: latest migration in script directory (or None)
     - error: description if the check itself failed
+    - fatal: True when error indicates a block condition (multi-head);
+      False when error is a skippable condition (test DB unreachable)
     """
     try:
-        head = get_alembic_head()
+        heads = get_alembic_heads()
     except Exception as e:
         return MigrationStatus(
             is_current=False,
             db_version=None,
             head_version=None,
-            error=f"Could not read alembic head: {e}",
+            error=f"Could not read alembic heads: {e}",
         )
+
+    if len(heads) > 1:
+        return MigrationStatus(
+            is_current=False,
+            db_version=None,
+            head_version=None,
+            error=f"Multiple alembic heads detected: {sorted(heads)}. Run `alembic merge heads` before pushing.",
+            fatal=True,
+        )
+
+    if len(heads) == 0:
+        return MigrationStatus(
+            is_current=False,
+            db_version=None,
+            head_version=None,
+            error="No alembic head found — migration directory may be empty",
+        )
+
+    head = heads[0]
 
     try:
         db_ver = get_db_version()
@@ -111,14 +155,6 @@ def check_migration_parity() -> MigrationStatus:
             db_version=None,
             head_version=head,
             error=f"Could not read database version: {e}",
-        )
-
-    if head is None:
-        return MigrationStatus(
-            is_current=False,
-            db_version=db_ver,
-            head_version=None,
-            error="No alembic head found — migration directory may be empty",
         )
 
     return MigrationStatus(

--- a/tests/unit/database/test_migration_check.py
+++ b/tests/unit/database/test_migration_check.py
@@ -38,9 +38,9 @@ class TestCheckMigrationParity:
     """Test check_migration_parity() integration."""
 
     @patch("precog.database.migration_check.get_db_version")
-    @patch("precog.database.migration_check.get_alembic_head")
+    @patch("precog.database.migration_check.get_alembic_heads")
     def test_current_when_versions_match(self, mock_head, mock_db):
-        mock_head.return_value = "0057"
+        mock_head.return_value = ["0057"]
         mock_db.return_value = "0057"
 
         result = check_migration_parity()
@@ -51,9 +51,9 @@ class TestCheckMigrationParity:
         assert result.error is None
 
     @patch("precog.database.migration_check.get_db_version")
-    @patch("precog.database.migration_check.get_alembic_head")
+    @patch("precog.database.migration_check.get_alembic_heads")
     def test_behind_when_db_older(self, mock_head, mock_db):
-        mock_head.return_value = "0057"
+        mock_head.return_value = ["0057"]
         mock_db.return_value = "0055"
 
         result = check_migration_parity()
@@ -64,9 +64,9 @@ class TestCheckMigrationParity:
         assert result.versions_behind == 2
 
     @patch("precog.database.migration_check.get_db_version")
-    @patch("precog.database.migration_check.get_alembic_head")
+    @patch("precog.database.migration_check.get_alembic_heads")
     def test_behind_when_db_empty(self, mock_head, mock_db):
-        mock_head.return_value = "0057"
+        mock_head.return_value = ["0057"]
         mock_db.return_value = None
 
         result = check_migration_parity()
@@ -75,7 +75,7 @@ class TestCheckMigrationParity:
         assert result.db_version is None
 
     @patch("precog.database.migration_check.get_db_version")
-    @patch("precog.database.migration_check.get_alembic_head")
+    @patch("precog.database.migration_check.get_alembic_heads")
     def test_error_on_head_failure(self, mock_head, mock_db):
         mock_head.side_effect = RuntimeError("Script dir broken")
 
@@ -85,9 +85,9 @@ class TestCheckMigrationParity:
         assert "Script dir broken" in result.error
 
     @patch("precog.database.migration_check.get_db_version")
-    @patch("precog.database.migration_check.get_alembic_head")
+    @patch("precog.database.migration_check.get_alembic_heads")
     def test_error_on_db_failure(self, mock_head, mock_db):
-        mock_head.return_value = "0057"
+        mock_head.return_value = ["0057"]
         mock_db.side_effect = RuntimeError("DB unreachable")
 
         result = check_migration_parity()
@@ -96,9 +96,9 @@ class TestCheckMigrationParity:
         assert "DB unreachable" in result.error
 
     @patch("precog.database.migration_check.get_db_version")
-    @patch("precog.database.migration_check.get_alembic_head")
+    @patch("precog.database.migration_check.get_alembic_heads")
     def test_error_when_no_head(self, mock_head, mock_db):
-        mock_head.return_value = None
+        mock_head.return_value = []
         mock_db.return_value = "0057"
 
         result = check_migration_parity()

--- a/tests/unit/scripts/test_check_test_db_migration_parity.py
+++ b/tests/unit/scripts/test_check_test_db_migration_parity.py
@@ -100,16 +100,41 @@ class TestMainExitCodes:
         assert "connection refused" in out
 
     @patch("precog.database.migration_check.check_migration_parity")
-    def test_unexpected_exception_is_swallowed_as_skip(self, mock_check, capsys):
-        """Defense-in-depth: if check_migration_parity itself raises, skip."""
+    def test_unexpected_exception_exits_two_loudly(self, mock_check, capsys):
+        """An unexpected exception in check_migration_parity is a bug in the
+        helper, not a skippable condition. Exit 2 = loud failure so the
+        developer sees the real error. Glokta S62 review: swallowing this
+        reintroduces the silent-CI pattern #867 exists to prevent.
+        """
         mock_check.side_effect = RuntimeError("unexpected failure")
 
         rc = hook_mod.main()
 
-        assert rc == 0
+        assert rc == 2
+        err = capsys.readouterr().err  # FATAL messages go to stderr
+        assert "FATAL" in err
+        assert "unexpected failure" in err
+
+    @patch("precog.database.migration_check.check_migration_parity")
+    def test_multi_head_alembic_chain_blocks_not_skips(self, mock_check, capsys):
+        """Multi-head alembic chain is a schema-hygiene problem, not a skip.
+        Glokta S62: silent skip reintroduces #867's target failure mode.
+        """
+        mock_check.return_value = MigrationStatus(
+            is_current=False,
+            db_version=None,
+            head_version=None,
+            error="Multiple alembic heads detected: ['0063', '0064_sibling']. Run `alembic merge heads` before pushing.",
+            fatal=True,
+        )
+
+        rc = hook_mod.main()
+
+        assert rc == 1  # Block, not skip
         out = capsys.readouterr().out
-        assert "SKIP" in out
-        assert "unexpected failure" in out
+        assert "ERROR" in out
+        assert "Multiple alembic heads" in out
+        assert "alembic merge heads" in out
 
     @patch("precog.database.migration_check.check_migration_parity")
     def test_forces_precog_env_to_test(self, mock_check, monkeypatch):
@@ -155,6 +180,33 @@ class TestScriptInvocation:
         )
         # Must print something actionable on stdout
         assert result.stdout.strip(), "Script should always print a status line"
+
+
+class TestPrePushValidationWiring:
+    """Verify the hook is actually invoked by the real push path.
+
+    Glokta S62: without this test, the hook could be dead code — registered
+    in .pre-commit-config.yaml but never fired because scripts/pre-push-
+    validation.sh (the live push entry point) doesn't call the pre-commit
+    framework. This test is the anti-regression guard on the wiring itself.
+    """
+
+    def test_pre_push_validation_invokes_parity_check(self):
+        """scripts/pre-push-validation.sh must invoke the parity script."""
+        repo_root = Path(__file__).parent.parent.parent.parent
+        validation_script = repo_root / "scripts" / "pre-push-validation.sh"
+        assert validation_script.exists(), (
+            "pre-push-validation.sh is the live push entry point; missing means "
+            "the entire pre-push validation layer is gone."
+        )
+        content = validation_script.read_text(encoding="utf-8")
+        assert "check_test_db_migration_parity.py" in content, (
+            "pre-push-validation.sh does not invoke the #867 parity check. "
+            "Without this wiring, the hook is dead code and #867's silent-CI "
+            "failure class is reintroduced. Add a call to "
+            "`python scripts/check_test_db_migration_parity.py` near the top "
+            "of the script (see STEP 0.2)."
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/scripts/test_check_test_db_migration_parity.py
+++ b/tests/unit/scripts/test_check_test_db_migration_parity.py
@@ -1,0 +1,161 @@
+"""Unit tests for scripts/check_test_db_migration_parity.py (#867).
+
+The hook itself is a thin adapter over precog.database.migration_check.
+These tests verify the adapter's exit-code + stdout contract at each
+branch: parity match, drift (behind), and graceful skip when the test
+DB is unreachable or the module is unavailable.
+
+Boundary choice:
+- We mock check_migration_parity() at its module-level binding inside
+  precog.database.migration_check. This mirrors tests/unit/database/
+  test_migration_check.py (the canonical project pattern) and keeps the
+  test independent of any actual DB connection. The hook's only
+  external collaborator is check_migration_parity(); mocking it lets
+  us drive every exit-code branch deterministically.
+
+Reference:
+- scripts/check_test_db_migration_parity.py
+- precog.database.migration_check.MigrationStatus
+- Issue #867 (this hook), Issue #792 (dev-DB sibling)
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from precog.database.migration_check import MigrationStatus
+
+# Add scripts/ to path so we can import the hook module.
+_SCRIPTS_DIR = Path(__file__).parent.parent.parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import check_test_db_migration_parity as hook_mod  # type: ignore[import-not-found]  # noqa: E402
+
+
+class TestMainExitCodes:
+    """Exit-code contract: 0 for OK/skip, 1 for drift."""
+
+    @patch("precog.database.migration_check.check_migration_parity")
+    def test_match_returns_zero(self, mock_check, capsys):
+        mock_check.return_value = MigrationStatus(
+            is_current=True,
+            db_version="0063",
+            head_version="0063",
+        )
+
+        rc = hook_mod.main()
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "OK" in out
+        assert "0063" in out
+
+    @patch("precog.database.migration_check.check_migration_parity")
+    def test_behind_returns_one_with_actionable_message(self, mock_check, capsys):
+        mock_check.return_value = MigrationStatus(
+            is_current=False,
+            db_version="0056",
+            head_version="0063",
+        )
+
+        rc = hook_mod.main()
+
+        assert rc == 1
+        out = capsys.readouterr().out
+        # Must flag the drift clearly
+        assert "ERROR" in out
+        assert "behind" in out.lower()
+        # Must mention both versions and the gap (7 behind)
+        assert "0056" in out
+        assert "0063" in out
+        assert "7" in out  # versions_behind
+        # Must include the exact remediation command
+        assert "alembic" in out
+        assert "upgrade head" in out
+        assert "PRECOG_ENV=test" in out
+        # Must cross-reference the issue for traceability
+        assert "#867" in out
+
+    @patch("precog.database.migration_check.check_migration_parity")
+    def test_unreachable_db_skips_with_warning(self, mock_check, capsys):
+        mock_check.return_value = MigrationStatus(
+            is_current=False,
+            db_version=None,
+            head_version="0063",
+            error="Could not read database version: connection refused",
+        )
+
+        rc = hook_mod.main()
+
+        assert rc == 0  # Graceful skip — do not block developer without test DB
+        out = capsys.readouterr().out
+        assert "SKIP" in out
+        # Surface the underlying reason so the developer knows why
+        assert "connection refused" in out
+
+    @patch("precog.database.migration_check.check_migration_parity")
+    def test_unexpected_exception_is_swallowed_as_skip(self, mock_check, capsys):
+        """Defense-in-depth: if check_migration_parity itself raises, skip."""
+        mock_check.side_effect = RuntimeError("unexpected failure")
+
+        rc = hook_mod.main()
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "SKIP" in out
+        assert "unexpected failure" in out
+
+    @patch("precog.database.migration_check.check_migration_parity")
+    def test_forces_precog_env_to_test(self, mock_check, monkeypatch):
+        """The hook must always check the test DB, never whatever env happens to be set."""
+        monkeypatch.setenv("PRECOG_ENV", "dev")
+        mock_check.return_value = MigrationStatus(
+            is_current=True, db_version="0063", head_version="0063"
+        )
+
+        hook_mod.main()
+
+        import os
+
+        assert os.environ["PRECOG_ENV"] == "test"
+
+
+class TestScriptInvocation:
+    """End-to-end: run the script as a subprocess and verify exit code."""
+
+    def test_script_is_executable_as_module(self, tmp_path, monkeypatch):
+        """Smoke test: the script can be invoked and returns an integer exit code.
+
+        We don't assert the specific exit code here because it depends on the
+        developer's local test DB state. We only verify the script runs to
+        completion without crashing (the branches' behavior is covered above).
+        """
+        repo_root = Path(__file__).parent.parent.parent.parent
+        script = repo_root / "scripts" / "check_test_db_migration_parity.py"
+        assert script.exists()
+
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            cwd=str(repo_root),
+        )
+
+        # Must exit with 0 or 1 — never crash (2+) or hang.
+        assert result.returncode in (0, 1), (
+            f"Script crashed: rc={result.returncode}\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )
+        # Must print something actionable on stdout
+        assert result.stdout.strip(), "Script should always print a status line"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds a pre-push hook that verifies the test database's `alembic_version` matches `alembic heads`, blocking the push if the test DB is behind.

Closes #867.

## Background

S61 root-caused a class of silent-CI failures: my test DB was 7 migrations behind head (0056 vs 0063), silently masking 3 real test bugs:
- Race test timing-sensitive (positions outside-fetch)
- ``RestrictViolation`` vs ``ForeignKeyViolation`` sibling-class assertion
- Unit-test DB-state dependency (market_id resolution)

This is a sibling of umbrella #764 (hand-written mocks producing fictional green CI). Same dynamic: test-infrastructure state drifting from production reality lets bugs pile up unseen. Mechanical enforcement at pre-push is the fix class.

## Design decisions

1. **Blocks on drift (exit 1)** vs #792's warn-only (exit 0). S61 proved the block is needed; warning wasn't enough.
2. **pre-push stage** (not pre-commit) — expensive DB query, wrong tier for edit-loop.
3. **Graceful SKIP** when test DB unreachable or env unset — doesn't block developers without a test DB.
4. **Shared helper** — introduces `src/precog/database/migration_check.py` so the #792 dev-DB hook and this test-DB hook call the same function. Single source of truth.

## Test plan

- [x] 6 unit tests covering match / behind / unreachable / unexpected-exception / PRECOG_ENV enforcement / subprocess smoke
- [x] `ruff format` + `ruff check` clean
- [x] Full pre-commit suite green (22 hooks passed or skipped)
- [x] Local smoke test: test DB at 0063 (matches head) → exit 0
- [x] Full pre-push suite: 4876 tests passed in 356s
- [ ] Post-merge: verify hook fires on a deliberately-drifted test DB in a follow-up session

## Notes

Samwise flagged 2 discretionary follow-ups:
- `get_db_version` / `get_alembic_head` in the shared helper have no direct unit-test coverage
- The #792 sibling has zero unit tests — back-fill opportunity

Both are out-of-scope for this PR.

## Review pipeline (S62 retroactive)

PM initially pushed this PR without in-pipeline Reviewer + Sentinel (Burst 1 protocol gap). Retroactively dispatched this session:
- Glokta — adversarial diff-scoped review (running)
- Ripley — highest-risk-first pre-merge QA (running)

Findings will be dispositioned before auto-merge. See session 62 protocol-change discussion for the Pipeline Completeness Gate that prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)