### PR TITLE
fix: pre-S68 backlog bundle — #914, #915, #916, #917 (mechanical cleanup)

### DIFF
--- a/scripts/fix_espn_team_ids.py
+++ b/scripts/fix_espn_team_ids.py
@@ -507,7 +507,7 @@ def generate_sql_updates(
                 f"INSERT INTO teams (team_code, team_name, display_name, sport, league, "  # noqa: S608
                 f"espn_team_id, current_elo_rating, conference, division) VALUES "
                 f"('{m['espn_code']}', '{m['name']}', '{display}', '{sport}', '{sport}', "
-                f"'{m['espn_id']}', 1500, NULL, NULL);"
+                f"'{m['espn_id']}', NULL, NULL, NULL);"
             )
 
     lines.append("")

--- a/src/precog/database/crud_events.py
+++ b/src/precog/database/crud_events.py
@@ -666,13 +666,13 @@ def _fill_event_null_fields(
     set_parts: list[str] = []
     params: list[Any] = []
 
-    if start_time and existing.get("start_time") is None:
+    if start_time is not None and existing.get("start_time") is None:
         set_parts.append("start_time = %s")
         params.append(start_time)
-    if end_time and existing.get("end_time") is None:
+    if end_time is not None and existing.get("end_time") is None:
         set_parts.append("end_time = %s")
         params.append(end_time)
-    if status and existing.get("status") is None:
+    if status is not None and existing.get("status") is None:
         set_parts.append("status = %s")
         params.append(status)
     if game_id is not None and existing.get("game_id") is None:

--- a/src/precog/schedulers/espn_game_poller.py
+++ b/src/precog/schedulers/espn_game_poller.py
@@ -1428,7 +1428,7 @@ class ESPNGamePoller(BasePoller):
         )
 
         # Update final result in games dimension if game is complete
