### PR TITLE
fix: #952 — PositionResponse.market_id int correction (Phase 2 blocker, S81 first-fire)

### DIFF
--- a/src/precog/trading/types.py
+++ b/src/precog/trading/types.py
@@ -208,7 +208,7 @@ class PositionResponse(TypedDict):
     position_key: str  # Business key (format: 'POS-{id}', stays constant)
 
     # Trade attribution
-    market_id: str  # Market identifier
+    market_id: int  # Integer FK to markets(id) surrogate PK (per Migration 0022)
     strategy_id: int  # Strategy that generated signal
     model_id: int  # Model that calculated probability
 

--- a/tests/unit/trading/test_types_contracts.py
+++ b/tests/unit/trading/test_types_contracts.py
@@ -1,0 +1,24 @@
+"""Contract tests for TypedDict shapes in precog.trading.types.
+
+See each test for rationale.
+
+Current pins:
+    - PositionResponse.market_id must be int (issue #952, Migration 0022).
+"""
+
+
+def test_position_response_market_id_is_int_per_migration_0022():
+    """PositionResponse.market_id must be int (regression: #952, Phase 2 blocker).
+
+    Migration 0022 changed positions.market_id to INTEGER. The TypedDict shape was
+    forgotten during that migration and silently diverged for months until the S81
+    retrospective audit caught it. Pin the invariant: mypy trusts TypedDict
+    annotations as gospel, so any future drift would cascade into Phase 2 manual
+    placement code (Epic #504) as silent runtime errors.
+    """
+    from precog.trading.types import PositionResponse
+
+    assert PositionResponse.__annotations__["market_id"] is int, (
+        "PositionResponse.market_id must be int to match DB column type "
+        "(see Migration 0022 and issue #952)."
+    )


### PR DESCRIPTION
## Summary

- `PositionResponse.market_id` TypedDict annotation was `str`; DB column is `integer` (Migration 0022). One-line correction + comment alignment + regression test pinning the invariant.
- **Phase 2 blocker** for Epic #504 (manual placement MVP): a type-system lie that would cascade into any manual-placement code consuming `PositionResponse`.
- Origin: S81 first-fire retrospective audit (session 68) — caught via Gate B MCP-verification against live schema.

Closes #952

## Why it's safe (scoping evidence)

| Check | Result |
|---|---|
| `PositionResponse` downstream consumers | Zero. Only re-exported via `trading/__init__.py`; no module reads `.market_id` as a string anywhere. |
| Real function signatures already int? | Yes. `position_manager.py:222` (`create_position`), `position_manager.py:672` (`list_positions`), + explicit Migration 0022 comment at `position_manager.py:708`. |
| MCP Gate B — `positions.market_id` in live dev DB | `data_type: integer`, `is_nullable: NO`, alembic head `0066`. |
| Sibling TypedDict drift | Checked — `analytics/types.py:PositionSummary.market_id` already `int`, no adjacent drift. |
| Test fixtures constructing string `market_id` for positions | Zero. Hits are deprecated files, SQL-string assertions, int literals, and logger fixtures (different concern). |

## Pipeline

| Role | Agent | Verdict |
|---|---|---|
| Builder | Samwise (pattern-compliance frame) | Complete — 1 LoC production + 1 regression test, ruff clean |
| Reviewer | Glokta (adversarial money-adjacent frame) | **APPROVE-WITH-NITS** — verified caller audit, Migration 0022, `is int` semantics |
| Tier 1 Momentum | PM-direct per Glokta line-numbered spec | Module-docstring redundancy trimmed (P3 Pattern 73 micro-violation) |
| Sentinel | Ripley (highest-risk-first frame) | **CLEAR TO MERGE** — Gate B PASS, revert-probe 5/5 catch, fixture sweep 0 real bugs |

## Regression test

Pins `PositionResponse.__annotations__["market_id"] is int` via identity-check on the class object. Ripley's revert-probe confirmed it fires on:

| Hypothetical regression | Catches? |
|---|---|
| `market_id: str` (full revert) | YES |
| `market_id: int \| None` (nullable drift) | YES |
| `market_id: str \| int` (union drift) | YES |
| `market_id: "int"` (stringified forward-ref) | YES |
| `from __future__ import annotations` added + annotation unchanged | YES (via loud test failure, which is desirable) |

## Follow-ups (non-blocking, filed separately)

Glokta's scope-gaps from the caller audit — all out of scope for this PR:

1. **Doc drift** — 7+ docs still show string-form `market_id="KALSHI-NFL-..."` in examples (`POSITION_MANAGER_USER_GUIDE`, `EDGE_CALCULATION_GUIDE`, `DEVELOPMENT_PATTERNS_V1.{31-34}`, `MANAGER_ARCHITECTURE_GUIDE`, `MODEL_MANAGER_USER_GUIDE`, `ARCHITECTURE_DECISIONS_V2.36`). Bundleable with #959 doc-hygiene sweep — LOW priority.
2. **T41 sibling TypedDict audit** — a lint/test that iterates all `*Response` TypedDicts in `src/precog/` and grep-asserts each `*_id: str` field is a genuine business key, not drifted surrogate. The pin-test pattern in this PR is the template.
3. **Pattern candidate for V1.35** — *"Column-type migrations must sweep every TypedDict whose shape mirrors that table, not just function signatures."* Captured for next S80 periodic sweep (~session 72).

## Test plan

- [x] Local: 2,723 unit + 1,242 integration/E2E + 1,045 stress/chaos/race tests pass (358s parallel, pre-push)
- [x] Ruff format + check clean
- [x] New regression test runs green (`tests/unit/trading/test_types_contracts.py::test_position_response_market_id_is_int_per_migration_0022`)
- [x] MCP Gate B verification of live `positions.market_id` column type
- [x] Revert-probe: 5 hypothetical regressions all fail the assertion
- [x] Fixture sweep: 0 positions-fixtures constructing string `market_id`
- [ ] CI claude-review (post-merge sweep per S68 next session)

**Note on pre-push bypass:** Push used `SKIP_TEST_TYPE_AUDIT=1` per the documented transitional policy (tracked in #887, retires via #893 shipped + pending #896 arc). The gap is in `schedulers/temporal_alignment_writer` (7 test types) and `database/crud_elo` (unit) — **neither touched by this PR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)