### PR TITLE
refactor: S61/S62 P2 cleanups — crud_positions docstrings + comments + test docstrings

### DIFF
--- a/src/precog/database/crud_positions.py
+++ b/src/precog/database/crud_positions.py
@@ -436,27 +436,17 @@ def update_position_price(
         ...     trailing_stop_state={"peak": "0.5800", "stop": "0.5500"}
         ... )
         >>> # Returns new surrogate id (e.g., 2)
+
+    Historical-id contract (S61 race-resilient refactor):
+        If ``position_id`` refers to a superseded row (row_current_ind=FALSE),
+        transparently operates on the current row for the same business key.
+        An ``id_repaired`` log line fires. Returned id may differ from the one
+        passed (it's the current row's id). Raises ValueError only if the id
+        has NEVER existed.
     """
-    # Race-resilient two-step outside fetch.
-    #
-    # Step 1: Find business key from (possibly now-historical) id. If the id
-    # has NEVER existed, raise — preserves the "raise on missing" contract.
-    # If the id exists but is historical (a sibling caller superseded it in
-    # our race window), this still finds the position_key for the Step 2
-    # business-key lookup.
-    #
-    # Step 2: Fetch current row by business key (race-resilient). A sibling
-    # supersede between our caller acquiring ``position_id`` and this fetch
-    # is handled transparently — we pick up the sibling's new current row
-    # and enter the retry closure keyed by that same business key.
-    #
-    # Why two steps (not the old one-query outside fetch): the previous
-    # ``SELECT * ... WHERE id = %s AND row_current_ind = TRUE`` raised
-    # ``ValueError("Position not found")`` whenever a sibling thread
-    # superseded the row in the race window, never reaching the retry
-    # closure that the FOR UPDATE + business-key lookup was designed to
-    # handle. See the race test
-    # ``test_concurrent_price_update_resolved_by_retry``.
+    # Two-step race-resilient outside fetch: Step 1 finds business key from any
+    # version (historical or current); Step 2 fetches current row by business key.
+    # Solves the sibling-supersede race — see test_concurrent_price_update_resolved_by_retry.
     row_for_bk = fetch_one("SELECT position_key FROM positions WHERE id = %s", (position_id,))
     if not row_for_bk:
         msg = f"Position not found: {position_id}"
@@ -471,7 +461,7 @@ def update_position_price(
         msg = (
             f"Position not found: {position_id} "
             f"(id known but no current row for business key {position_bk!r} — "
-            f"a concurrent close may have left this position with no current version)"
+            f"schema invariant violation: every business key should have exactly one current row)"
         )
         raise ValueError(msg)
 
@@ -736,21 +726,17 @@ def close_position(
         ...     exit_reason='target_hit',
         ...     realized_pnl=Decimal("8.00")
         ... )
+
+    Historical-id contract (S61 race-resilient refactor):
+        If ``position_id`` refers to a superseded row (row_current_ind=FALSE),
+        transparently operates on the current row for the same business key.
+        Returned id may differ from the one passed. Raises ValueError only if
+        the id has NEVER existed. The closure's ``status != "open"`` guard
+        still protects against double-close races (see #627).
     """
-    # Race-resilient two-step outside fetch.
-    #
-    # Step 1: Find business key from (possibly now-historical) id. If the id
-    # has NEVER existed, raise — preserves the "raise on missing" contract.
-    # If the id exists but is historical (a sibling caller superseded it in
-    # our race window), this still finds the position_key for the Step 2
-    # business-key lookup.
-    #
-    # Step 2: Fetch current row by business key (race-resilient). A sibling
-    # supersede between our caller acquiring ``position_id`` and this fetch
-    # is handled transparently — we pick up the sibling's new current row
-    # and enter the retry closure keyed by that same business key. The
-    # closure's own ``status != "open"`` guard still protects against
-    # double-close races (see #627 rationale below).
+    # Two-step race-resilient outside fetch: Step 1 finds business key from any
+    # version; Step 2 fetches current row by business key. Solves the sibling-
+    # supersede race — see #627 double-close rationale in the closure below.
     row_for_bk = fetch_one("SELECT position_key FROM positions WHERE id = %s", (position_id,))
     if not row_for_bk:
         msg = f"Position not found: {position_id}"
