### PR TITLE
refactor: #887 Slice 1 — test type coverage audit from CI to pre-push + register 3 modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -469,42 +469,15 @@ jobs:
   # NOTE: validate-quick removed — it was a strict subset of pre-commit-checks
   # (ruff lint + ruff format + mypy, all covered by pre-commit run --all-files)
 
-  test-type-coverage:
-    name: Test Type Coverage Audit (TESTING_STRATEGY V3.2)
-    runs-on: ubuntu-latest
-    needs: detect-changes
-    # Run if code or tests changed
-    if: needs.detect-changes.outputs.code == 'true' || github.event_name == 'workflow_dispatch'
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.14'
-          allow-prereleases: true
-
-      - name: Run test type coverage audit (STRICT - all 8 test types required)
-        run: python scripts/audit_test_type_coverage.py --strict
-        continue-on-error: true  # Tech debt: 10/11 modules missing test types (Issue #155 - 57h effort)
-        # V2.0 ENFORCEMENT: All 8 test types MANDATORY per TEST_REQUIREMENTS_COMPREHENSIVE V2.0
-
-      - name: Generate JSON report for artifacts
-        if: always()  # Generate report even if strict check fails
-        run: python scripts/audit_test_type_coverage.py --json > test_type_coverage.json
-
-      - name: Upload coverage report
-        if: always()  # Upload report even if strict check fails
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-type-coverage-report
-          path: test_type_coverage.json
+  # Test Type Coverage Audit job removed in session 63 (#887) — moved to
+  # scripts/pre-push-validation.sh as a fast-fail structural gate. The CI job
+  # had run with continue-on-error: true for months, muting the signal into
+  # invisibility; pre-push enforcement restores author-time feedback.
 
   ci-summary:
     name: CI Summary
     runs-on: ubuntu-latest
-    needs: [pre-commit-checks, security-scan, documentation-validation, test, integration-tests, test-type-coverage]
+    needs: [pre-commit-checks, security-scan, documentation-validation, test, integration-tests]
     if: always()
     steps:
       - name: Check all jobs status
@@ -518,11 +491,10 @@ jobs:
           echo "Unit Tests:               ${{ needs.test.result }}"
           echo "Integration Tests:        ${{ needs.integration-tests.result }}"
           echo "Stress & Chaos Tests:     pre-push only (threading hangs on CI runners)"
-          echo "Test Type Coverage:       ${{ needs.test-type-coverage.result }}"
+          echo "Test Type Coverage:       pre-push only (#887 migrated from CI)"
           echo "=========================================="
 
           # Check if any job that actually ran failed (skipped jobs are OK)
-          # test-type-coverage excluded: tech debt tracking, not a gate
           if [[ "${{ needs.pre-commit-checks.result }}" == "failure" ]] || \
              [[ "${{ needs.security-scan.result }}" == "failure" ]] || \
              [[ "${{ needs.documentation-validation.result }}" == "failure" ]] || \
@@ -540,7 +512,6 @@ jobs:
           [[ "${{ needs.security-scan.result }}" == "skipped" ]] && ((SKIPPED+=1))
           [[ "${{ needs.test.result }}" == "skipped" ]] && ((SKIPPED+=1))
           [[ "${{ needs.integration-tests.result }}" == "skipped" ]] && ((SKIPPED+=1))
-          [[ "${{ needs.test-type-coverage.result }}" == "skipped" ]] && ((SKIPPED+=1))
 
           echo ""
           if [[ $SKIPPED -gt 0 ]]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,7 +260,9 @@ gh pr create --title "..." --body "..."
 
 Branch protection on `main` (restored session 43, 2026-04-08): requires PR, must be up-to-date with main, and the **`CI Summary`** status check must pass before merge.
 
