### PR TITLE
fix: #912 — add page_size to execute_values in crud_ledger.py (rowcount accuracy on batches >100)

### DIFF
--- a/src/precog/database/crud_ledger.py
+++ b/src/precog/database/crud_ledger.py
@@ -560,8 +560,18 @@ def insert_temporal_alignment_batch(alignments: list[dict]) -> int:
     # submitted. ON CONFLICT DO NOTHING will skip duplicates; cur.rowcount
     # on execute_values reports the effective count, unlike executemany
     # where DB-API 2.0 leaves rowcount undefined across iterations.
+    #
+    # page_size=len(validated_params) forces a single page so cur.rowcount
+    # reflects the full batch. Default page_size=100 would otherwise report
+    # only the last page's rowcount for batches > 100 rows (issue #912).
     with get_cursor(commit=True) as cur:
-        execute_values(cur, insert_query, validated_params, template=template)
+        execute_values(
+            cur,
+            insert_query,
+            validated_params,
+            template=template,
+            page_size=len(validated_params),
+        )
         return cast("int", cur.rowcount)
 
 
@@ -823,8 +833,17 @@ def upsert_market_trades_batch(trades: list[dict]) -> int:
 
     template = "(%s, %s, %s, %s, %s, %s, %s, %s)"
 
+    # page_size=len(validated_params) forces a single page so cur.rowcount
+    # reflects the full batch. Default page_size=100 would otherwise report
+    # only the last page's rowcount for batches > 100 rows (issue #912).
     with get_cursor(commit=True) as cur:
-        execute_values(cur, insert_query, validated_params, template=template)
+        execute_values(
+            cur,
+            insert_query,
+            validated_params,
+            template=template,
+            page_size=len(validated_params),
+        )
         return cast("int", cur.rowcount)
 
 

--- a/tests/unit/database/test_crud_ledger_temporal.py
+++ b/tests/unit/database/test_crud_ledger_temporal.py
@@ -345,6 +345,36 @@ class TestInsertTemporalAlignmentBatch:
         assert "DO NOTHING" in sql
         assert "market_snapshot_id, game_state_id" in sql
 
+    @patch("precog.database.crud_ledger.execute_values")
+    @patch("precog.database.crud_ledger.get_cursor")
+    def test_batch_insert_passes_page_size_full_batch(self, mock_get_cursor, mock_exec_values):
+        """execute_values is called with page_size=len(params) for accurate rowcount.
+
+        psycopg2.extras.execute_values defaults page_size=100. For batches >100 rows,
+        cur.rowcount reports only the LAST page's count. The fix passes
+        page_size=len(validated_params) so rowcount reflects the full batch.
+
+        This test uses N=150 rows to exercise the >100 boundary (issue #912).
+        """
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 150
+
+        # 150 rows crosses the default 100-row page boundary
+        rows = []
+        for i in range(150):
+            row = _default_alignment_dict()
+            row["market_snapshot_id"] = 2000 + i
+            row["game_state_id"] = 3000 + i
+            rows.append(row)
+
+        insert_temporal_alignment_batch(rows)
+
+        # execute_values must have been called with page_size=150 as a kwarg
+        call_kwargs = mock_exec_values.call_args.kwargs
+        assert call_kwargs.get("page_size") == 150, (
+            f"expected page_size=150, got {call_kwargs.get('page_size')!r}"
+        )
+
 
 # =============================================================================
 # GET ALIGNMENTS BY MARKET TESTS

--- a/tests/unit/database/test_crud_ledger_trades.py
+++ b/tests/unit/database/test_crud_ledger_trades.py
@@ -321,6 +321,36 @@ class TestUpsertMarketTradesBatch:
         with pytest.raises(ValueError, match="count must be a positive integer"):
             upsert_market_trades_batch([row])
 
+    @patch("precog.database.crud_ledger.execute_values")
+    @patch("precog.database.crud_ledger.get_cursor")
+    def test_batch_passes_page_size_full_batch(self, mock_get_cursor, mock_exec_values):
+        """execute_values is called with page_size=len(params) for accurate rowcount.
+
+        psycopg2.extras.execute_values defaults page_size=100. For batches >100 rows,
+        cur.rowcount reports only the LAST page's count. The fix passes
+        page_size=len(validated_params) so rowcount reflects the full batch.
+
+        This test uses N=150 rows to exercise the >100 boundary (issue #912).
+        """
+        mock_cursor = _mock_cursor_context(mock_get_cursor)
+        mock_cursor.rowcount = 150
+
+        # 150 rows crosses the default 100-row page boundary. Each row needs
+        # a unique external_trade_id so ON CONFLICT doesn't skip any of them.
+        rows = []
+        for i in range(150):
+            row = _default_trade_dict()
+            row["external_trade_id"] = f"trade-{i:04d}"
+            rows.append(row)
+
+        upsert_market_trades_batch(rows)
+
+        # execute_values must have been called with page_size=150 as a kwarg
+        call_kwargs = mock_exec_values.call_args.kwargs
+        assert call_kwargs.get("page_size") == 150, (
+            f"expected page_size=150, got {call_kwargs.get('page_size')!r}"
+        )
+
 
 # =============================================================================
 # GET MARKET TRADES TESTS


