### PR TITLE
refactor: #891 — remove dead get_current_model (zero callers, docstring self-inconsistent)

### DIFF
--- a/src/precog/database/crud_probability_models.py
+++ b/src/precog/database/crud_probability_models.py
@@ -313,32 +313,6 @@ def update_model_metrics(
     )
 
 
-def get_current_model(model_id: int) -> dict[str, Any] | None:
-    """Fetch the CURRENT SCD2 row for a model by the CURRENT id.
-
-    Helper used by ``ModelManager.update_status`` / ``update_metrics`` to
-    re-resolve the returned row after supersede (the supersede allocates
-    a NEW model_id; the caller needs to fetch the new row to return it).
-    Looks up by ``(model_name, model_version)`` + ``row_current_ind =
-    TRUE`` so callers holding a stale id can re-resolve after a
-    concurrent supersede.
-
-    Returns None if no current row matches — should never happen
-    post-supersede but guards against race windows.
-    """
-    query = """
-        SELECT model_id, model_name, model_version, model_class, domain,
-               config, description, status,
-               validation_calibration, validation_accuracy,
-               validation_sample_size, created_at, created_by, notes
-        FROM probability_models
-        WHERE model_id = %s AND row_current_ind = TRUE
-    """
-    with get_cursor() as cur:
-        cur.execute(query, (model_id,))
-        return cast("dict[str, Any] | None", cur.fetchone())
-
-
 def get_current_model_by_name_version(model_name: str, model_version: str) -> dict[str, Any] | None:
     """Fetch the CURRENT SCD2 row for a model by (name, version).
 


### PR DESCRIPTION
## Summary
Closes the #883 portion of umbrella #891 (S68 follow-ups from session 63 Migration 0064 PR).

claude-review on #883 flagged `crud_probability_models.get_current_model(model_id)` as potentially unreachable after the 0064 SCD2 work. Session 64 verification confirmed:

- **Zero callers.** `grep -rn "get_current_model\b"` across `src/` + `tests/` returns only the function definition itself.
- **Intended callers use a different sibling.** `ModelManager.update_status` and `update_metrics` both use `get_current_model_by_name_version(name, version)` (imported at `model_manager.py:501` and `:654`, called at `:584` and `:747`).
- **Docstring was self-inconsistent.** Claimed "Looks up by `(model_name, model_version)` + `row_current_ind = TRUE`" but the signature took `model_id` and the SQL queried `WHERE model_id = %s`. Residue from an earlier design that got refactored into `get_current_model_by_name_version` without cleanup.

## Scope
- 1 file, 26 lines deleted, 0 lines added
- **No SCD2 write-path change** — this was a pure read helper with zero reachability
- All 5 SCD2 supersede unit tests still pass (`test_crud_probability_models_scd2_unit.py`)

## Test plan
- [x] `grep -rn "get_current_model\b"` → zero hits post-delete
- [x] `pytest test_crud_probability_models_scd2_unit.py` → 5/5 pass
- [x] `ruff check` → clean
- [x] Pre-push validation → green
- [ ] CI green post-merge

Part of #891.

🤖 Generated with [Claude Code](https://claude.com/claude-code)