-`CI Summary` is the umbrella job in `.github/workflows/ci.yml` that aggregates all the underlying jobs (`pre-commit-checks`, `security-scan`, `documentation-validation`, `test`, `integration-tests`, `test-type-coverage`). It is the **only** required status check, by design — most of those underlying jobs are gated on `needs.detect-changes.outputs.code == 'true'` and skip on docs-only PRs. Requiring them individually would block every docs-only PR forever waiting for skipped checks. `CI Summary` runs unconditionally (`if: always()`) and correctly treats skipped jobs as success while still failing on any actual job failure.
+`CI Summary` is the umbrella job in `.github/workflows/ci.yml` that aggregates all the underlying jobs (`pre-commit-checks`, `security-scan`, `documentation-validation`, `test`, `integration-tests`). It is the **only** required status check, by design — most of those underlying jobs are gated on `needs.detect-changes.outputs.code == 'true'` and skip on docs-only PRs. Requiring them individually would block every docs-only PR forever waiting for skipped checks. `CI Summary` runs unconditionally (`if: always()`) and correctly treats skipped jobs as success while still failing on any actual job failure.
+
+**Test type coverage audit** (formerly a CI job with `continue-on-error`) was migrated to `scripts/pre-push-validation.sh` in session 63 (#887) as a fast-fail structural gate. The CI job had muted the signal into invisibility; pre-push enforcement blocks at the author's push instead of reporting a non-gating red X to reviewers.
 
 Admin override is enabled (`enforce_admins: false`) for emergency direct pushes. The Windows test job (`Tests (Python 3.14 on windows-latest, main only)`) is also deliberately not required because per #697 it only runs on main-branch pushes, not PR runs.
 

--- a/scripts/audit_test_type_coverage.py
+++ b/scripts/audit_test_type_coverage.py
@@ -63,9 +63,10 @@ TEST_TYPES = {
 }
 
 # Module tiers determine REQUIRED test types
-# Critical Path (90%+ coverage) needs ALL 8 types
-# Business Logic (85%+) needs 6 types (skip performance, chaos)
-# Infrastructure (80%+) needs 4 types (unit, integration, stress, race)
+# V3.2 policy (see TIER_REQUIREMENTS below): critical, business, AND infrastructure
+# all require ALL 8 test types. Experimental tier requires only unit.
+# (The earlier tier distinctions — business=6, infrastructure=4 — were retired
+# in TESTING_STRATEGY_V3.2 in favor of uniform strict coverage.)
 #
 # Issue #217: Added missing modules (2025-12-13)
 # - Fixed analytics/ -> trading/ path errors
@@ -203,6 +204,16 @@ MODULE_TIERS = {
     "cli/_future/position": "experimental",
     "cli/_future/strategy": "experimental",
     "cli/_future/trade": "experimental",
+    # Session 63 registrations (#887 Slice 1):
+    # - crud_lookups: #738 lookup-tables work (sessions 53-55)
+    # - crud_probability_models: #883 Migration 0064 SCD2 (session 63)
+    # - migration_check: #875 test-DB parity hook plumbing (session 63)
+    # All three tagged experimental per the line 214 policy definition
+    # ("new modules still in development"). Promote to infrastructure/business
+    # as their test suites expand — track in umbrella #887.
+    "database/crud_lookups": "experimental",
+    "database/crud_probability_models": "experimental",
+    "database/migration_check": "experimental",
 }
 
 # Required test types per tier

--- a/scripts/pre-push-validation.sh
+++ b/scripts/pre-push-validation.sh
@@ -234,6 +234,57 @@ if [[ -n "$FAST_PATH_NAME" ]]; then
 fi
 
 # ==============================================================================
+# STEP 0: Test Type Coverage Audit (#887, session 63)
+# ==============================================================================
+# Fast-fail structural gate — runs before test tiers so a tier-registration gap
+# or missing-test-types failure blocks the push immediately instead of waiting
+# on a 30-60s test run.
+#
+# Policy source: docs/foundation/TESTING_STRATEGY_V3.9.md
+# Script: scripts/audit_test_type_coverage.py --strict
+# History: moved from CI to pre-push in session 63 (#887) — CI's
+# continue-on-error: true had muted the signal into invisibility for months.
+# Umbrella #155 (ancestor) closed without the work landing; #887 tracks the
+# burn-down.
+#
+# Escape hatch (TRANSITION ONLY): SKIP_TEST_TYPE_AUDIT=1 bypasses this gate.
+# Use only when pushing gap-closing work itself (where the push-under-audit
+# would be blocked by pre-existing failures). The 11 known gaps + 3 registered-
+# but-incomplete modules (#887 Slice 1 state) are the transitional inventory;
+# once closed, the skip should never be needed. Do NOT add `SKIP_TEST_TYPE_AUDIT=1`
+# to any CI, alias, or config — it is a one-off escape hatch for interactive use.
+if [[ "${SKIP_TEST_TYPE_AUDIT:-0}" == "1" ]]; then
+    echo "  Test type coverage audit: SKIPPED (SKIP_TEST_TYPE_AUDIT=1 — tracked in #887)"
+    echo ""
+else
+    AUDIT_START=$(date +%s)
+    if ! python scripts/audit_test_type_coverage.py --strict; then
+        AUDIT_END=$(date +%s)
+        AUDIT_DURATION=$((AUDIT_END - AUDIT_START))
+        echo ""
+        echo "Test type coverage audit FAILED (${AUDIT_DURATION}s)"
+        echo ""
+        echo "Fix options:"
+        echo "  - Add missing test types for the listed modules"
+        echo "  - Register untracked modules in MODULE_TIERS in"
+        echo "    scripts/audit_test_type_coverage.py (copy the suggested block"
+        echo "    from the audit output above)"
+        echo "  - Adjust a module's tier if too strict for its maturity"
+        echo "    (experimental = unit only; business/infrastructure = all 8)"
+        echo ""
+        echo "Temporary bypass (transitional only, see #887):"
+        echo "  SKIP_TEST_TYPE_AUDIT=1 git push"
+        echo ""
+        echo "To audit manually:   python scripts/audit_test_type_coverage.py --strict"
+        echo "Tracked in:          GitHub issue #887"
+        exit 1
+    fi
+    AUDIT_END=$(date +%s)
+    echo "  Test type coverage audit: PASSED ($((AUDIT_END - AUDIT_START))s)"
+    echo ""
+fi
+
+# ==============================================================================
 # STEP 1+2+3: Run selected tiers IN PARALLEL
 # ==============================================================================
 # Each tier runs in a subshell that writes output to its own log file. After

--- a/tests/unit/database/test_crud_lookups.py
+++ b/tests/unit/database/test_crud_lookups.py
@@ -1,0 +1,486 @@
+"""Unit tests for ``crud_lookups`` sports/leagues FK lookup cache.
+
+``crud_lookups`` maintains a lazy, thread-safe in-process cache of the
+``sports`` and ``leagues`` lookup tables (migration 0060, #738 A1).  The
+cache is populated on first use via ``fetch_all`` and re-used for the
+process lifetime.
+
+These unit tests exercise the cache lifecycle, the strict vs. ``_or_none``
+public API, the degraded-cache path (``fetch_all`` raises), the
+``resolve_league_id_via_game`` helper (which additionally uses
+``fetch_one`` via a late import), and the mixed-value resolver.
+
+Pattern references:
+  * Pattern 22 — VCR OR live for external API tests (N/A here: no HTTP)
+  * Pattern 43 — Mock Fidelity (``fetch_all`` returns ``list[dict]`` with
+    the real column names: ``id``, ``sport_key``, ``league_key``,
+    ``sport_id``)
+  * Pattern 45 — ``*_or_none`` helpers short-circuit on ``None`` input
+    WITHOUT triggering cache population.
+
+Slice 2 pilot — first of 10 CRUD unit test burn-down files (#887).
+Issue: #887
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from precog.database import crud_lookups
+
+pytestmark = [pytest.mark.unit]
+
+
+# =============================================================================
+# Shared fixtures
+# =============================================================================
+
+# Keep the seed minimal — 3 sports, 4 leagues — so tests stay focused.
+# "soccer" appears in BOTH sports and leagues (mirrors the real migration 0060
+# seed) to exercise the sport-first precedence rule in
+# resolve_sport_id_for_mixed_value.
+_SPORT_ROWS = [
+    {"id": 1, "sport_key": "football"},
+    {"id": 2, "sport_key": "basketball"},
+    {"id": 3, "sport_key": "soccer"},
+]
+_LEAGUE_ROWS = [
+    {"id": 10, "league_key": "nfl", "sport_id": 1},
+    {"id": 11, "league_key": "ncaaf", "sport_id": 1},
+    {"id": 20, "league_key": "nba", "sport_id": 2},
+    {"id": 30, "league_key": "soccer", "sport_id": 3},
+]
+
+
+def _fetch_all_side_effect(sql: str, params: tuple | None = None) -> list[dict]:
+    """Return the correct seed rows based on which table the SQL targets."""
+    if "FROM sports" in sql:
+        return [dict(row) for row in _SPORT_ROWS]
+    if "FROM leagues" in sql:
+        return [dict(row) for row in _LEAGUE_ROWS]
+    raise AssertionError(f"Unexpected fetch_all SQL in test: {sql!r}")
+
+
+@pytest.fixture(autouse=True)
+def _invalidate_cache_between_tests():
+    """Reset module-level cache state before AND after every test.
+
+    Module globals (``_sport_key_to_id`` etc.) leak between tests otherwise.
+    We always go through the public ``invalidate_cache()`` API rather than
+    mutating the globals directly.
+    """
+    crud_lookups.invalidate_cache()
+    yield
+    crud_lookups.invalidate_cache()
+
+
+# =============================================================================
+# A. Cache lifecycle
+# =============================================================================
+
+
+class TestCacheLifecycle:
+    """Cache populates once, re-uses, can be invalidated, degrades gracefully."""
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_first_call_populates_cache_two_fetches(self, mock_fetch: MagicMock) -> None:
+        """First public-API call triggers exactly one fetch per lookup table."""
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        crud_lookups.get_sport_id("football")
+
+        # One SELECT against sports, one against leagues — total = 2.
+        assert mock_fetch.call_count == 2
+        sqls = [call.args[0] for call in mock_fetch.call_args_list]
+        assert any("FROM sports" in sql for sql in sqls)
+        assert any("FROM leagues" in sql for sql in sqls)
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_second_call_reuses_cache(self, mock_fetch: MagicMock) -> None:
+        """After first populate, subsequent calls do NOT touch fetch_all."""
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        crud_lookups.get_sport_id("football")
+        crud_lookups.get_sport_id("basketball")
+        crud_lookups.get_league_id("nfl")
+
+        # Still only the initial 2 fetches (one per table).
+        assert mock_fetch.call_count == 2
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_invalidate_cache_forces_repopulate(self, mock_fetch: MagicMock) -> None:
+        """invalidate_cache() causes the next lookup to re-fetch."""
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        crud_lookups.get_sport_id("football")
+        assert mock_fetch.call_count == 2
+
+        crud_lookups.invalidate_cache()
+        crud_lookups.get_sport_id("football")
+
+        # Re-fetched both tables again.
+        assert mock_fetch.call_count == 4
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_degraded_cache_on_fetch_all_exception(self, mock_fetch: MagicMock) -> None:
+        """If fetch_all raises, cache is populated with empty dicts.
+
+        Subsequent ``*_or_none`` calls must return None; strict calls must
+        raise KeyError whose message contains ``Valid keys: []``.
+        """
+        # Bare ``Exception`` is caught — use a synthetic to stay portable.
+        mock_fetch.side_effect = Exception("relation 'sports' does not exist")
+
+        # _or_none helpers degrade silently.
+        assert crud_lookups.get_sport_id_or_none("football") is None
+        assert crud_lookups.get_league_id_or_none("nfl") is None
+        assert crud_lookups.get_sport_id_from_league_or_none("nfl") is None
+
+        # Strict helpers raise KeyError with the empty-keys sentinel.
+        with pytest.raises(KeyError, match=r"Valid keys: \[\]"):
+            crud_lookups.get_sport_id("football")
+        with pytest.raises(KeyError, match=r"Valid keys: \[\]"):
+            crud_lookups.get_league_id("nfl")
+        with pytest.raises(KeyError, match=r"Valid keys: \[\]"):
+            crud_lookups.get_sport_id_from_league("nfl")
+
+
+# =============================================================================
+# B. get_sport_id / get_sport_id_or_none
+# =============================================================================
+
+
+class TestGetSportId:
+    """Strict + permissive sport_key → sports.id resolution."""
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_known_sport_key_returns_int(self, mock_fetch: MagicMock) -> None:
+        """Happy path: seeded sport_key resolves to its id."""
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        assert crud_lookups.get_sport_id("football") == 1
+        assert crud_lookups.get_sport_id("basketball") == 2
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_unknown_sport_key_raises_keyerror_with_valid_keys(self, mock_fetch: MagicMock) -> None:
+        """Unknown key raises KeyError whose message includes the sorted valid-key list."""
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        with pytest.raises(KeyError) as exc_info:
+            crud_lookups.get_sport_id("quidditch")
+
+        # KeyError wraps the message in another pair of quotes; use str().
+        msg = str(exc_info.value)
+        assert "quidditch" in msg
+        assert "Valid keys:" in msg
+        # Sorted list of the 2 seeded keys.
+        assert "'basketball'" in msg
+        assert "'football'" in msg
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_or_none_known_returns_int(self, mock_fetch: MagicMock) -> None:
+        mock_fetch.side_effect = _fetch_all_side_effect
+        assert crud_lookups.get_sport_id_or_none("football") == 1
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_or_none_unknown_returns_none(self, mock_fetch: MagicMock) -> None:
+        mock_fetch.side_effect = _fetch_all_side_effect
+        assert crud_lookups.get_sport_id_or_none("quidditch") is None
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_or_none_none_input_short_circuits(self, mock_fetch: MagicMock) -> None:
+        """None input returns None WITHOUT populating the cache (Pattern 45)."""
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        assert crud_lookups.get_sport_id_or_none(None) is None
+
+        # Cache was never touched.
+        assert mock_fetch.call_count == 0
+
+
+# =============================================================================
+# C. get_league_id / get_league_id_or_none
+# =============================================================================
+
+
+class TestGetLeagueId:
+    """Strict + permissive league_key → leagues.id resolution."""
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_known_league_key_returns_int(self, mock_fetch: MagicMock) -> None:
+        mock_fetch.side_effect = _fetch_all_side_effect
+        assert crud_lookups.get_league_id("nfl") == 10
+        assert crud_lookups.get_league_id("nba") == 20
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_unknown_league_key_raises_keyerror(self, mock_fetch: MagicMock) -> None:
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        with pytest.raises(KeyError) as exc_info:
+            crud_lookups.get_league_id("nhl")
+
+        msg = str(exc_info.value)
+        assert "nhl" in msg
+        assert "Valid keys:" in msg
+        assert "'nfl'" in msg
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_or_none_known_returns_int(self, mock_fetch: MagicMock) -> None:
+        mock_fetch.side_effect = _fetch_all_side_effect
+        assert crud_lookups.get_league_id_or_none("ncaaf") == 11
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_or_none_unknown_returns_none(self, mock_fetch: MagicMock) -> None:
+        mock_fetch.side_effect = _fetch_all_side_effect
+        assert crud_lookups.get_league_id_or_none("nhl") is None
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_or_none_none_input_short_circuits(self, mock_fetch: MagicMock) -> None:
+        mock_fetch.side_effect = _fetch_all_side_effect
+        assert crud_lookups.get_league_id_or_none(None) is None
+        assert mock_fetch.call_count == 0
+
+
+# =============================================================================
+# D. get_sport_id_from_league / _or_none
+# =============================================================================
+
+
+class TestGetSportIdFromLeague:
+    """league_key → parent sports.id resolution via the leagues.sport_id FK."""
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_known_league_resolves_parent_sport(self, mock_fetch: MagicMock) -> None:
+        """'nfl' → football (sport_id=1); 'nba' → basketball (sport_id=2)."""
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        assert crud_lookups.get_sport_id_from_league("nfl") == 1
+        assert crud_lookups.get_sport_id_from_league("ncaaf") == 1
+        assert crud_lookups.get_sport_id_from_league("nba") == 2
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_unknown_league_raises_keyerror(self, mock_fetch: MagicMock) -> None:
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        with pytest.raises(KeyError) as exc_info:
+            crud_lookups.get_sport_id_from_league("nhl")
+
+        # Parity with TestGetSportId / TestGetLeagueId: pin the helpful
+        # "Valid keys: [...]" context so a regression to bare KeyError("nhl")
+        # would fail loudly.
+        msg = str(exc_info.value)
+        assert "nhl" in msg
+        assert "Valid keys:" in msg
+        assert "'nfl'" in msg
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_or_none_known_returns_parent_sport(self, mock_fetch: MagicMock) -> None:
+        """Symmetric with TestGetSportId.B / TestGetLeagueId.C happy-path `_or_none`."""
+        mock_fetch.side_effect = _fetch_all_side_effect
+        assert crud_lookups.get_sport_id_from_league_or_none("nfl") == 1
+        assert crud_lookups.get_sport_id_from_league_or_none("nba") == 2
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_or_none_unknown_returns_none(self, mock_fetch: MagicMock) -> None:
+        mock_fetch.side_effect = _fetch_all_side_effect
+        assert crud_lookups.get_sport_id_from_league_or_none("nhl") is None
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_or_none_none_input_short_circuits(self, mock_fetch: MagicMock) -> None:
+        mock_fetch.side_effect = _fetch_all_side_effect
+        assert crud_lookups.get_sport_id_from_league_or_none(None) is None
+        assert mock_fetch.call_count == 0
+
+
+# =============================================================================
+# E. resolve_league_id_via_game
+# =============================================================================
+
+
+class TestResolveLeagueIdViaGame:
+    """game_id → games.league → leagues.id resolution path.
+
+    Note: ``resolve_league_id_via_game`` does ``from .connection import
+    fetch_one`` inside the function body.  We patch at the origin module
+    (``precog.database.connection.fetch_one``) so the late import picks up
+    the mock.
+    """
+
+    @patch("precog.database.connection.fetch_one")
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_none_game_id_returns_none_without_fetch_one(
+        self, mock_fetch_all: MagicMock, mock_fetch_one: MagicMock
+    ) -> None:
+        """None game_id short-circuits; fetch_one MUST NOT be called."""
+        mock_fetch_all.side_effect = _fetch_all_side_effect
+
+        assert crud_lookups.resolve_league_id_via_game(None) is None
+        assert mock_fetch_one.call_count == 0
+
+    @patch("precog.database.connection.fetch_one")
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_game_row_missing_returns_none(
+        self, mock_fetch_all: MagicMock, mock_fetch_one: MagicMock
+    ) -> None:
+        """fetch_one returns None (no games row) → resolver returns None."""
+        mock_fetch_all.side_effect = _fetch_all_side_effect
+        mock_fetch_one.return_value = None
+
+        assert crud_lookups.resolve_league_id_via_game(42) is None
+
+    @patch("precog.database.connection.fetch_one")
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_game_row_with_known_league_returns_league_id(
+        self, mock_fetch_all: MagicMock, mock_fetch_one: MagicMock
+    ) -> None:
+        """Valid game_id → games.league → leagues.id."""
+        mock_fetch_all.side_effect = _fetch_all_side_effect
+        mock_fetch_one.return_value = {"league": "nfl"}
+
+        assert crud_lookups.resolve_league_id_via_game(42) == 10
+        # Pin the SQL text + params binding — a regression that changed
+        # the WHERE clause or the game_id param would otherwise be masked
+        # by the mock's indifference to input.
+        mock_fetch_one.assert_called_once_with(
+            "SELECT league FROM games WHERE id = %s",
+            (42,),
+        )
+
+    @patch("precog.database.connection.fetch_one")
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_game_row_with_unknown_league_returns_none(
+        self, mock_fetch_all: MagicMock, mock_fetch_one: MagicMock
+    ) -> None:
+        """games.league value not in lookup cache → None (permissive _or_none path)."""
+        mock_fetch_all.side_effect = _fetch_all_side_effect
+        mock_fetch_one.return_value = {"league": "nhl"}
+
+        assert crud_lookups.resolve_league_id_via_game(42) is None
+
+    @patch("precog.database.connection.fetch_one")
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_fetch_one_exception_returns_none(
+        self, mock_fetch_all: MagicMock, mock_fetch_one: MagicMock
+    ) -> None:
+        """fetch_one raising is caught → resolver returns None gracefully."""
+        mock_fetch_all.side_effect = _fetch_all_side_effect
+        mock_fetch_one.side_effect = Exception("connection refused")
+
+        assert crud_lookups.resolve_league_id_via_game(42) is None
+
+
+# =============================================================================
+# F. resolve_sport_id_for_mixed_value
+# =============================================================================
+
+
+class TestResolveSportIdForMixedValue:
+    """game_odds.sport mixed-convention resolver: accepts sport OR league key."""
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_none_input_short_circuits(self, mock_fetch: MagicMock) -> None:
+        """None input returns None WITHOUT populating the cache."""
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        assert crud_lookups.resolve_sport_id_for_mixed_value(None) is None
+        assert mock_fetch.call_count == 0
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_sport_key_resolves_directly(self, mock_fetch: MagicMock) -> None:
+        """When value is a sport_key ('football'), use sports map directly."""
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        assert crud_lookups.resolve_sport_id_for_mixed_value("football") == 1
+        assert crud_lookups.resolve_sport_id_for_mixed_value("basketball") == 2
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_league_key_resolves_via_fallback(self, mock_fetch: MagicMock) -> None:
+        """When value is a league_key ('nfl'), fall back to league→sport_id map."""
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        # 'nfl' is NOT a sport_key but IS a league_key → parent sport = football (1).
+        assert crud_lookups.resolve_sport_id_for_mixed_value("nfl") == 1
+        # 'nba' → parent sport = basketball (2).
+        assert crud_lookups.resolve_sport_id_for_mixed_value("nba") == 2
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_sport_first_precedence_on_collision(self, mock_fetch: MagicMock) -> None:
+        """'soccer' exists as BOTH a sport_key and a league_key → prefer sport.
+
+        Mirrors the real migration 0060 seed where 'soccer' is both. The
+        source iterates `if value in _sport_key_to_id` FIRST before the
+        league fallback, so the sport's id (3) must win over the league
+        parent-id lookup (which would also resolve to 3 here — but even if
+        the seed diverged, precedence must be sport-first).
+        """
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        # The assertion pins precedence behavior: resolve_sport_id_for_mixed_value
+        # must walk the sport map first, not the league fallback.
+        assert crud_lookups.resolve_sport_id_for_mixed_value("soccer") == 3
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_unknown_value_returns_none_without_raising(self, mock_fetch: MagicMock) -> None:
+        """Value matching neither map returns None (permissive, no raise)."""
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        assert crud_lookups.resolve_sport_id_for_mixed_value("quidditch") is None
+
+
+# =============================================================================
+# G. invalidate_cache — fixture verification + mid-test re-fetch
+# =============================================================================
+
+
+class TestInvalidateCacheFixtureBehavior:
+    """Prove the autouse fixture isolates tests and invalidate_cache mid-test works."""
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_first_sequential_test_triggers_fresh_fetch(self, mock_fetch: MagicMock) -> None:
+        """Sibling of the next test — each must independently trigger a fresh fetch."""
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        crud_lookups.get_sport_id("football")
+
+        # If the autouse fixture failed to invalidate, this assertion would
+        # hold only for the first-run test in the class; running it twice
+        # proves cleanup between tests works.
+        assert mock_fetch.call_count == 2
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_second_sequential_test_with_different_lookup(self, mock_fetch: MagicMock) -> None:
+        """Sibling test — exercises a DIFFERENT surface to gain independent signal.
+
+        The first sibling above uses `get_sport_id("football")`. If both tests
+        called the identical lookup, the pair wouldn't prove anything stronger
+        than either test alone. This test calls `get_league_id("nfl")` so that
+        if the autouse fixture ever regresses to a cache-clear-but-not-reset
+        state, this test would see call_count != 2 (because a stale sport-only
+        cache would satisfy the league query without re-fetching).
+        """
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        crud_lookups.get_league_id("nfl")
+
+        assert mock_fetch.call_count == 2, (
+            "Cache leaked between tests — autouse invalidate_cache fixture broken"
+        )
+
+    @patch("precog.database.crud_lookups.fetch_all")
+    def test_invalidate_cache_mid_test_forces_refetch(self, mock_fetch: MagicMock) -> None:
+        """Mid-test invalidate_cache() causes the next lookup to re-fetch both tables."""
+        mock_fetch.side_effect = _fetch_all_side_effect
+
+        crud_lookups.get_sport_id("football")
+        assert mock_fetch.call_count == 2
+
+        crud_lookups.invalidate_cache()
+
+        # Still 2 — invalidate alone doesn't fetch.
+        assert mock_fetch.call_count == 2
+
+        crud_lookups.get_sport_id("football")
+        # Now re-populated → total is 4.
+        assert mock_fetch.call_count == 4


### PR DESCRIPTION
## Summary
- Move the test type coverage audit from a non-gating CI job to `scripts/pre-push-validation.sh` as a fast-fail Step 0 gate
- Register 3 untracked modules in `MODULE_TIERS` (`crud_lookups`, `crud_probability_models`, `migration_check` — all experimental tier)
- Fix stale comment in `audit_test_type_coverage.py` that claimed business=6/infra=4 types; actual V3.2 policy is all-8 for non-experimental tiers
- Remove `test-type-coverage` job + CI Summary references in `ci.yml`; update `CLAUDE.md` pointer

Closes `#887` Slice 1 (acceptance criteria 1–4 + untracked-module registration). Slices 2–3 remain tracked in `#887` (10 CRUD unit-test gaps + temporal_alignment_writer 7-type gap).

## Why this change

The CI `test-type-coverage` job had run with `continue-on-error: true` since C3-era, muting its signal into an invisible red X on every PR. Legacy umbrella `#155` (57h tech debt) closed without the 57 hours landing. Running the audit in session 63: **71/82 modules passing, 11 failing with real gaps, 3 untracked modules** — two of which came from PRs merged/merging the same day (`#883` added `crud_probability_models`, `#875` added `migration_check`), proving the audit's signal works; only the band-aid was broken.

Pre-push enforcement restores the feedback loop:
- Feedback at author's push, not reviewer's glance (ownership)
- Cannot silently accumulate (blocks vs. non-gating red X)
- Zero CI-minute cost
- Signal loop: push new module → audit blocks → author registers in `MODULE_TIERS`

## Transitional escape hatch

The current tree has 12 pre-existing audit failures, which would self-block any push until closed. `SKIP_TEST_TYPE_AUDIT=1 git push` is provided as a documented escape hatch for the transitional burn-down period. Usage is rare/temporary and tracked in `#887`. Do NOT wire this into CI or aliases.

## Test plan
- [x] `bash -n scripts/pre-push-validation.sh` — syntax clean
- [x] `python scripts/audit_test_type_coverage.py --strict` — runs, reports correct 12 gaps (11 prior + `crud_lookups` now visible as tracked)
- [x] Pre-push suite ran end-to-end: 2624 unit + 1228 integration + 1045 stress/chaos/race, all green (~6 min)
- [x] Bypass printed expected message: `Test type coverage audit: SKIPPED (SKIP_TEST_TYPE_AUDIT=1 — tracked in #887)`
- [ ] CI Summary passes on this PR without the removed job (validates via merge)
- [ ] Trial failing push after merge: intentionally introduce a gap, verify pre-push blocks; restore and confirm unblock

## Files changed
- `.github/workflows/ci.yml` — remove `test-type-coverage` job + 3 references in CI Summary
- `CLAUDE.md` — update CI Summary aggregated-job list; add pre-push pointer
- `scripts/audit_test_type_coverage.py` — 3 new `MODULE_TIERS` entries + fix stale tier-policy comment
- `scripts/pre-push-validation.sh` — add Step 0 (audit gate) + `SKIP_TEST_TYPE_AUDIT=1` escape hatch

## Pipeline Completeness Gate

**Tier 2 — PM-direct Builder + Sentinel; Reviewer stage: user-ACK waiver.** User directly scoped and approved the CI→pre-push migration in session 63 conversation. Post-merge CI claude-review bot will serve as Reviewer backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)