### PR TITLE
docs: #889 S68 follow-up — fix stale pytest paths in renamed-test docstrings

### DIFF
--- a/tests/unit/database/test_crud_ledger_account.py
+++ b/tests/unit/database/test_crud_ledger_account.py
@@ -11,8 +11,8 @@ Related:
 - migration_batch_plan_v1.md: Migration 0026 spec
 
 Usage:
-    pytest tests/unit/database/test_account_ledger_crud.py -v
-    pytest tests/unit/database/test_account_ledger_crud.py -v -m unit
+    pytest tests/unit/database/test_crud_ledger_account.py -v
+    pytest tests/unit/database/test_crud_ledger_account.py -v -m unit
 """
 
 from datetime import UTC, datetime

--- a/tests/unit/database/test_crud_ledger_temporal.py
+++ b/tests/unit/database/test_crud_ledger_temporal.py
@@ -12,8 +12,8 @@ Related:
 - migration_batch_plan_v1.md: Migration 0027 spec
 
 Usage:
-    pytest tests/unit/database/test_temporal_alignment_crud.py -v
-    pytest tests/unit/database/test_temporal_alignment_crud.py -v -m unit
+    pytest tests/unit/database/test_crud_ledger_temporal.py -v
+    pytest tests/unit/database/test_crud_ledger_temporal.py -v -m unit
 """
 
 from datetime import UTC, datetime

--- a/tests/unit/database/test_crud_ledger_trades.py
+++ b/tests/unit/database/test_crud_ledger_trades.py
@@ -12,8 +12,8 @@ Related:
 - migration_batch_plan_v1.md: Migration 0028 spec
 
 Usage:
-    pytest tests/unit/database/test_market_trades_crud.py -v
-    pytest tests/unit/database/test_market_trades_crud.py -v -m unit
+    pytest tests/unit/database/test_crud_ledger_trades.py -v
+    pytest tests/unit/database/test_crud_ledger_trades.py -v -m unit
 """
 
 from datetime import UTC, datetime


### PR DESCRIPTION
## Summary
- Session 63 PR #889 renamed 3 test files to match the `test_*<module_name>*.py` audit glob but left the docstring `Usage:` sections referencing the OLD filenames.
- 6 substring replacements across 3 files (docstring-only; 0 code / 0 test changes).
- Addresses the #889 item in umbrella **#891** (S68 follow-up).

## Changes
- `test_crud_ledger_account.py`  — `test_account_ledger_crud.py` → self-name (2 refs)
- `test_crud_ledger_temporal.py` — `test_temporal_alignment_crud.py` → self-name (2 refs)
- `test_crud_ledger_trades.py`   — `test_market_trades_crud.py` → self-name (2 refs)

## Why this matters
Stale paths in `Usage:` blocks surface as a soft trap — copy-pasting the command fails with "file not found," which looks like a missing test file when it's actually stale documentation. claude-review flagged this immediately after #889 merged.

## Test plan
- [x] `pytest tests/unit/database/test_crud_ledger_{account,temporal,trades}.py --collect-only` → 87 tests collected (new paths resolve)
- [x] Pre-push validation tiers all green (unit 2667 / integration+e2e 1229 / stress+chaos+race 1045 passed)
- [ ] CI green post-merge

Part of #891.

🤖 Generated with [Claude Code](https://claude.com/claude-code)