-        if game_id and normalized_status in ("final", "final_ot"):
+        if game_id and normalized_status == "final":
             try:
                 update_game_result(
                     game_id=game_id,

--- a/tests/property/database/test_crud_operations_properties.py
+++ b/tests/property/database/test_crud_operations_properties.py
@@ -10,7 +10,7 @@ Related Issue: Issue #234 (State Change Detection)
 """
 
 import pytest
-from hypothesis import assume, given, settings
+from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
 
 from precog.database.crud_game_states import (
@@ -575,6 +575,28 @@ def basketball_situation_strategy(draw: st.DrawFn) -> dict:
 
 
 @st.composite
+def football_situation_strategy(draw: st.DrawFn) -> dict:
+    """Generate a realistic football situation dict.
+
+    Mirrors TRACKED_SITUATION_KEYS["football"] in crud_game_states.py:
+    possession, down, distance, yard_line, is_red_zone, home_win_probability.
+    """
+    return {
+        "possession": draw(nfl_teams),
+        "down": draw(down_strategy),
+        "distance": draw(distance_strategy),
+        "yard_line": draw(yard_line_strategy),
+        "is_red_zone": draw(red_zone_strategy),
+        "home_win_probability": draw(
+            st.one_of(
+                st.none(),
+                st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_subnormal=False),
+            )
+        ),
+    }
+
+
+@st.composite
 def hockey_situation_strategy(draw: st.DrawFn) -> dict:
     """Generate a realistic hockey situation dict."""
     return {
@@ -742,6 +764,99 @@ class TestGameStateChangedSportAwareProperties:
 
         result = game_state_changed(
             current, home_score, away_score, period, game_status, new_situation, league="nhl"
+        )
+
+        assert result is False
+
+    @given(
+        situation=football_situation_strategy(),
+    )
+    @settings(max_examples=50, suppress_health_check=[HealthCheck.too_slow])
+    def test_football_situation_strategy_has_tracked_keys(
+        self,
+        situation: dict,
+    ) -> None:
+        """football_situation_strategy produces every key in TRACKED_SITUATION_KEYS['football'].
+
+        Regression test for #915: ensures the fixture stays in sync with the
+        tracked-keys list. If someone adds a key to TRACKED_SITUATION_KEYS["football"]
+        without extending the strategy, this test fires.
+        """
+        for key in TRACKED_SITUATION_KEYS["football"]:
+            assert key in situation, f"football_situation_strategy missing key: {key}"
+
+    @given(
+        home_score=score_strategy,
+        away_score=score_strategy,
+        period=period_strategy,
+        game_status=game_status_strategy,
+        situation=football_situation_strategy(),
+        league=st.sampled_from(["nfl", "ncaaf"]),
+    )
+    @settings(max_examples=100)
+    def test_football_same_situation_reflexive(
+        self,
+        home_score: int,
+        away_score: int,
+        period: int,
+        game_status: str,
+        situation: dict,
+        league: str,
+    ) -> None:
+        """Same football situation with league should always return False."""
+        current = {
+            "home_score": home_score,
+            "away_score": away_score,
+            "period": period,
+            "game_status": game_status,
+            "situation": situation,
+        }
+
+        result = game_state_changed(
+            current, home_score, away_score, period, game_status, situation, league=league
+        )
+
+        assert result is False
+
+    @given(
+        home_score=score_strategy,
+        away_score=score_strategy,
+        period=period_strategy,
+        game_status=game_status_strategy,
+        situation=football_situation_strategy(),
+        new_clock=st.text(min_size=0, max_size=5),
+        league=st.sampled_from(["nfl", "ncaaf"]),
+    )
+    @settings(max_examples=100)
+    def test_football_untracked_change_ignored(
+        self,
+        home_score: int,
+        away_score: int,
+        period: int,
+        game_status: str,
+        situation: dict,
+        new_clock: str,
+        league: str,
+    ) -> None:
+        """Football changes to untracked fields (e.g., clock) should NOT trigger state change."""
+        current = {
+            "home_score": home_score,
+            "away_score": away_score,
+            "period": period,
+            "game_status": game_status,
+            "situation": situation,
+        }
+
+        # Only change an untracked field (clock is not in TRACKED_SITUATION_KEYS["football"])
+        new_situation = situation.copy()
+        new_situation["clock"] = new_clock
+
+        # Keep tracked fields identical
+        for key in TRACKED_SITUATION_KEYS["football"]:
+            new_situation[key] = situation[key]
+
+        result = game_state_changed(
+            current, home_score, away_score, period, game_status, new_situation, league=league
         )
 
         assert result is False

--- a/tests/unit/database/test_crud_operations_unit.py
+++ b/tests/unit/database/test_crud_operations_unit.py
@@ -2876,6 +2876,53 @@ class TestFillEventNullFields:
         assert 15 in params
 
     @patch("precog.database.crud_events.get_cursor")
+    def test_empty_string_start_time_is_written(self, mock_get_cursor):
+        """start_time='' is falsy in Python but ``is not None`` — should still be written.
+
+        Regression test for #914: previously ``if start_time and ...`` would
+        silently skip empty-string values. After the fix we use ``is not None``
+        (matching the adjacent game_id pattern), so "" is treated as a real
+        caller-provided value and written to the column.
+        """
+        mock_cursor = MagicMock()
+        mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        existing = {"id": 42, "start_time": None, "end_time": None, "status": None, "game_id": None}
+
+        _fill_event_null_fields(existing, start_time="", end_time="", status="")
+
+        mock_cursor.execute.assert_called_once()
+        sql = mock_cursor.execute.call_args[0][0]
+        params = mock_cursor.execute.call_args[0][1]
+        # All three fields should appear in SET clause
+        set_clause = sql.split("WHERE")[0]
+        assert "start_time" in set_clause
+        assert "end_time" in set_clause
+        assert "status" in set_clause
+        # Empty-string params included
+        assert params.count("") == 3
+
+    @patch("precog.database.crud_events.get_cursor")
+    def test_none_string_fields_are_skipped(self, mock_get_cursor):
+        """None caller values for start_time/end_time/status should still be skipped.
+
+        Regression test for #914: verifies the ``is not None`` guard still
+        correctly filters out None (the common no-value case). Paired with
+        test_empty_string_start_time_is_written, this pins down both ends of
+        the behavior change.
+        """
+        mock_cursor = MagicMock()
+        mock_get_cursor.return_value.__enter__ = MagicMock(return_value=mock_cursor)
+        mock_get_cursor.return_value.__exit__ = MagicMock(return_value=False)
+
+        existing = {"id": 42, "start_time": None, "end_time": None, "status": None, "game_id": None}
+
+        _fill_event_null_fields(existing, start_time=None, end_time=None, status=None)
+
+        mock_cursor.execute.assert_not_called()
+
+    @patch("precog.database.crud_events.get_cursor")
     def test_game_id_zero_is_treated_as_value(self, mock_get_cursor):
         """game_id=0 is falsy in Python but should still be written if existing is NULL.
 

--- a/tests/unit/schedulers/test_espn_game_poller_unit.py
+++ b/tests/unit/schedulers/test_espn_game_poller_unit.py
@@ -227,6 +227,41 @@ class TestStatusNormalization:
         poller = ESPNGamePoller(espn_client=mock_espn_client)
         assert poller._normalize_game_status("") == "pre"
 
+    @pytest.mark.parametrize(
+        "raw_status",
+        [
+            "pre",
+            "PRE",
+            "scheduled",
+            "in",
+            "IN",
+            "in_progress",
+            "halftime",
+            "HALFTIME",
+            "post",
+            "final",
+            "final/ot",
+            "final/2ot",
+            "unknown",
+            "weird_status",
+            "",
+        ],
+    )
+    def test_normalize_never_outputs_final_ot(
+        self, mock_espn_client: MagicMock, raw_status: str
+    ) -> None:
+        """Regression test for #916: _normalize_game_status never emits 'final_ot'.
+
+        The caller in _process_game previously checked for 'final_ot' as a
+        possible output, but the normalizer maps every overtime variant
+        (final/ot, final/2ot) to 'final'. This test pins that invariant so the
+        dead-branch removal in _process_game stays safe.
+        """
+        poller = ESPNGamePoller(espn_client=mock_espn_client)
+        result = poller._normalize_game_status(raw_status)
+        assert result != "final_ot"
+        assert result in {"pre", "in_progress", "halftime", "final"}
+
 
 # =============================================================================
 # Unit Tests: Poll Once


### PR DESCRIPTION
## Summary

Bundle cleanup closing four LOW-priority pre-S68 backlog issues. All four were Gate-B-verified session 66 (schema + sibling-function validity) before Builder dispatch.

### Four fixes

| Issue | File | Change |
|---|---|---|
| **#914** | `src/precog/database/crud_events.py:669-675` | 3 truthiness guards (`if X and ...`) → `is not None and ...` for `start_time`, `end_time`, `status` string fields. Mirrors the correct `game_id` pattern at :678 |
| **#915** | `tests/property/database/test_crud_operations_properties.py` | New `football_situation_strategy` hypothesis fixture + 3 property tests (shape validation, reflexivity, untracked-change-ignored). Field-level match for `TRACKED_SITUATION_KEYS["football"]` |
| **#916** | `src/precog/schedulers/espn_game_poller.py:1431` | Remove dead `"final_ot"` branch — normalizer at `:1645-1652` provably never emits it. Added 15-way parametrized regression pinning the invariant |
| **#917** | `scripts/fix_espn_team_ids.py:510` | Hardcoded `1500` → `NULL` for `current_elo_rating` on auto-created teams (column is nullable, MCP-verified) |

### Test plan

- [x] Serial: 1682 tests pass across `tests/unit/database/`, `tests/property/database/`, `tests/unit/schedulers/`
- [x] Targeted subsets: `TestFillEventNullFields` (8), `TestStatusNormalization` (21), `TestGameStateChangedSportAwareProperties` (7) — all pass
- [x] Ruff check + format clean (679 files)
- [x] All 23 pre-commit hooks pass
- [x] Spock review: **APPROVE** — mechanically correct, regression tests would catch reverts (`review_bundle_spock_memo.md`)
- [x] Ripley QA: **CLEAR TO MERGE** — property tests verified locally (3+29 pass in 1.46s), #914 semantic change is dormant (sole caller at `kalshi_poller.py:1172` never produces empty strings), #916 parametrized regression pins invariant (`review_bundle_ripley_memo.md`)

### Pipeline Completeness Gate (protocols.md § Step 7)

- Builder: Samwise commit `2c912b3` ✓
- Reviewer: Spock APPROVE ✓
- Sentinel: Ripley CLEAR TO MERGE ✓
- Push bypass: `SKIP_TEST_TYPE_AUDIT=1` — sanctioned per audit script's own documentation. Pre-existing #887 Class A gaps (6 CRUD modules sharing `test_crud_operations_unit.py`) unrelated to this bundle; closure tracked via #893 Option 1 queued for session 67.

Closes #914
Closes #915
Closes #916
Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)