### PR TITLE
refactor: #887 Slice 3 — rename crud_orders + crud_historical sibling tests to match audit glob

### DIFF
--- a/tests/unit/database/test_crud_historical.py
+++ b/tests/unit/database/test_crud_historical.py
@@ -11,8 +11,8 @@ Related:
 - Pattern 1: Decimal Precision (NEVER USE FLOAT)
 
 Usage:
-    pytest tests/unit/database/test_historical_data_crud.py -v
-    pytest tests/unit/database/test_historical_data_crud.py -v -m unit
+    pytest tests/unit/database/test_crud_historical.py -v
+    pytest tests/unit/database/test_crud_historical.py -v -m unit
 """
 
 from unittest.mock import MagicMock, patch

--- a/tests/unit/database/test_crud_orders.py
+++ b/tests/unit/database/test_crud_orders.py
@@ -12,8 +12,8 @@ Related:
 - Glokta findings #1-#5
 
 Usage:
-    pytest tests/unit/database/test_order_crud.py -v
-    pytest tests/unit/database/test_order_crud.py -v -m unit
+    pytest tests/unit/database/test_crud_orders.py -v
+    pytest tests/unit/database/test_crud_orders.py -v -m unit
 """
 
 from decimal import Decimal


### PR DESCRIPTION
## Summary
- Extends session 63 #889 rename-beats-rewrite pattern to two more #887 audit gaps.
- Both modules already had full single-module unit test coverage; the audit glob just couldn't see them due to substring order.
- 73 tests covered across 2 renames, zero code change.

## Renames
- `test_order_crud.py` → `test_crud_orders.py` (48 tests)
- `test_historical_data_crud.py` → `test_crud_historical.py` (25 tests)

Each file's sole `from precog.database.<module> import ...` targets exactly the module in its new filename.

## #887 burn-down status
- Before: 10 gaps
- After:  **8 gaps** (-2)

Session 64 sibling-survey findings for the remaining 8 are tracked in **#893** — they split into two structural classes (multi-module test file: 5 gaps needing design decision; genuine gaps: 2 modules needing new tests).

## Docstring paths
Applied session 63 lesson learned from #892: updated `Usage:` block paths inside each renamed file in the same commit, avoiding the #892-style follow-up PR.

## Test plan
- [x] `pytest --collect-only` on new paths → 73 tests collected
- [x] `scripts/audit_test_type_coverage.py --strict` → gap count drops 10 → 8
- [x] Pre-push validation tiers all green (unit 2667+, integration+e2e 1229, stress+chaos+race 1045)
- [ ] CI green post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)