### PR TITLE
docs: point CLAUDE.md at SCHEMA_SUMMARY_V2.0 (supersedes V1.16)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,7 +170,7 @@ precog-repo/
 - `docs/guides/POSITION_MANAGER_USER_GUIDE_V1.1.md`
 
 **Database & API:**
-- `docs/database/DATABASE_SCHEMA_SUMMARY_V1.16.md` - Complete schema
+- `docs/database/DATABASE_SCHEMA_SUMMARY_V2.0.md` - Complete schema (supersedes V1.16; freshness marker shows alembic_head sync state)
 - `docs/api-integration/API_INTEGRATION_GUIDE_V2.0.md`
 - `docs/api-integration/KALSHI_DECIMAL_PRICING_CHEAT_SHEET_V1.0.md` - CRITICAL reference
 


### PR DESCRIPTION
## Summary
- CLAUDE.md's Key Documents pointer was still referencing stale `DATABASE_SCHEMA_SUMMARY_V1.16.md`. V2.0 supersedes it.
- Both docs are internally stale against current alembic head (0064) — tracked in **#897** for the V2.1 rewrite covering migrations 0052-0064.
- This PR is the one-line accuracy-bump; the full V2.1 work is a separate Scheherazade session.

## Change
- `CLAUDE.md:173`: `DATABASE_SCHEMA_SUMMARY_V1.16.md` → `DATABASE_SCHEMA_SUMMARY_V2.0.md` (plus note about freshness-marker signaling of sync state)

## Test plan
- [x] Pre-push validation green (docs-only fast path — no files matched Python/YAML/lint checks)
- [ ] CI green post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)