### PR TITLE
docs: codify Pattern 73 at CLAUDE.md Critical Patterns (#929)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,34 @@ ASCII output for console (Windows cp1252). Explicit UTF-8 for file I/O.
 ### 6. Immutable Versioning
 Strategies and models are immutable once created. Create new version, don't modify existing.
 
+### 8. Single Source of Truth (Pattern 73) — canonical rule + pointers, never duplicates
+
+**The rule:** Any rule, value, formula, or logic that appears in more than one location MUST have ONE canonical definition plus pointers/imports from the others. **Never copy the rule text, formula, or logic.** Applies identically to docs and code.
+
+```python
+# CORRECT (code) — canonical constant, imports from elsewhere
+# db/constants.py
+VALID_EDGE_OUTCOMES = ("yes", "no", "void", "unresolved")
+
+# crud_analytics.py
+from precog.database.constants import VALID_EDGE_OUTCOMES
+if actual_outcome not in VALID_EDGE_OUTCOMES: ...
+
+# CORRECT (docs) — canonical rule + pointer
+# protocols.md § Step 7a has the full claude-review parse rule
+# Session-start Step 5a: "apply the canonical parse rule from Step 7a"
+
+# WRONG — duplicated rule text / logic
+# crud_analytics.py
+if actual_outcome not in ("yes", "no", "void", "unresolved"): ...  # copy
+# crud_other.py
+if actual_outcome not in ("yes", "no", "void", "unresolved"): ...  # copy drifts eventually
+```
+
+**Why this is critical:** duplicated rules silently drift when one copy is updated and others aren't. Session 66 found three Pattern 73 violations in one session (claude-review parse rule, slotting checklist, Pipeline Completeness Gate) — all had the same shape: *rule exists somewhere, invocation point doesn't reference it, drift goes undetected until someone asks the right question.* See Pattern 73 in `docs/guides/DEVELOPMENT_PATTERNS_V*.md`.
+
+**Before copying any rule/logic to a second location: either (a) extract to a shared helper/constant and import, or (b) write a pointer that references the canonical location.** Audit triggers S81 + #929 check for compliance periodically.
+
 ### 7. External API Test Mocking — VCR OR live, NEVER hand-written
 
 Tests that exercise code calling **Kalshi, ESPN, or any HTTP client** use one of two approaches — **never** hand-written `MagicMock` response dicts:


### PR DESCRIPTION
## Summary

Promotes Pattern 73 (Single Source of Truth — canonical rule + pointers, never duplicates) from `docs/guides/DEVELOPMENT_PATTERNS_V*.md` into CLAUDE.md's Critical Patterns as Section 8.

Session 66 surfaced three Pattern 73 violations in a single session, all with identical failure shape: rule exists in a canonical location, invocation point doesn't reference it, drift goes undetected until someone asks the right question. This edit makes the rule load-bearing at the same level as the other Critical Patterns so it's present in the opening read of every session.

Session 66 drafted the edit but left it uncommitted at session close; session 67 ships it.

## What's in the diff

- `CLAUDE.md` +28 lines — new Section 8 with:
  - The rule: canonical definition + pointers, never copies of rule text / formula / logic
  - Code example (canonical constant + import from consumers)
  - Docs example (canonical protocol step + pointer from invocation)
  - Anti-example (duplicated tuple literal that will drift)
  - Rationale with session 66 evidence
  - Before-copying checklist: extract-and-import OR write a pointer
  - Pointer to #929 and S81 as periodic enforcement

## Section numbering

New section is numbered **8**, sitting between existing Sections 6 and 7. Section numbering in CLAUDE.md reflects chronological order of additions (Section 7 "External API Test Mocking" was itself added session 50 per #772), not logical grouping. Renumbering existing sections would churn the file for no gain and break any external references.

## Related

- #929 — META: Pattern 73 compliance audit (OPEN, priority-medium) — referenced as the periodic enforcement trigger
- S81 — Decay Panel retrospective re-audit — referenced as a coupled audit signal
- Session 66 three-violations insight (`memory/session_66_actual.md`)
- Pattern 73 canonical reference in `docs/guides/DEVELOPMENT_PATTERNS_V1.33.md`

## Test plan
- [x] Pre-commit hooks pass (Doc Version Drift G1, ADR Drift G7, whitespace, EOF, line endings)
- [x] No code changes — docs-only
- [ ] Docs Validation CI green
- [ ] CI Summary green

Closes #929? — **No.** This edit is one side of the #929 proposal (CLAUDE.md codification); the full scope (periodic audit scan of protocols.md / roster files / checklist files / skills for rule-invocation coherence) remains. #929 stays OPEN, targeted at session 68-69 as part of S69 memory/protocol decay audit.