### PR TITLE
docs: #899 — add PR template with Closes #NNN reminder

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+  Delete placeholder sections that don't apply. Keep the Summary + Test plan headings.
+  The "Related issues" section below is REQUIRED if this PR fixes a tracked issue —
+  GitHub auto-close only fires from PR body, not commit messages of squash-merged commits.
+-->
+
+## Summary
+
+<!-- 1-3 sentences. What does this PR do, and why? -->
+
+## Related issues
+
+<!--
+  REQUIRED if this PR fixes a tracked issue. Uncomment/fill the relevant lines and delete the rest.
+  GitHub auto-closes referenced issues on merge IFF this appears in the PR BODY (not commits).
+  Origin: #899 — sessions 42/64 lost 20+ sessions of MEMORY decay because fixer PRs omitted this.
+-->
+
+<!-- Closes #NNN -->
+<!-- Fixes #NNN -->
+<!-- Resolves #NNN -->
+<!-- Part of #NNN (use when the PR is a step toward an umbrella/epic, not a complete fix) -->
+
+## Test plan
+
+<!-- Bulleted markdown checklist. Include specific pytest invocations or manual-test steps. -->
+
+- [ ]
+- [ ] CI green post-merge
+- [ ] Claude Review addressed per S68 (if the PR touches production code or patterns)
+
+<!--
+  Co-authored-by lines are added by commit messages, not here.
+  For Tier 2 PRs: reference the design/review/QA agents in the commit message body (B+R+S pipeline trail).
+-->


### PR DESCRIPTION
## Summary

Lowest-friction fix from #899 Option 1. New `.github/PULL_REQUEST_TEMPLATE.md` with a Related issues section containing commented-out `Closes #NNN` / `Fixes #NNN` / `Resolves #NNN` / `Part of #NNN` placeholders. Every new PR body pre-populates with the reminder; writer deletes what doesn't apply. Zero enforcement overhead.

## Related issues

Closes #899

## Why this matters

Sessions 42 + 64 found that fixer PRs (#688, #690) had omitted `Closes #NNN` in their bodies for the issues they resolved (#662, #622). GitHub auto-close reads PR body, not commit messages of squash-merged commits. The result: issues stayed open for 20+ sessions, MEMORY.md Active Priorities accumulated stale items, and session 64 nearly dispatched Mulder + Holden for a "design pass" on already-fixed bugs.

## Alternatives considered (from #899)

- **Option 2 — pre-push hook:** would mechanically enforce by regex-matching issue numbers in title/commits against the body. Costs implementation + maintenance.
- **Option 3 — CI claude-review extension:** post-push sticky comment on missing `Closes`. Same reliability as Option 2 with even less friction at push time.

Both are more reliable but expensive relative to Option 1's zero-cost placeholder. Upgrade later if this still fails after adoption.

## Test plan

- [x] Template file created at `.github/PULL_REQUEST_TEMPLATE.md`
- [x] This PR itself used the template (see "Related issues" section above with `Closes #899`)
- [ ] CI green post-merge
- [ ] First post-merge PR by any author confirms the template auto-populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)