### PR DESCRIPTION
## Summary

Two `psycopg2.extras.execute_values` calls in `src/precog/database/crud_ledger.py` were omitting the `page_size` kwarg. psycopg2's default is `page_size=100`, so for batches >100 rows, `cur.rowcount` reported only the LAST page's count. The existing docstrings ASSERTED rowcount accuracy — post-fix, the docstrings are finally true.

**Closes #912.**

## The bug (behavioral proof)

Ripley reproduced against `precog_test` via a TEMP table:

| Batch size | pre-fix `cur.rowcount` | post-fix `cur.rowcount` |
|---|---|---|
| 150 rows | **50** (only last page) | **150** (correct) |

Batches ≤100 behaved correctly both pre- and post-fix.

## Call sites fixed

- `src/precog/database/crud_ledger.py` — `insert_temporal_alignment_batch` (was line 564, now multi-line with comment)
- `src/precog/database/crud_ledger.py` — `upsert_market_trades_batch` (was line 827, now multi-line with comment)

Both now pass `page_size=len(validated_params)` with a grep-able inline comment tying back to #912:

```python
execute_values(
    cur, insert_query, validated_params,
    template=template,
    page_size=len(validated_params),  # #912 — force single page so cur.rowcount reflects full batch
)
```

## Tests added

- `tests/unit/database/test_crud_ledger_temporal.py::test_batch_insert_passes_page_size_full_batch`
- `tests/unit/database/test_crud_ledger_trades.py::test_batch_passes_page_size_full_batch`

Both use N=150 to cross the >100 boundary, mock at the import site per Pattern 43 (`precog.database.crud_ledger.execute_values`), and assert on `call_args.kwargs["page_size"] == 150` (kwarg-form — won't silently pass if someone regresses to positional).

Full suite: **64 targeted tests pass**, **1062 broader `tests/unit/database/` passes** (+2 over baseline, no silent drops).

## Caller audit (money-adjacent safety check)

Glokta enumerated every consumer of the rowcount:

| Caller | File:line | Uses rowcount? | Depends on old under-reported behavior? |
|---|---|---|---|
| `TemporalAlignmentWriter._poll_once` | `src/precog/schedulers/temporal_alignment_writer.py:230` | Yes — logs it + returns as `items_created` | **No.** Sum is ephemeral (BasePoller running total + INFO log + Rich console). Zero conditional logic branches on the value. |
| `upsert_market_trades_batch` src callers | (none) | n/a | n/a — no src callers exist yet |
| Tests | 2 test files | Mock rowcount directly | n/a |

**No persisted metric, no threshold alert, no dashboard persistence, no downstream math.** The behavior change is visible only in log lines and in-memory accumulators — a pure correction, never a regression.

## Review pipeline (Micro-ANNOUNCE, Tier 2)

- **Builder:** Samwise (commit 4b1c914). Pattern compliance — existing docstrings claim rowcount accuracy; this makes them true
- **Reviewer:** Glokta — **APPROVE** (adversarial money-adjacent frame, caller audit). 3 P3 nits, all non-blocking: (a) `page_size=0` is an infinite loop in psycopg2 `_paginate` but guarded by `if not` early returns at both call sites; (b) batch-size discipline at 1000 rows still within PostgreSQL safe limits; (c) symmetric duplication between the two fixed sites is preferable to premature 3-line helper extraction
- **Sentinel:** Ripley — **CLEAR TO MERGE** (8-check pass + real-DB rowcount proof via TEMP table rollback, zero persistent state)

## Pipeline Completeness Gate

- ✅ Builder output captured (commit 4b1c914 with inline explanation)
- ✅ Reviewer output captured (APPROVE, caller audit complete)
- ✅ Sentinel output captured (CLEAR TO MERGE, real-DB behavioral proof)

## `SKIP_TEST_TYPE_AUDIT=1` transitional bypass

Same rationale as PR #956 and #957: #887 Class A audit is binary pass/fail; 2 modules (`crud_elo` experimental + `temporal_alignment_writer` business via #896) still fail. Bypass retires after #896 lands. Full pre-push integration + e2e suite passed.

## Test plan
- [x] Pre-push local: 64 targeted unit + full integration + e2e green
- [x] Review pipeline complete (Samwise → Glokta → Ripley, all outputs captured)
- [x] Real-DB rowcount behavioral proof (Ripley TEMP-table probe)
- [x] Caller audit — no downstream breakage
- [x] Ruff + Mypy clean
- [ ] CI + claude-review comment
- [ ] Docstrings-now-true invariant holds in production (silent — no observable difference for batches ≤100)