### PR TITLE
refactor: C2c Gap A — explicit SCD2 columns in StrategyManager.create_strategy

### DIFF
--- a/src/precog/trading/strategy_manager.py
+++ b/src/precog/trading/strategy_manager.py
@@ -202,9 +202,11 @@ class StrategyManager:
             insert_sql = """
                 INSERT INTO strategies (
                     strategy_name, strategy_version, strategy_type, domain,
-                    config, description, status, created_by, notes
+                    config, description, status, created_by, notes,
+                    row_current_ind, row_start_ts, row_end_ts
                 )
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        TRUE, NOW(), NULL)
                 RETURNING strategy_id, strategy_name, strategy_version, strategy_type,
                           domain, config, description, status, paper_roi, live_roi,
                           paper_trades_count, live_trades_count, created_at, created_by, notes


### PR DESCRIPTION
## Summary

Mirror the explicit SCD2-INSERT pattern already used in `ModelManager.create_model` (analytics/model_manager.py:184-191). No behavior change — the row produced is bit-for-bit identical to what the column defaults (DEFAULT true, DEFAULT now(), nullable-no-default) would have produced.

5-line diff to `src/precog/trading/strategy_manager.py:202-213`. Adds the three SCD2 columns (`row_current_ind`, `row_start_ts`, `row_end_ts`) to the INSERT column list and their `TRUE, NOW(), NULL` SQL literals to VALUES. Python parameter tuple unchanged (9 `%s` placeholders, 9 values). RETURNING clause unchanged.

## Context

Phase B cohort C2c of the Schema Hardening Arc (epic #745, cohort issue #791). Session 65 Galadriel + Holden design review (see memos in `memory/design_review_c2c_*`) confirmed C2c is substantively closed — migration 0064 (session 63) landed the SCD2 spine AND wired the consumer layer correctly. One asymmetry remained: `ModelManager.create_model` writes SCD2 cols explicitly while `StrategyManager.create_strategy` relied on column defaults. This PR closes that gap.

Why close it now (all three matter in aggregate):
1. **Pattern 2 compliance** — CLAUDE.md §3 emphasizes SCD2 write discipline; 0064's migration docstring cites model_manager's explicit INSERT as the target pattern
2. **Self-documenting** — a reader of `create_strategy` now has a local signal that the table is SCD2
3. **Forward schema hazard** — if a future migration shifts defaults (e.g., for soft-delete semantics or #878 `created_at` carry-forward), relying on defaults silently breaks; explicit writes are an invariant

## Tier 2 Micro-ANNOUNCE pipeline

- **Builder: Samwise** (pattern-compliance frame) — 5-line diff, column ORDER verified against `model_manager.py:184-191` verbatim
- **Reviewer: Spock** (logical correctness, diff-scoped cold-context) — APPROVE, Q1-Q6 all PASS
- **Sentinel: Ripley** (highest-risk-first, MCP-verified) — CLEAR TO MERGE, R1-R6 all EXERCISED-CLEAN, MCP confirmed no INSERT triggers or CHECK constraints on SCD2 columns

Both reviewers independently flagged one convergent secondary finding: `create_strategy` INSERT path is not structurally asserted at unit tier — filed as #906 follow-up (mock-cursor test to lock in drift protection).

## Test plan

- [x] `PRECOG_ENV=test python -m pytest tests/unit/trading/test_strategy_manager_unit.py -q --no-cov` — 31/31 green
- [x] `PRECOG_ENV=test python -m pytest tests/unit/database/test_crud_strategies_scd2_unit.py -q --no-cov` — 6/6 green
- [x] `PRECOG_ENV=test python -m pytest tests/integration/trading/test_strategy_manager.py -q --no-cov` — 19/19 green, including `test_create_strategy`, `test_create_strategy_version`, `test_unique_constraint` (hit the partial UNIQUE index `idx_strategies_name_version_current` directly), `test_strategy_lifecycle_end_to_end`, `test_multiple_versions_coexist` — live INSERT verified against post-edit SQL
- [x] Pre-push full-stress gate passed on retry (first attempt hit flaky `test_burst_respects_rate_limit` in unrelated `espn_rate_limits.py` — 1 fail / 1044 pass on first attempt, 0 fail on retry)
- [x] No test assertion updates required (confirmed by Samwise + re-verified by Spock grepping for `call_args`, `execute.call_count`, `INSERT INTO strategies`, `execute_values` in test file — zero matches)
- [ ] CI green post-merge
- [ ] Claude Review addressed per S68

## Design review artifacts

- `memory/design_review_c2c_galadriel_memo.md` (cross-module harmony — MCP-first)
- `memory/design_review_c2c_holden_memo.md` (schema safety — MCP-first)
- `memory/design_review_c2c_synthesis.md` (PM consolidation)

## Refs

- Epic: #745 (Schema Hardening Arc)
- Cohort: #791 (Phase B C2c)
- Related session 65 issue filings: #903, #904, #905, #906
- Updated this session: #877 (closed as code-fixed), #878 (Holden's H-4 answer), #891 (disposition comment)
- Prior: migration 0064 in #883 (session 63)

🤖 Generated with [Claude Code](https://claude.com/claude-code)