@@ -765,7 +751,7 @@ def close_position(
         msg = (
             f"Position not found: {position_id} "
             f"(id known but no current row for business key {position_bk!r} — "
-            f"a concurrent close may have left this position with no current version)"
+            f"schema invariant violation: every business key should have exactly one current row)"
         )
         raise ValueError(msg)
 
@@ -1072,19 +1058,16 @@ def set_trailing_stop_state(
         - PR #665: canonical Pattern 49 adoption for positions
           (``update_position_price`` and ``close_position``).
         - Pattern 49 (DEVELOPMENT_PATTERNS_V1.30.md): SCD Race Prevention.
+
+    Historical-id contract (S61 race-resilient refactor):
+        If ``position_id`` refers to a superseded row (row_current_ind=FALSE),
+        transparently operates on the current row for the same business key.
+        Returned id may differ from the one passed. Raises ValueError only if
+        the id has NEVER existed.
     """
-    # Race-resilient two-step outside fetch.
-    #
-    # Step 1: Find business key from (possibly now-historical) id. If the id
-    # has NEVER existed, raise — preserves the "raise on missing" contract.
-    # If the id exists but is historical (a sibling caller superseded it in
-    # our race window), this still finds the position_key for the Step 2
-    # business-key lookup.
-    #
-    # Step 2: Fetch current row by business key (race-resilient). A sibling
-    # supersede between our caller acquiring ``position_id`` and this fetch
-    # is handled transparently — we pick up the sibling's new current row
-    # and enter the retry closure keyed by that same business key.
+    # Two-step race-resilient outside fetch: Step 1 finds business key from any
+    # version; Step 2 fetches current row by business key. Solves the sibling-
+    # supersede race on the trailing-stop write paths — see #629.
     row_for_bk = fetch_one("SELECT position_key FROM positions WHERE id = %s", (position_id,))
     if not row_for_bk:
         msg = f"Position not found: {position_id}"
@@ -1099,7 +1082,7 @@ def set_trailing_stop_state(
         msg = (
             f"Position not found: {position_id} "
             f"(id known but no current row for business key {position_bk!r} — "
-            f"a concurrent close may have left this position with no current version)"
+            f"schema invariant violation: every business key should have exactly one current row)"
         )
         raise ValueError(msg)
 

--- a/tests/integration/database/test_scd_copy_forward.py
+++ b/tests/integration/database/test_scd_copy_forward.py
@@ -305,45 +305,14 @@ class TestPositionsEdgeIdCopyForward:
 
 @pytest.mark.integration
 class TestPositionsHistoricalIdRepair:
-    """Historical-id repair contract (Glokta P1-2, #863 adversarial review).
-
-    After the two-step outside fetch landed in ``update_position_price``,
-    ``close_position``, and ``set_trailing_stop_state`` (crud_positions.py
-    business-key resolution pattern), a caller that passes a NOW-HISTORICAL
-    ``position_id`` — one whose business key still has a current row because
-    a sibling caller superseded it — must operate on the current row rather
-    than raise ``Position not found``.
-
-    Each test exercises this repair path end-to-end against a real DB:
-
-        1. Seed an open position chain.
-        2. Supersede it once via the CRUD under test to allocate a new
-           current version; the original surrogate is now historical.
-        3. Call the CRUD under test AGAIN with the historical id and
-           different parameters.
-        4. Assert the call succeeds (except for ``close_position`` where
-           the retry closure's ``status != 'open'`` guard fires correctly
-           on the already-closed sibling row — that's the audit trail
-           Glokta specifically requested).
-        5. Assert SCD invariants: exactly one ``row_current_ind = TRUE``
-           row at the end; the returned id is distinct from both the
-           historical caller-supplied id AND the intermediate sibling id
-           (i.e. a third SCD version was created).
-
-    These tests are the direct regression guard for PR #863 Glokta's
-    P1-1 (observability) and P1-2 (test coverage) findings.
-    """
+    """Historical-id repair contract regression guard (PR #863 Glokta P1-1/P1-2)."""
 
     def test_update_position_price_repairs_historical_id(
         self,
         position_with_edge: tuple[int, str, int, int],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Historical id whose business key has a current row must repair.
-
-        Also asserts the ``id_repaired`` info log line fires — Glokta P1-1
-        observability requirement.
-        """
+        """Historical id repair path; also asserts id_repaired log line fires (Glokta P1-1)."""
         historical_surrogate_id, position_bk, _market_pk, _edge_pk = position_with_edge
 
         # Step 2: supersede once to allocate a new current version.
@@ -394,16 +363,7 @@ class TestPositionsHistoricalIdRepair:
         self,
         position_with_edge: tuple[int, str, int, int],
     ) -> None:
-        """Historical id passed to close_position must repair to current row.
-
-        The test first supersedes via ``close_position`` (transitioning status
-        to 'closed'), then re-invokes ``close_position`` with the historical
-        id. The retry closure's ``status != 'open'`` guard fires correctly on
-        the repaired id — this is exactly the audit-trail behavior Glokta
-        requested: the guard fires on the CURRENT row (the sibling's closed
-        version), surfacing the stale-state collision loudly rather than
-        silently inserting a new current version over a closed position.
-        """
+        """Historical id repair → status-guard fires on already-closed sibling (Glokta P1-1 audit-trail)."""
         historical_surrogate_id, _position_bk, _market_pk, _edge_pk = position_with_edge
 
         # Step 2: first close succeeds and transitions status to 'closed'.


### PR DESCRIPTION
## Summary

Bundles two related P2 cleanup items from S61 + S62 review cycles. Closes #866 + completes the #868 S68 fix-now follow-up.

Net change: **+35/-92** (docstring expansion for historical-id contract offset by comment + test-docstring condensation).

## Changes

### crud_positions.py

**Docstring additions** (closes #866 P2-1) — added "Historical-id contract" block to 3 CRUD docstrings (``update_position_price``, ``close_position``, ``set_trailing_stop_state``). Documents the S61 race-resilient refactor's behavior widening: callers passing historical ids transparently operate on current rows; returned id may differ from input; ValueError only when id has NEVER existed.

**Error message reword** (closes #866 P2-2) — replaced "a concurrent close may have left this position with no current version" (which misrepresents the invariant — ``close_position`` preserves row_current_ind atomicity) with "schema invariant violation: every business key should have exactly one current row". Applied to all 3 instances via ``replace_all``.

**Block comment condensation** (#868 S68 fix-now) — the "Race-resilient two-step outside fetch" block comments in each of the 3 functions were 10-20 lines each, violating CLAUDE.md's one-short-line rule for non-obvious WHY. Condensed each to 2-3 lines preserving the race rationale + regression-test pointer + issue references (#627, #629).

### tests/integration/database/test_scd_copy_forward.py

**Test docstring condensation** (#868 S68 fix-now) — ``TestPositionsHistoricalIdRepair`` class docstring (28 lines) and 2 per-method docstrings (4-10 lines each) were multi-paragraph, violating CLAUDE.md one-liner rule. Condensed to single-line docstrings referencing the Glokta P1-1/P1-2 findings they guard against. Test names + ``pytest.raises`` patterns already communicate contracts.

## Scope boundary (deferred)

- **#873** (observability gap — ``close_position`` + ``set_trailing_stop_state`` missing ``id_repaired`` log) — remains a separate P2 follow-up
- **#874** (missing happy-path test for ``close_position`` with historical id + open row) — remains a separate P2 follow-up
- ``_jsonb_dumps`` docstring at crud_positions.py:30 — multi-line justified by Decimal encoder + #629/#706 historical context; kept as-is

## Test plan

- [x] ruff format + ruff check clean
- [x] Pre-commit hooks all pass (22 hooks)
- [x] Pre-push validation all tiers green (unit 2621/integration 1212/stress-chaos-race 1045)
- [x] No behavior changes — docstring + comment + string-literal edits only

🤖 Generated with [Claude Code](https://claude.com/claude-code)